### PR TITLE
:bookmark: Release 2.1.901

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,15 @@
+2.1.901 (2023-10-10)
+====================
+
+- Set ``DEFAULT`` (as OpenSSL default list) for ciphers in SSLContext if none is provided instead of Python default.
+- Fixed an edge case where chosen state machine would be indicated to not end stream where it should.
+- Fixed a rare case where ``ProtocolError`` was raised instead of ``SSLError`` in the underlying QUIC layer state-machine.
+- Small performance improvement in sending a body by removing an obsolete logic made for a removed constraint.
+- Changed default ``User-Agent`` to ``urllib3.future/x.y.z``.
+- Removed a compatibility operation that added a ``Content-Length`` header on request with unknown body length.
+  This was present due to a bug in Traefik server. A investigation will be conducted and a relevant issue will be
+  addressed.
+
 2.1.900 (2023-10-07)
 ====================
 

--- a/src/urllib3/backend/_base.py
+++ b/src/urllib3/backend/_base.py
@@ -288,7 +288,11 @@ class BaseBackend:
         raise NotImplementedError
 
     def endheaders(
-        self, message_body: bytes | None = None, *, encode_chunked: bool = False
+        self,
+        message_body: bytes | None = None,
+        *,
+        encode_chunked: bool = False,
+        expect_body_afterward: bool = False,
     ) -> None:
         """This method conclude the request context construction."""
         raise NotImplementedError
@@ -306,6 +310,8 @@ class BaseBackend:
     def send(
         self,
         data: (bytes | typing.IO[typing.Any] | typing.Iterable[bytes] | str),
+        *,
+        eot: bool = False,
     ) -> None:
         """The send() method SHOULD be invoked after calling endheaders() if and only if the request
         context specify explicitly that a body is going to be sent."""

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -257,7 +257,6 @@ def create_urllib3_context(
                 "'ssl_minimum_version' or 'ssl_maximum_version'"
             )
 
-        # 'ssl_version' is deprecated and will be removed in the future.
         else:
             # Use 'ssl_minimum_version' and 'ssl_maximum_version' instead.
             ssl_minimum_version = _SSL_VERSION_TO_TLS_VERSION.get(
@@ -282,6 +281,11 @@ def create_urllib3_context(
     # the case of OpenSSL 1.1.1+ or use our own secure default ciphers.
     if ciphers:
         context.set_ciphers(ciphers)
+    else:
+        # avoid relying on cpython default cipher list
+        # and instead retrieve OpenSSL own default. This should make
+        # urllib3.future less seen by basic firewall anti-bot rules.
+        context.set_ciphers("DEFAULT")
 
     # Setting the default here, as we may have no ssl module on import
     cert_reqs = ssl.CERT_REQUIRED if cert_reqs is None else cert_reqs

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -136,7 +136,7 @@ class TestSSL:
 
         ssl_.create_urllib3_context()
 
-        context.set_ciphers.assert_not_called()
+        context.set_ciphers.assert_called_once_with("DEFAULT")
 
     @pytest.mark.parametrize(
         "kwargs",

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -917,7 +917,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             request_headers = r.json()
 
             if not headers:
-                assert request_headers["User-Agent"].startswith("python-urllib3/")
+                assert request_headers["User-Agent"].startswith("urllib3.future/")
                 assert "key" not in request_headers["User-Agent"]
             else:
                 assert request_headers["User-Agent"] == "key"

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -2274,7 +2274,7 @@ class TestContentFraming(SocketDummyServerTestCase):
         assert b"Host: localhost:" in sent_bytes
         assert b"Accept-Encoding: identity\r\n" in sent_bytes
         assert b"Transfer-Encoding: chunked\r\n" in sent_bytes
-        assert b"User-Agent: python-urllib3/" in sent_bytes
+        assert b"User-Agent: urllib3.future/" in sent_bytes
         assert b"content-length" not in sent_bytes.lower()
         assert b"\r\n\r\na\r\nxxxxxxxxxx\r\n0\r\n\r\n" in sent_bytes
 
@@ -2343,7 +2343,7 @@ class TestContentFraming(SocketDummyServerTestCase):
         assert sent_bytes.count(b":") == 5
         assert b"Host: localhost:" in sent_bytes
         assert b"Accept-Encoding: identity\r\n" in sent_bytes
-        assert b"User-Agent: python-urllib3/" in sent_bytes
+        assert b"User-Agent: urllib3.future/" in sent_bytes
 
         if should_be_chunked:
             assert b"content-length" not in sent_bytes.lower()
@@ -2362,7 +2362,7 @@ class TestContentFraming(SocketDummyServerTestCase):
     @pytest.mark.parametrize(
         ["header", "header_value", "expected"],
         [
-            ("content-length", "10", b": 10\r\n\r\nxxxxxxxx"),
+            ("content-length", "8", b": 8\r\n\r\nxxxxxxxx"),
             (
                 "transfer-encoding",
                 "chunked",

--- a/test/with_traefik/test_send_data.py
+++ b/test/with_traefik/test_send_data.py
@@ -51,8 +51,17 @@ class TestPostBody(TraefikTestCase):
             for i in range(3):
                 if isinstance(body, BytesIO):
                     body.seek(0, 0)
+                    # traefik bug with http3, should not happen!
+                    if i > 0:
+                        headers = {"content-length": "-1"}
+                    else:
+                        headers = {}
+                else:
+                    headers = {}
 
-                resp = p.request(method, f"/{method.lower()}", body=body)
+                resp = p.request(
+                    method, f"/{method.lower()}", body=body, headers=headers
+                )
 
                 assert resp.status == 200
                 assert resp.version == (20 if i == 0 else 30)


### PR DESCRIPTION
2.1.901 (2023-10-10)
====================

- Set ``DEFAULT`` (as OpenSSL default list) for ciphers in SSLContext if none is provided instead of Python default.
- Fixed an edge case where the chosen state machine would be indicated not to end stream where it should.
- Fixed a rare case where ``ProtocolError`` was raised instead of ``SSLError`` in the underlying QUIC layer state machine.
- Small performance improvement in sending a body by removing an obsolete logic made for a removed constraint.
- Changed default ``User-Agent`` to ``urllib3.future/x.y.z``.
- Removed a compatibility operation that added a ``Content-Length`` header on request with an unknown body length.
  This was present due to a bug in Traefik server. An investigation will be conducted and a relevant issue will be
  addressed.