### PR TITLE
:bookmark: Release 2.2.904

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.2.904 (2023-11-06)
+====================
+
+- Fixed concurrent/multiplexed request overflow in a full connection pool.
+- Fixed connection close that had in-flight request (in multiplexed mode), the connection appeared as not idle on clean reuse.
+
 2.2.903 (2023-11-06)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.2.903"
+__version__ = "2.2.904"

--- a/src/urllib3/backend/_base.py
+++ b/src/urllib3/backend/_base.py
@@ -99,7 +99,9 @@ class LowLevelResponse:
     @from_promise.setter
     def from_promise(self, value: ResponsePromise) -> None:
         if value.stream_id != self._stream_id:
-            raise ValueError
+            raise ValueError(
+                "Trying to assign a ResponsePromise to an unrelated LowLevelResponse"
+            )
         self.__promise = value
 
     @property

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -978,3 +978,9 @@ class HfaceBackend(BaseBackend):
 
         self._protocol = None
         self._stream_id = None
+        self._promises = {}
+        self._pending_responses = {}
+        self.__custom_tls_settings = None
+        self.conn_info = None
+        self.__expected_body_length = None
+        self.__remaining_body_length = None

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -475,7 +475,9 @@ class PoolManager(RequestMethods):
                 from_promise = response._fp.from_promise
 
         if from_promise is None:
-            raise ValueError
+            raise ValueError(
+                "Internal: Unable to identify originating ResponsePromise from a LowLevelResponse"
+            )
 
         # Retrieve request ctx
         method = typing.cast(str, from_promise.get_parameter("method"))


### PR DESCRIPTION
2.2.904 (2023-11-06)
=================


- Fixed concurrent/multiplexed request overflow in a full connection pool.
- Fixed connection close that had in-flight request (in multiplexed mode), the connection appeared as not idle on clean reuse.