### PR TITLE
:bookmark: Release 2.2.906

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+2.2.906 (2023-11-11)
+====================
+
+- Bumped minimum requirement for ``qh3`` to version 0.14.0 in order to drop private calls in ``contrib.hface.protocols._qh3``.
+- Cache last 1024 ``parse_url`` function call as it is costly.
+- Fixed incomplete flow control window checks while sending data in HTTP/2.
+- Fixed unexpected BrokenPipeError exception in a rare edge case.
+- Changed behavior for efficiency around ``socket.recv`` to pull ``conn.blocksize`` bytes regardless of ``Response.read(amt=...)``.
+
 2.2.905 (2023-11-08)
 ====================
 

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -8,6 +8,6 @@ trustme==0.9.0
 types-backports
 types-requests
 nox
-qh3>=0.10.0,<1.0.0
+qh3>=0.14.0,<1.0.0
 h11>=0.11.0,<1.0.0
 h2>=4.0.0,<5.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 requires-python = ">=3.7"
 dynamic = ["version"]
 dependencies = [
-  "qh3>=0.13.0,<1.0.0; (platform_system == 'Darwin' or platform_system == 'Windows' or platform_system == 'Linux') and (platform_python_implementation == 'CPython' or (platform_python_implementation == 'PyPy' and python_version >= '3.8' and python_version < '3.11'))",
+  "qh3>=0.14.0,<1.0.0; (platform_system == 'Darwin' or platform_system == 'Windows' or platform_system == 'Linux') and (platform_python_implementation == 'CPython' or (platform_python_implementation == 'PyPy' and python_version >= '3.8' and python_version < '3.11'))",
   "h11>=0.11.0,<1.0.0",
   "h2>=4.0.0,<5.0.0",
 ]
@@ -55,7 +55,7 @@ socks = [
   "PySocks>=1.5.6,<2.0,!=1.5.7",
 ]
 qh3 = [
-  "qh3>=0.13.0,<1.0.0",
+  "qh3>=0.14.0,<1.0.0",
 ]
 
 [project.urls]

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.2.905"
+__version__ = "2.2.906"

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -394,7 +394,13 @@ class HTTPConnection(HfaceBackend):
                 value = str(content_length)
             self.putheader(header, value)
 
-        rp = self.endheaders(expect_body_afterward=chunks is not None)
+        try:
+            rp = self.endheaders(expect_body_afterward=chunks is not None)
+        except BrokenPipeError as e:
+            rp = e.promise  # type: ignore[attr-defined]
+            assert rp is not None
+            rp.set_parameter("response_options", response_options)
+            raise e
 
         if rp:
             rp.set_parameter("response_options", response_options)

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import typing
+from functools import lru_cache
 
 from ..exceptions import LocationParseError
 from .util import to_str
@@ -366,6 +367,7 @@ def _encode_target(target: str) -> str:
     return encoded_target
 
 
+@lru_cache(maxsize=1024)
 def parse_url(url: str) -> Url:
     """
     Given a url, return a parsed :class:`.Url` namedtuple. Best-effort is

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -525,7 +525,7 @@ class TestUtil:
 
     def test_parse_url_bytes_type_error(self) -> None:
         with pytest.raises(TypeError):
-            parse_url(b"https://www.google.com/")  # type: ignore[arg-type]
+            parse_url(b"https://www.google.com/")
 
     @pytest.mark.parametrize(
         "kwargs, expected",


### PR DESCRIPTION
2.2.906 (2023-11-11)
=================

- Bumped minimum requirement for ``qh3`` to version 0.14.0 in order to drop private calls in ``contrib.hface.protocols._qh3``.
- Cache last 1024 ``parse_url`` function calls as it is costly.
- Fixed incomplete flow control window checks while sending data in HTTP/2.
- Fixed unexpected BrokenPipeError exception in a rare edge case.
- Changed behavior for efficiency around ``socket.recv`` to pull ``conn.blocksize`` bytes regardless of ``Response.read(amt=...)``.
