### PR TITLE
:bookmark: Release 2.0.933

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+2.0.933 (2023-09-21)
+====================
+
+Bugfixes
+--------
+
+- Fixed ``HTTPSConnectionPool`` not accepting and forwarding ``ca_cert_data``. (`#20 <https://github.com/jawah/urllib3.future/issues/20>`__)
+
+
 2.0.932 (2023-09-12)
 ====================
 

--- a/changelog/20.bugfix.rst
+++ b/changelog/20.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed ``HTTPSConnectionPool`` not accepting and forwarding ``ca_cert_data``.

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.0.932"
+__version__ = "2.0.933"


### PR DESCRIPTION
2.0.933 (2023-09-21)
====================

Bugfixes
--------

- Fixed ``HTTPSConnectionPool`` not accepting and forwarding ``ca_cert_data``. (`#20 <https://github.com/jawah/urllib3.future/issues/20>`__)

