### PR TITLE
:bookmark: Release 2.0.935

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.0.935 (2023-10-01)
+====================
+
+- Fixed a violation in our QUIC transmission due to sending multiple datagram at once. (`#26 <https://github.com/jawah/urllib3.future/issues/26>`__)
+
+
 2.0.934 (2023-09-23)
 ====================
 

--- a/changelog/26.bugfix.rst
+++ b/changelog/26.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a violation in our QUIC transmission due to sending multiple datagram at once.

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.0.934"
+__version__ = "2.0.935"


### PR DESCRIPTION
2.0.935 (2023-10-01)
====================

- Fixed a violation in our QUIC transmission due to sending multiple datagrams at once. (`#26 <https://github.com/jawah/urllib3.future/issues/26>`__)
