### PR TITLE
:bookmark: Release 2.1.902

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
           TRAEFIK_COMPOSE_SCHEMA: |
             services:
               proxy:
-                image: traefik:v2.10
+                image: traefik:v2.10.4
                 restart: unless-stopped
                 healthcheck:
                   test: [ "CMD", "traefik" ,"healthcheck", "--ping" ]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+2.1.902 (2023-10-21)
+====================
+
+- Fixed an issue where streaming response did not yield data until the stream was closed.
+- Unified peercert/issuercert dict output in ConnectionInfo output format when HTTP/3.
+- Made body stripped from HTTP requests changing the request method to GET after HTTP 303 "See Other" redirect responses.
+  Headers ``content-encoding, content-language, content-location, content-type, content-length, digest, last-modified`` are
+  also stripped in the said case.
+  Port of the security fix GHSA-g4mx-q9vg-27p4
+- ``_TYPE_BODY`` now accept `Iterable[str]` in addition to `Iterable[bytes]`.
+
 2.1.901 (2023-10-10)
 ====================
 

--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -281,6 +281,12 @@ class TestingApp(RequestHandler):
     def headers(self, request: httputil.HTTPServerRequest) -> Response:
         return Response(json.dumps(dict(request.headers)))
 
+    def headers_and_params(self, request: httputil.HTTPServerRequest) -> Response:
+        params = request_params(request)
+        return Response(
+            json.dumps({"headers": dict(request.headers), "params": params})
+        )
+
     def multi_headers(self, request: httputil.HTTPServerRequest) -> Response:
         return Response(json.dumps({"headers": list(request.headers.get_all())}))
 

--- a/src/urllib3/_base_connection.py
+++ b/src/urllib3/_base_connection.py
@@ -8,7 +8,12 @@ from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT
 from .util.url import Url
 
 _TYPE_BODY = typing.Union[
-    bytes, typing.IO[typing.Any], typing.Iterable[bytes], str, LowLevelResponse
+    bytes,
+    typing.IO[typing.Any],
+    typing.Iterable[bytes],
+    typing.Iterable[str],
+    str,
+    LowLevelResponse,
 ]
 
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.1.901"
+__version__ = "2.1.902"

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -544,12 +544,19 @@ class HfaceBackend(BaseBackend):
                     if isinstance(event, event_type_collectable):
                         events.append(event)
 
-                if (event_type and isinstance(event, event_type)) or (
-                    maximal_data_in_read and data_in_len >= maximal_data_in_read
-                ):
+                target_cap_reached: bool = (
+                    maximal_data_in_read is not None
+                    and data_in_len >= maximal_data_in_read
+                )
+
+                if (event_type and isinstance(event, event_type)) or target_cap_reached:
                     # if event type match, make sure it is the latest one
                     # simply put, end_stream should be True.
-                    if respect_end_stream_signal and hasattr(event, "end_stream"):
+                    if (
+                        target_cap_reached is False
+                        and respect_end_stream_signal
+                        and hasattr(event, "end_stream")
+                    ):
                         if event.end_stream is True:
                             return events
                         continue

--- a/src/urllib3/contrib/hface/protocols/http3/_qh3.py
+++ b/src/urllib3/contrib/hface/protocols/http3/_qh3.py
@@ -108,11 +108,9 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
         return ProtocolError, H3Error, QuicConnectionError, AssertionError
 
     def is_available(self) -> bool:
-        # TODO: check concurrent stream limit
         return not self._terminated
 
     def has_expired(self) -> bool:
-        # TODO: check that we do not run out of stream IDs.
         return self._terminated
 
     @property
@@ -295,8 +293,10 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
             )
             issuer_info["subject"].append(  # type: ignore[attr-defined]
                 (
-                    name,
-                    item.value,
+                    (
+                        name,
+                        item.value,
+                    ),
                 )
             )
 
@@ -308,8 +308,10 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
             )
             issuer_info["issuer"].append(  # type: ignore[attr-defined]
                 (
-                    name,
-                    item.value,
+                    (
+                        name,
+                        item.value,
+                    ),
                 )
             )
 
@@ -372,8 +374,10 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
             )
             peer_info["subject"].append(  # type: ignore[attr-defined]
                 (
-                    name,
-                    item.value,
+                    (
+                        name,
+                        item.value,
+                    ),
                 )
             )
 
@@ -385,8 +389,10 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
             )
             peer_info["issuer"].append(  # type: ignore[attr-defined]
                 (
-                    name,
-                    item.value,
+                    (
+                        name,
+                        item.value,
+                    ),
                 )
             )
 

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -17,6 +17,17 @@ if typing.TYPE_CHECKING:
 # ``Host``, and ``User-Agent``.
 SKIP_HEADER = "@@@SKIP_HEADER@@@"
 SKIPPABLE_HEADERS = frozenset(["accept-encoding", "host", "user-agent"])
+NOT_FORWARDABLE_HEADERS = frozenset(
+    [
+        "content-encoding",
+        "content-language",
+        "content-location",
+        "content-type",
+        "content-length",
+        "digest",
+        "last-modified",
+    ]
+)
 
 ACCEPT_ENCODING = "gzip,deflate"
 try:

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -480,6 +480,17 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             assert r.status == 200
             assert r.data == b"Dummy server!"
 
+    def test_303_redirect_makes_request_lose_body(self) -> None:
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            response = pool.request(
+                "POST",
+                "/redirect",
+                fields={"target": "/headers_and_params", "status": "303 See Other"},
+            )
+        data = response.json()
+        assert data["params"] == {}
+        assert "Content-Type" not in HTTPHeaderDict(data["headers"])
+
     def test_bad_connect(self) -> None:
         with HTTPConnectionPool("badhost.invalid", self.port) as pool:
             with pytest.raises(MaxRetryError) as e:

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -243,6 +243,20 @@ class TestPoolManager(HTTPDummyServerTestCase):
             assert r._pool.num_connections == 1
             assert len(http.pools) == 1
 
+    def test_303_redirect_makes_request_lose_body(self) -> None:
+        with PoolManager() as http:
+            response = http.request(
+                "POST",
+                f"{self.base_url}/redirect",
+                fields={
+                    "target": f"{self.base_url}/headers_and_params",
+                    "status": "303 See Other",
+                },
+            )
+        data = response.json()
+        assert data["params"] == {}
+        assert "Content-Type" not in HTTPHeaderDict(data["headers"])
+
     def test_unknown_scheme(self) -> None:
         with PoolManager() as http:
             unknown_scheme = "unknown"


### PR DESCRIPTION
2.1.902 (2023-10-21)
====================

- Fixed an issue where streaming response did not yield data until the stream was closed.
- Unified peercert/issuercert dict output in ConnectionInfo output format when HTTP/3.
- Made body stripped from HTTP requests changing the request method to GET after HTTP 303 "See Other" redirect responses.
  Headers ``content-encoding, content-language, content-location, content-type, content-length, digest, last-modified`` are
  also stripped in the said case.
  Port of the security fix GHSA-g4mx-q9vg-27p4
- ``_TYPE_BODY`` now accept `Iterable[str]` in addition to `Iterable[bytes]`.
