### PR TITLE
:bug: Fixed several issues with multiplexing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+2.2.901 (2023-11-04)
+====================
+
+- Fixed several issues with multiplexing.
+  (i) Fixed max concurrent streams in HTTP/2, and HTTP/3.
+  (ii) Fixed tracking of unconsumed response prior to try upgrade the connection (to HTTP/3).
+  (iii) Fixed (always) releasing multiplexed connections into pool.
+  (iv) Fixed request having body being interrupted by the ``EarlyResponse`` exception 'signal'.
+
 2.2.900 (2023-11-01)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.2.900"
+__version__ = "2.2.901"

--- a/src/urllib3/backend/_base.py
+++ b/src/urllib3/backend/_base.py
@@ -283,6 +283,7 @@ class BaseBackend:
         self.conn_info: ConnectionInfo | None = None
 
         self._promises: list[ResponsePromise] = []
+        self._pending_responses: list[LowLevelResponse] = []
 
     def __contains__(self, item: ResponsePromise) -> bool:
         return item in self._promises
@@ -306,6 +307,10 @@ class BaseBackend:
     @property
     def is_saturated(self) -> bool:
         raise NotImplementedError
+
+    @property
+    def is_idle(self) -> bool:
+        return not self._promises and not self._pending_responses
 
     @property
     def is_multiplexed(self) -> bool:

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -247,8 +247,8 @@ class HTTPConnection(HfaceBackend):
     def is_connected(self) -> bool:
         if self.sock is None:
             return False
-        # wait_for_read become flaky with concurrent streams!
-        if self._promises:
+        # wait_for_read: not functional with multiplexed connection!
+        if self._promises or self._pending_responses:
             return True
         return not wait_for_read(self.sock, timeout=0.0)
 

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -441,7 +441,11 @@ class PoolManager(RequestMethods):
             if not pool:
                 continue
 
-            response = pool.get_response(promise=promise)
+            try:
+                response = pool.get_response(promise=promise)
+            except ValueError:
+                response = None
+
             put_back_pool.append((pool_key, pool))
 
             if response:
@@ -449,6 +453,11 @@ class PoolManager(RequestMethods):
 
         for pool_key, pool in put_back_pool:
             self.pools[pool_key] = pool
+
+        if promise is not None and response is None:
+            raise ValueError(
+                "Invoked get_response with promise=... that no connections across pools recognize"
+            )
 
         if response is None:
             return None

--- a/test/with_traefik/test_connectionpool_multiplexed.py
+++ b/test/with_traefik/test_connectionpool_multiplexed.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from test import notMacOS
 from time import time
 
 from urllib3 import HTTPSConnectionPool, ResponsePromise
@@ -43,3 +44,63 @@ class TestConnectionPoolMultiplexed(TraefikTestCase):
 
             assert 3.5 >= round(time() - before, 2)
             assert pool.get_response() is None
+
+    def test_multiplexing_without_preload(self) -> None:
+        with HTTPSConnectionPool(
+            self.host, self.https_port, ca_certs=self.ca_authority
+        ) as pool:
+            promises = []
+
+            for i in range(5):
+                promise_slow = pool.urlopen(
+                    "GET", "/delay/3", multiplexed=True, preload_content=False
+                )
+                promise_fast = pool.urlopen(
+                    "GET", "/delay/1", multiplexed=True, preload_content=False
+                )
+
+                assert isinstance(promise_fast, ResponsePromise)
+                assert isinstance(promise_slow, ResponsePromise)
+                promises.append(promise_slow)
+                promises.append(promise_fast)
+
+            assert len(promises) == 10
+
+            for i in range(5):
+                response = pool.get_response()
+                assert response is not None
+                assert response.status == 200
+                assert "/delay/1" in response.json()["url"]
+
+            for i in range(5):
+                response = pool.get_response()
+                assert response is not None
+                assert response.status == 200
+                assert "/delay/3" in response.json()["url"]
+
+            assert pool.get_response() is None
+
+    @notMacOS()
+    def test_multiplexing_stream_saturation(self) -> None:
+        with HTTPSConnectionPool(
+            self.host, self.https_port, ca_certs=self.ca_authority, maxsize=2
+        ) as pool:
+            promises = []
+
+            for i in range(300):
+                promise = pool.urlopen(
+                    "GET", "/delay/1", multiplexed=True, preload_content=False
+                )
+                assert isinstance(promise, ResponsePromise)
+                promises.append(promise)
+
+            assert len(promises) == 300
+
+            for i in range(300):
+                response = pool.get_response()
+                assert response is not None
+                assert response.status == 200
+                assert "/delay/1" in response.json()["url"]
+
+            assert pool.get_response() is None
+            assert pool.pool is not None and pool.pool.qsize() == 2


### PR DESCRIPTION
2.2.901 (2023-11-04)
====================

- Fixed several issues with multiplexing.
  (i) Fixed max concurrent streams in HTTP/2, and HTTP/3.
  (ii) Fixed tracking of unconsumed response prior to try to upgrade the connection (to HTTP/3).
  (iii) Fixed (always) releasing multiplexed connections into the pool.
  (iv) Fixed request having body being interrupted by the ``EarlyResponse`` exception 'signal'.
