### PR TITLE
:bookmark: Release 2.3.901

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,23 @@
+2.3.901 (2023-11-26)
+====================
+
+- Small performance improvement while in HTTP/1.1
+- Any string passed down to the body will enforce a default ``Content-Type: text/plain; charset=utf-8`` for safety, unless
+  you specified a ``Content-Type`` header yourself. The ``charset`` parameter will always be set to ``utf-8``.
+  It is recommended that you pass ``bytes`` instead of a plain string. If a conflicting charset has been set that
+  does not refer to utf-8, a warning will be raised.
+- Added callable argument in ``urlopen``, and ``request`` named ``on_upload_body`` that enable you to track
+  body upload progress for a single request. It takes 4 positional arguments, namely:
+  (total_sent: int, total_to_be_sent: int | None, is_completed: bool, any_error: bool)
+  total_to_be_sent may be set to None if we're unable to know in advance the total size (blind iterator/generator).
+- Fixed a rare case where ``ProtocolError`` was raised instead of expected ``IncompleteRead`` exception.
+- Improved HTTP/3 overall performance.
+- Changed the default max connection per host for (http, https) pools managed by ``PoolManager``.
+  If the ``PoolManager`` is instantiated with ``num_pools=10``, each (managed) subsequent pool will have ``maxsize=10``.
+- Improved performance while in a multithreading context while using many multiplexed connections.
+- Changed the default max saturated multiplexed connections to 64 as the minimum.
+  Now a warning will be fired if you reach the maximum capacity of stored saturated multiplexed connections.
+
 2.3.900 (2023-11-18)
 ====================
 

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -784,3 +784,29 @@ You may give your certificate to urllib3.future this way::
         r = https_pool.request("GET", "/")
 
 .. note:: If your platform isn't served by this feature it will raise a warning and ignore the certificate.
+
+Monitor upload progress
+-----------------------
+
+You can, since version 2.3.901, monitor upload progress.
+To do so, pass on to the argument ``on_upload_body`` a callable that accept 4 positional arguments.
+
+The arguments are as follow: ``total_sent: int, content_length: int | None, is_completed: bool, any_error: bool``.
+
+- total_sent: Amount of bytes already sent
+- content_length: Expected total bytes to be sent
+- is_completed: Flag that indicate end of transmission (body)
+- any_error: If anything goes wrong during upload, will be set to True
+
+.. warning:: content_length might be set to ``None`` in case that we couldn't infer the actual body length. Can happen if body is an iterator or generator. In that case you still can manually provide a valid ``Content-Length`` header.
+
+See the following example::
+
+    from urllib3 import PoolManager
+
+    def track(total_sent: int, content_length: int | None, is_completed: bool, any_error: bool) -> None:
+        print(f"{total_sent} / {content_length} bytes", f"{is_completed=} {any_error=}")
+
+    with PoolManager() as pm:
+        resp = pm.urlopen("POST", "https://httpbin.org/post", data=b"foo"*1024*10, on_upload_body=track)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ filterwarnings = [
     # https://github.com/pytest-dev/pytest/issues/10977
     '''default:ast\.(Num|NameConstant|Str) is deprecated and will be removed in Python 3\.14; use ast\.Constant instead:DeprecationWarning:_pytest''',
     '''default:Attribute s is deprecated and will be removed in Python 3\.14; use value instead:DeprecationWarning:_pytest''',
+    '''default:A conflicting charset has been set in Content-Type:UserWarning''',
 ]
 
 [tool.isort]

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.3.900"
+__version__ = "2.3.901"

--- a/src/urllib3/contrib/hface/protocols/_protocols.py
+++ b/src/urllib3/contrib/hface/protocols/_protocols.py
@@ -181,6 +181,13 @@ class HTTPProtocol(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def is_idle(self) -> bool:
+        """
+        Return True if this connection is BOTH available and not doing anything.
+        """
+        raise NotImplementedError
+
     @property
     @abstractmethod
     def error_codes(self) -> HTTPErrorCodes:

--- a/src/urllib3/contrib/hface/protocols/http1/_h11.py
+++ b/src/urllib3/contrib/hface/protocols/http1/_h11.py
@@ -101,15 +101,14 @@ def headers_from_response(
 
     Generates from pseudo (colon) headers from a response line.
     """
-    regular_headers: list[HeaderType] = []
+    headers: list[HeaderType] = []
 
-    for name, value in response.headers:
-        if name.startswith(b":"):
-            raise ValueError("Pseudo header not allowed in HTTP/1: " + name.decode())
-        regular_headers.append((name, value))
+    headers.append((b":status", str(response.status_code).encode()))
 
-    pseudo_headers = [(b":status", str(response.status_code).encode())]
-    return pseudo_headers + regular_headers
+    for header, value in response.headers:
+        headers.append((header, value))
+
+    return headers
 
 
 class HTTP1ProtocolHyperImpl(HTTP1Protocol):
@@ -130,6 +129,9 @@ class HTTP1ProtocolHyperImpl(HTTP1Protocol):
 
     def is_available(self) -> bool:
         return self._connection.our_state == self._connection.their_state == h11.IDLE
+
+    def is_idle(self) -> bool:
+        return self.is_available()
 
     def has_expired(self) -> bool:
         return self._terminated

--- a/src/urllib3/contrib/hface/protocols/http2/_h2.py
+++ b/src/urllib3/contrib/hface/protocols/http2/_h2.py
@@ -69,6 +69,9 @@ class HTTP2ProtocolHyperImpl(HTTP2Protocol):
         max_streams = self._connection.remote_settings.max_concurrent_streams
         return self._terminated is False and max_streams > self._open_stream_count
 
+    def is_idle(self) -> bool:
+        return self._terminated is False and self._open_stream_count == 0
+
     def has_expired(self) -> bool:
         return self._terminated
 

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -237,6 +237,9 @@ class IncompleteRead(ProtocolError):
     """
 
     def __init__(self, partial: int, expected: int) -> None:
+        super().__init__(
+            f"peer closed connection without sending complete message body (received {partial} bytes, expected {expected})"
+        )
         self.partial = partial
         self.expected = expected
 

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -221,6 +221,8 @@ class PoolManager(RequestMethods):
         super().__init__(headers)
         self.connection_pool_kw = connection_pool_kw
 
+        self._num_pools = num_pools
+
         self.pools: RecentlyUsedContainer[PoolKey, HTTPConnectionPool]
         self.pools = RecentlyUsedContainer(num_pools)
 
@@ -281,6 +283,10 @@ class PoolManager(RequestMethods):
                 request_context.pop(kw, None)
 
         request_context["preemptive_quic_cache"] = self._preemptive_quic_cache
+
+        # By default, each HttpPool can have up to num_pools connections
+        if "maxsize" not in request_context:
+            request_context["maxsize"] = self._num_pools
 
         return pool_cls(host, port, **request_context)
 

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -196,6 +196,7 @@ def rewind_body(body: typing.IO[typing.AnyStr], body_pos: _TYPE_BODY_POSITION) -
 class ChunksAndContentLength(typing.NamedTuple):
     chunks: typing.Iterable[bytes] | None
     content_length: int | None
+    is_string: bool
 
 
 def body_to_chunks(
@@ -224,7 +225,7 @@ def body_to_chunks(
             if not datablock:
                 break
             if encode:
-                datablock = datablock.encode("iso-8859-1")
+                datablock = datablock.encode("utf-8")
             yield datablock
 
     # No body, we need to make a recommendation on 'Content-Length'
@@ -273,4 +274,15 @@ def body_to_chunks(
             chunks = (body,)
             content_length = mv.nbytes
 
-    return ChunksAndContentLength(chunks=chunks, content_length=content_length)
+    return ChunksAndContentLength(
+        chunks=chunks,
+        content_length=content_length,
+        is_string=isinstance(
+            body,
+            (
+                str,
+                io.StringIO,
+                io.TextIOWrapper,
+            ),
+        ),
+    )


### PR DESCRIPTION
2.3.901 (2023-11-26)
====================

- Small performance improvement while in HTTP/1.1
- Any string passed down to the body will enforce a default ``Content-Type: text/plain; charset=utf-8`` for safety, unless
  you specified a ``Content-Type`` header yourself. The ``charset`` parameter will always be set to ``utf-8``.
  It is recommended that you pass ``bytes`` instead of a plain string. If a conflicting charset has been set that
  does not refer to utf-8, a warning will be raised.
- Added callable argument in ``urlopen``, and ``request`` named ``on_upload_body`` that enables you to track
  body upload progress for a single request. It takes 4 positional arguments, namely:
  (total_sent: int, total_to_be_sent: int | None, is_completed: bool, any_error: bool)
  total_to_be_sent may be set to None if we're unable to know in advance the total size (blind iterator/generator).
- Fixed a rare case where ``ProtocolError`` was raised instead of expected ``IncompleteRead`` exception.
- Improved HTTP/3 overall performance.
- Changed the default max connection per host for (http, https) pools managed by ``PoolManager``.
  If the ``PoolManager`` is instantiated with ``num_pools=10``, each (managed) subsequent pool will have ``maxsize=10``.
- Improved performance in a multithreading context while using many multiplexed connections.
- Changed the default max saturated multiplexed connections to 64 as the minimum.
  Now a warning will be fired if you reach the maximum capacity of stored saturated multiplexed connections.
