### PR TITLE
:bug: Fixed QUIC connection not taking cert_data due to an accidental variable override

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.2.902 (2023-11-05)
+====================
+
+- Fixed QUIC connection not taking ``cert_data`` due to an accidental variable override.
+
 2.2.901 (2023-11-04)
 ====================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,10 @@ qh3 = [
 ]
 
 [project.urls]
-"Changelog" = "https://github.com/urllib3/urllib3/blob/main/CHANGES.rst"
-"Documentation" = "https://urllib3.readthedocs.io"
-"Code" = "https://github.com/urllib3/urllib3"
-"Issue tracker" = "https://github.com/urllib3/urllib3/issues"
+"Changelog" = "https://github.com/jawah/urllib3.future/blob/main/CHANGES.rst"
+"Documentation" = "https://urllib3future.readthedocs.io"
+"Code" = "https://github.com/jawah/urllib3.future"
+"Issue tracker" = "https://github.com/jawah/urllib3.future/issues"
 
 [tool.hatch.version]
 path = "src/urllib3/_version.py"

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.2.901"
+__version__ = "2.2.902"

--- a/src/urllib3/contrib/hface/protocols/http3/_qh3.py
+++ b/src/urllib3/contrib/hface/protocols/http3/_qh3.py
@@ -95,8 +95,6 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
                 tls_config.keypassword,
             )
 
-        self._configuration.load_verify_locations(tls_config.cafile)
-
         self._quic: QuicConnection = QuicConnection(configuration=self._configuration)
         self._connection_ids: set[bytes] = set()
         self._remote_address = remote_address


### PR DESCRIPTION
2.2.902 (2023-11-05)
====================

- Fixed QUIC connection not taking ``cert_data`` due to an accidental variable override.
