### PR TITLE
:bookmark: Release 2.0.936

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.0.936 (2023-10-01)
+====================
+
+- Added support for event ``StreamReset`` to raise a ``ProtocolError`` when received from either h2 or h3. (`#28 <https://github.com/jawah/urllib3.future/issues/28>`__)
+
+
 2.0.935 (2023-10-01)
 ====================
 

--- a/changelog/28.feature.rst
+++ b/changelog/28.feature.rst
@@ -1,1 +1,0 @@
-Added support for event ``StreamReset`` to raise a ``ProtocolError`` when received from either h2 or h3.

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.0.935"
+__version__ = "2.0.936"


### PR DESCRIPTION
2.0.936 (2023-10-01)
====================

- Added support for event ``StreamReset`` to raise a ``ProtocolError`` when received from either h2 or h3. (`#28 <https://github.com/jawah/urllib3.future/issues/28>`__)
