### PR TITLE
:bookmark: Release 2.0.932

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,18 @@
+2.0.932 (2023-09-12)
+====================
+
+Bugfixes
+--------
+
+- Fixed `assert_hostname` behavior when HTTPSConnection targets HTTP/3 over QUIC (`#8 <https://github.com/jawah/urllib3.future/issues/8>`__)
+- Fixed protocol violation for HTTP/2 and HTTP/3 where we sent ``Connection: keep-alive`` when it is
+  forbidden. (`#16 <https://github.com/jawah/urllib3.future/issues/16>`__)
+- Fixed ``unpack_chunk`` workaround function in the ``send`` method when body is multipart/form-data (`#17 <https://github.com/jawah/urllib3.future/issues/17>`__)
+- Fixed the flow control when sending a body for a HTTP/2 connection.
+  The body will be split into numerous chunks if the size exceed the specified blocksize when not
+  using HTTP/1.1 in order to avoid ProtocolError (flow control) (`#18 <https://github.com/jawah/urllib3.future/issues/18>`__)
+
+
 2.0.931 (2023-07-16)
 ====================
 

--- a/changelog/16.bugfix.rst
+++ b/changelog/16.bugfix.rst
@@ -1,2 +1,0 @@
-Fixed protocol violation for HTTP/2 and HTTP/3 where we sent ``Connection: keep-alive`` when it is
-forbidden.

--- a/changelog/17.bugfix.rst
+++ b/changelog/17.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed ``unpack_chunk`` workaround function in the ``send`` method when body is multipart/form-data

--- a/changelog/18.bugfix.rst
+++ b/changelog/18.bugfix.rst
@@ -1,3 +1,0 @@
-Fixed the flow control when sending a body for a HTTP/2 connection.
-The body will be split into numerous chunks if the size exceed the specified blocksize when not
-using HTTP/1.1 in order to avoid ProtocolError (flow control)

--- a/changelog/8.bugfix.rst
+++ b/changelog/8.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed `assert_hostname` behavior when HTTPSConnection targets HTTP/3 over QUIC

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.0.931"
+__version__ = "2.0.932"


### PR DESCRIPTION
2.0.932 (2023-09-12)
====================

Bugfixes
--------

- Fixed `assert_hostname` behavior when HTTPSConnection targets HTTP/3 over QUIC (`#8 <https://github.com/jawah/urllib3.future/issues/8>`__)
- Fixed protocol violation for HTTP/2 and HTTP/3 where we sent ``Connection: keep-alive`` when it is
  forbidden. (`#16 <https://github.com/jawah/urllib3.future/issues/16>`__)
- Fixed ``unpack_chunk`` workaround function in the ``send`` method when body is multipart/form-data (`#17 <https://github.com/jawah/urllib3.future/issues/17>`__)
- Fixed the flow control when sending a body for a HTTP/2 connection.
  The body will be split into numerous chunks if the size exceed the specified blocksize when not
  using HTTP/1.1 in order to avoid ProtocolError (flow control) (`#18 <https://github.com/jawah/urllib3.future/issues/18>`__)


