### PR TITLE
:bug: Fixed the workaround unpack chunk in the send method when the body is a form-data

### DIFF
--- a/changelog/17.bugfix.rst
+++ b/changelog/17.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``unpack_chunk`` workaround function in the ``send`` method when body is multipart/form-data

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -740,7 +740,7 @@ class HfaceBackend(BaseBackend):
             self.__remaining_body_length = self.__expected_body_length
 
         def unpack_chunk(possible_chunk: bytes) -> bytes:
-            """This hacky function is there because we won't alter the send() method signature.
+            """This hacky function is there because we won't alter send() method signature.
             Therefor cannot know intention prior to this. b"%x\r\n%b\r\n" % (len(chunk), chunk)
             """
             if (
@@ -749,6 +749,9 @@ class HfaceBackend(BaseBackend):
             ):
                 _: list[bytes] = possible_chunk.split(b"\r\n", maxsplit=1)
                 if len(_) != 2 or any(uc == b"" for uc in _):
+                    return possible_chunk
+                # boundary case
+                if _[-1][:-2].startswith(b"--") and _[-1][:-2].endswith(b"--"):
                     return possible_chunk
                 return _[-1][:-2]
             return possible_chunk


### PR DESCRIPTION
…

We need to remove this altogether soon as we do not depend on the stdlib, we can change the method signature now.