### PR TITLE
Release 2.0.932

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+2.0.932 (2023-07-27)
+====================
+
+Bugfixes
+--------
+
+- Fixed `assert_hostname` behavior when HTTPSConnection targets HTTP/3 over QUIC (`#8 <https://github.com/jawah/urllib3.future/issues/8>`__)
+
+
 2.0.931 (2023-07-16)
 ====================
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ python -m pip install requests
 python -m pip install urllib3.future
 ```
 
-| Package          | Is compatible? | Notes                                                                                                                                           |
-|------------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| requests         | ✅              | Invalid chunked transmission may raises ConnectionError instead of ChunkedEncodingError. Use of Session() is required to enable HTTP/3 support. |
-| HTTPie           | ✅              | Require plugin `httpie-next` to be installed or wont be able to upgrade to HTTP/3 (QUIC/Alt-Svc Cache Layer)                                    |
-| pip              | 🛑             | Cannot use the fork because of vendored urllib3 v1.x                                                                                            |
-| openapigenerator | ✅              | Simply patch generated `setup.py` requirement and replace urllib3 to urllib3.future                                                             |
+| Package          | Is compatible? | Notes                                                                                                        |
+|------------------|----------------|--------------------------------------------------------------------------------------------------------------|
+| requests         | ✅              | Use of Session() is required to enable HTTP/3 support.                                                       |
+| HTTPie           | ✅              | Require plugin `httpie-next` to be installed or wont be able to upgrade to HTTP/3 (QUIC/Alt-Svc Cache Layer) |
+| pip              | 🛑             | Cannot use the fork because of vendored urllib3 v1.x, but technically feasible                               |
+| openapigenerator | ✅              | Simply patch generated `setup.py` requirement and replace urllib3 to urllib3.future                          |
 
 Want to report an incompatibility? Open an issue in that repository.
 All projects that depends on listed *compatible* package should work as-is.

--- a/changelog/8.bugfix.rst
+++ b/changelog/8.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed `assert_hostname` behavior when HTTPSConnection targets HTTP/3 over QUIC

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.0.931"
+__version__ = "2.0.932"


### PR DESCRIPTION
2.0.932 (2023-07-27)
====================

Bugfixes
--------

- Fixed `assert_hostname` behavior when HTTPSConnection targets HTTP/3 over QUIC (`#8 <https://github.com/jawah/urllib3.future/issues/8>`__)
