### PR TITLE
:bug: Reverted relying on qh3 to dynamically retrieve the max concurrent streams allowed before connection saturation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.2.907 (2023-11-11)
+====================
+
+- Reverted relying on ``qh3`` to dynamically retrieve the max concurrent streams allowed before connection saturation.
+
 2.2.906 (2023-11-11)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.2.906"
+__version__ = "2.2.907"

--- a/src/urllib3/contrib/hface/protocols/http3/_qh3.py
+++ b/src/urllib3/contrib/hface/protocols/http3/_qh3.py
@@ -109,7 +109,7 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
         return ProtocolError, H3Error, QuicConnectionError, AssertionError
 
     def is_available(self) -> bool:
-        max_stream_bidi = self._quic.max_concurrent_bidi_streams
+        max_stream_bidi = 128  # todo: find a way to adapt dynamically to self._quic.max_concurrent_bidi_streams
         return (
             self._terminated is False
             and max_stream_bidi > self._quic.open_outbound_streams


### PR DESCRIPTION
2.2.907 (2023-11-11)
====================

- Reverted relying on ``qh3`` to dynamically retrieve the max concurrent streams allowed before connection saturation.

