### PR TITLE
:bug: Fixed an issue where specifying `cert_reqs=ssl.CERT_NONE` or `assert_hostname` was ignored when using HTTP/3 over QUIC

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.3.902 (2023-12-08)
+====================
+
+- Fixed an issue where specifying `cert_reqs=ssl.CERT_NONE` or `assert_hostname` was ignored when using HTTP/3 over QUIC.
+
 2.3.901 (2023-11-26)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.3.901"
+__version__ = "2.3.902"

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -642,6 +642,8 @@ class HTTPSConnection(HTTPConnection):
                 self.key_file or self.key_data,
                 self.key_password,
                 self.assert_fingerprint,
+                self.assert_hostname,
+                self.cert_reqs,
             )
         except NotImplementedError:
             server_hostname: str = self.host


### PR DESCRIPTION
Close https://github.com/jawah/niquests/issues/52