### PR TITLE
:bookmark: Release 2.0.934

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,16 @@
+2.0.934 (2023-09-23)
+====================
+
+- Added public `ConnectionInfo` class that will be present in each `HttpConnection` instance.
+
+  Passing the kwarg ``on_post_connection`` that accept a callable with a single positional argument
+  in ``PoolManager.urlopen`` method will result in a call each time a connection is picked out
+  of the pool. The function will be passed a ``ConnectionInfo`` object.
+  The same argument (``on_post_connection``) can be passed down to the ``HTTPConnectionPool.urlopen`` method. (`#23 <https://github.com/jawah/urllib3.future/issues/23>`__)
+
+- `#22 <https://github.com/jawah/urllib3.future/issues/22>`__
+
+
 2.0.933 (2023-09-21)
 ====================
 

--- a/changelog/22.misc.rst
+++ b/changelog/22.misc.rst
@@ -1,3 +1,0 @@
-Changed the socket set options for both TCP and UDP. Previously it was not possible to set socket options for UDP.
-
-Instead of a three values tuple, you can (but not enforced) specify a fourth value that should either be ``tcp`` or ``udp``.

--- a/changelog/23.feature.rst
+++ b/changelog/23.feature.rst
@@ -1,6 +1,0 @@
-Added public `ConnectionInfo` class that will be present in each `HttpConnection` instance.
-
-Passing the kwarg ``on_post_connection`` that accept a callable with a single positional argument
-in ``PoolManager.urlopen`` method will result in a call each time a connection is picked out
-of the pool. The function will be passed a ``ConnectionInfo`` object.
-The same argument (``on_post_connection``) can be passed down to the ``HTTPConnectionPool.urlopen`` method.

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.0.933"
+__version__ = "2.0.934"


### PR DESCRIPTION
2.0.934 (2023-09-23)
====================

- Added public `ConnectionInfo` class that will be present in each `HttpConnection` instance.

  Passing the kwarg ``on_post_connection`` that accept a callable with a single positional argument
  in ``PoolManager.urlopen`` method will result in a call each time a connection is picked out
  of the pool. The function will be passed a ``ConnectionInfo`` object.
  The same argument (``on_post_connection``) can be passed down to the ``HTTPConnectionPool.urlopen`` method. (`#23 <https://github.com/jawah/urllib3.future/issues/23>`__)

- `#22 <https://github.com/jawah/urllib3.future/issues/22>`__
