### PR TITLE
:bookmark: Release 2.2.905

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.2.905 (2023-11-08)
+====================
+
+- Fixed loss of a QUIC connection due to an inappropriate check in ``conn.is_connected``.
+- Separate saturated (multiplexed) connections from the main pool to a distinct one.
+
 2.2.904 (2023-11-06)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.2.904"
+__version__ = "2.2.905"

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -250,6 +250,9 @@ class HTTPConnection(HfaceBackend):
         # wait_for_read: not functional with multiplexed connection!
         if self._promises or self._pending_responses:
             return True
+        # wait_for_read: not functional w/ UDP!
+        if self._svn == HttpVersion.h3:
+            return self._protocol is not None and self._protocol.has_expired() is False
         return not wait_for_read(self.sock, timeout=0.0)
 
     @property

--- a/src/urllib3/contrib/hface/protocols/http2/_h2.py
+++ b/src/urllib3/contrib/hface/protocols/http2/_h2.py
@@ -66,7 +66,10 @@ class HTTP2ProtocolHyperImpl(HTTP2Protocol):
 
     def is_available(self) -> bool:
         max_streams = self._connection.remote_settings.max_concurrent_streams
-        return self._terminated is False and max_streams > len(self._connection.streams)
+        return (
+            self._terminated is False
+            and max_streams > self._connection.open_outbound_streams
+        )
 
     def has_expired(self) -> bool:
         return self._terminated

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -252,7 +252,7 @@ class TestConnectionPool:
             assert conn1 == pool._get_conn()
             assert conn2 != pool._get_conn()
 
-            assert pool.num_connections == 3
+            assert pool.num_connections == 2
             assert "Connection pool is full, discarding connection" in caplog.text
             assert "Connection pool size: 1" in caplog.text
 

--- a/test/with_traefik/test_connectionpool_multiplexed.py
+++ b/test/with_traefik/test_connectionpool_multiplexed.py
@@ -95,6 +95,7 @@ class TestConnectionPoolMultiplexed(TraefikTestCase):
                 promises.append(promise)
 
             assert len(promises) == 300
+            assert pool.num_connections == 2
 
             for i in range(300):
                 response = pool.get_response()
@@ -103,4 +104,4 @@ class TestConnectionPoolMultiplexed(TraefikTestCase):
                 assert "/delay/1" in response.json()["url"]
 
             assert pool.get_response() is None
-            assert pool.pool is not None and pool.pool.qsize() == 2
+            assert pool.pool is not None and pool.num_connections == 2


### PR DESCRIPTION
2.2.905 (2023-11-08)
====================

- Fixed loss of a QUIC connection due to an inappropriate check in ``conn.is_connected``.
- Separate saturated (multiplexed) connections from the main pool to a distinct one.
