### PR TITLE
:bookmark: Release 2.4.900

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,31 @@
+2.4.900 (2023-12-30)
+====================
+
+- Added issuer certificate extraction from SSLSocket with native calls with Python 3.10+ in ``ConnectionInfo``.
+- Added support for DNS over TLS, DNS over HTTPS, DNS over QUIC, DNS over UDP, and local hosts-like DNS.
+  ``PoolManager``, and ``HTTPPoolManager`` constructor now expose an additional keyword argument, ``resolver=...``.
+  You can assign to it one of the presented protocol. Also, you may chain a list of resolver, each resolver can be
+  limited to a list of host-pattern or not. Default is the system DNS. This new feature is covered by our thread-safety
+  promise.
+
+  You can now do the following: ``PoolManage(resolver="doh://dns.google")`` for example.
+  Refer to the official documentation to learn about the full capabilities.
+- Support for SOCKS proxies is now provided by `python-socks` instead of `PySocks` due to being largely
+  unmaintained within a reasonable period of time. This change is made completely transparent.
+- Added details in ``ConnectionInfo`` about detailed timings and others details.
+  ``established_latency`` is a _timedelta_ that represent the amount of time consumed to get an ESTABLISHED network link.
+  ``resolution_latency`` is a _timedelta_ that represent the amount of time consumed for the hostname resolution.
+  ``tls_handshake_latency`` is a _timedelta_ that represent the amount of time consumed for the TLS handshake.
+  ``request_sent_latency`` is a _timedelta_ that represent the amount of time consumed to encode and send the whole request through the socket.
+- Fixed a rare thread safety issue when using at least one HTTP/3 multiplexed connection.
+- Deprecated function ``util.connection.create_connection(..)`` in favor of newly added ``contrib.resolver`` that will
+  host from now on that function within ``BaseResolver`` as a method. Users are encouraged to migrate as soon as possible.
+- Support for preemptively negotiating HTTP/3 over QUIC based on RFC 9460 via a HTTPS DNS record.
+- Added support for enforcing IPv6, and/or IPv4 using the keyword parameter ``socket_family`` that can be provided in
+  ``PoolManager``, ``HTTP(S)ConnectionPool`` and ``HTTP(S)Connection``. The three accepted values are ``socket.AF_UNSPEC``
+  ``socket.AF_INET``, and ``socket.AF_INET6``. Respectively, allow all, ipv4 only, and ipv6 only. Anything else will raise
+  **ValueError**.
+
 2.3.902 (2023-12-08)
 ====================
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,31 @@
 <h1 align="center">
-
-![urllib3](https://github.com/jawah/urllib3.future/raw/main/docs/_static/logo.png)
-
+<img src="https://github.com/jawah/urllib3.future/raw/main/docs/_static/logo.png" width="450px" alt="urllib3.future logo"/>
 </h1>
 
 <p align="center">
   <a href="https://pypi.org/project/urllib3-future"><img alt="PyPI Version" src="https://img.shields.io/pypi/v/urllib3-future.svg?maxAge=86400" /></a>
   <a href="https://pypi.org/project/urllib3-future"><img alt="Python Versions" src="https://img.shields.io/pypi/pyversions/urllib3-future.svg?maxAge=86400" /></a>
   <br><small>urllib3.future is as BoringSSL is to OpenSSL but to urllib3 (except support is available!)</small>
+  <br><small>✨🍰Enjoy HTTP like its 2024🍰✨</small>
 </p>
 
 ⚡ urllib3.future is a powerful, *user-friendly* HTTP client for Python.<br>
 ⚡ urllib3.future goes beyond supported features while remaining compatible.<br>
-⚡ urllib3.future brings many critical features that are missing from the Python standard libraries:
+⚡ urllib3.future brings many critical features that are missing from both the Python standard libraries **and urllib3**:
 
 - Thread safety.
 - Connection pooling.
 - Client-side SSL/TLS verification.
+- Highly customizable DNS resolution.
 - File uploads with multipart encoding.
+- DNS over UDP, TLS, QUIC, or HTTPS. DNSSEC protected.
 - Helpers for retrying requests and dealing with HTTP redirects.
 - Support for gzip, deflate, brotli, and zstd encoding.
 - HTTP/1.1, HTTP/2 and HTTP/3 support.
 - Proxy support for HTTP and SOCKS.
+- Detailed connection inspection.
 - Multiplexed connection.
-- 93% test coverage.
+- 95% test coverage.
 
 urllib3.future is powerful and easy to use:
 
@@ -66,7 +68,7 @@ require `urllib3`.
 - **It's a fork**
 
 ⚠️ Installing urllib3.future shadows the actual urllib3 package (_depending on installation order_). 
-The semver will always be like _MAJOR.MINOR.9PP_ like 2.0.941, the patch node  is always greater or equal to 900.
+The semver will always be like _MAJOR.MINOR.9PP_ like 2.0.941, the patch node is always greater or equal to 900.
 
 Support for bugs or improvements is served in this repository. We regularly sync this fork
 with the main branch of urllib3/urllib3 against bugfixes and security patches if applicable.
@@ -91,7 +93,7 @@ python -m pip install requests
 python -m pip install urllib3.future
 ```
 
-We suggest using the package [**Niquests**](https://github.com/jawah/niquests) as a drop-in replacement for **Requests**. 
+Nowadays, we suggest using the package [**Niquests**](https://github.com/jawah/niquests) as a drop-in replacement for **Requests**. 
 It leverages urllib3.future capabilities.
 
 ## Documentation

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 coverage==7.0.4
 tornado==6.2
-PySocks==1.7.1
+python-socks==2.4.4
 pytest==7.2.0
 pytest-timeout==2.1.0
 trustme==0.9.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,8 +84,8 @@ html_static_path = ["_static"]
 html_theme_options = {
     "announcement": """
         <a style=\"text-decoration: none; color: white;\" 
-           href=\"https://github.com/sponsors/urllib3\">
-           <img src=\"/en/latest/_static/favicon.png\"/> Support urllib3 on GitHub Sponsors
+           href=\"https://github.com/sponsors/Ousret\">
+           <img src=\"/en/latest/_static/favicon.png\"/> Support urllib3.future on GitHub Sponsors
         </a>
     """,
     "sidebar_hide_name": True,
@@ -138,4 +138,8 @@ nitpick_ignore = [
     ("py:class", "urllib3.backend._base.LowLevelResponse"),
     ("py:class", "LowLevelResponse"),
     ("py:class", "QuicPreemptiveCacheType"),
+    ("py:class", "socket.SocketKind"),
+    ("py:class", "socket.AddressFamily"),
+    ("py:class", "timedelta"),
+    ("py:class", "TLSVersion"),
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-urllib3
-=======
+urllib3.future
+==============
 
 .. toctree::
    :hidden:
@@ -15,18 +15,21 @@ urllib3
 ⚡ urllib3.future is a powerful, *user-friendly* HTTP client for Python.
 ⚡ urllib3.future goes beyond supported features while remaining compatible.
 
-⚡ urllib3.future brings many critical features that are missing from the Python standard libraries:
+⚡ urllib3.future brings many critical features that are missing from both the Python standard libraries and **urllib3**:
 
 - Thread safety.
 - Connection pooling.
 - Client-side SSL/TLS verification.
+- Highly customizable DNS resolution.
 - File uploads with multipart encoding.
+- DNS over UDP, TLS, QUIC, or HTTPS. DNSSEC protected.
 - Helpers for retrying requests and dealing with HTTP redirects.
 - Support for gzip, deflate, brotli, and zstd encoding.
 - HTTP/1.1, HTTP/2 and HTTP/3 support.
-- Multiplexed connection.
 - Proxy support for HTTP and SOCKS.
-- 100% test coverage.
+- Detailed connection inspection.
+- Multiplexed connection.
+- 95% test coverage.
 
 urllib3 is powerful and easy to use:
 
@@ -59,7 +62,7 @@ The :doc:`reference/index` documentation provides API-level documentation.
 License
 -------
 
-urllib3.future is made available under the MIT License. For more details, see `LICENSE.txt <https://github.com/urllib3/urllib3/blob/master/LICENSE.txt>`_.
+urllib3.future is made available under the MIT License. For more details, see `LICENSE.txt <https://github.com/jawah/urllib3.future/blob/master/LICENSE.txt>`_.
 
 Contributing
 ------------

--- a/docs/reference/contrib/index.rst
+++ b/docs/reference/contrib/index.rst
@@ -7,3 +7,4 @@ prime time or that require optional third-party dependencies.
 .. toctree::
 
    socks
+   resolver

--- a/docs/reference/contrib/resolver.rst
+++ b/docs/reference/contrib/resolver.rst
@@ -1,0 +1,7 @@
+DNS Resolver
+============
+
+.. automodule:: urllib3.contrib.resolver
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -278,7 +278,7 @@ def run_loop_in_thread() -> Generator[tornado.ioloop.IOLoop, None, None]:
 
         # run asyncio.run in a thread and collect exceptions from *either*
         # the loop failing to start, or failing to close
-        ran = tpe.submit(_run_and_close_tornado, run)  # type: ignore[arg-type]
+        ran = tpe.submit(_run_and_close_tornado, run)
         for f in concurrent.futures.as_completed((loop_started, ran)):  # type: ignore[misc]
             if f is loop_started:
                 io_loop, stop_event = loop_started.result()

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,4 @@
-mypy==1.6.1; python_version >= '3.8'
+mypy==1.8.0; python_version >= '3.8'
 mypy==1.4.1; python_version < '3.8'
 idna>=2.0.0
 cryptography>=1.3.4
@@ -11,3 +11,4 @@ nox
 qh3>=0.14.0,<1.0.0
 h11>=0.11.0,<1.0.0
 h2>=4.0.0,<5.0.0
+python_socks>=2.0,<3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 name = "urllib3-future"
 description = "urllib3.future is a powerful HTTP 1.1, 2, and 3 client"
 readme = "README.md"
-keywords = ["urllib", "httplib", "threadsafe", "filepost", "http", "https", "ssl", "pooling", "multiplexed", "concurrent"]
+keywords = ["urllib", "httplib", "threadsafe", "filepost", "http", "https", "ssl", "pooling", "multiplexed", "concurrent", "dns", "dot", "doq", "doh", "dou", "dns-over-quic", "dns-over-https", "dns-over-tls"]
 authors = [
   {name = "Andrey Petrov", email = "andrey.petrov@shazow.net"}
 ]
@@ -52,7 +52,7 @@ zstd = [
 ]
 secure = []
 socks = [
-  "PySocks>=1.5.6,<2.0,!=1.5.7",
+  "python-socks>=2.0,<3.0",
 ]
 qh3 = [
   "qh3>=0.14.0,<1.0.0",
@@ -110,6 +110,7 @@ filterwarnings = [
     '''default:ast\.(Num|NameConstant|Str) is deprecated and will be removed in Python 3\.14; use ast\.Constant instead:DeprecationWarning:_pytest''',
     '''default:Attribute s is deprecated and will be removed in Python 3\.14; use value instead:DeprecationWarning:_pytest''',
     '''default:A conflicting charset has been set in Content-Type:UserWarning''',
+    '''default:util\.connection\.create_connection\(\) is deprecated and scheduled for removal:DeprecationWarning''',
 ]
 
 [tool.isort]

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -1,5 +1,5 @@
 """
-Python HTTP library with thread-safe connection pooling, file post support, user friendly, and more
+Python HTTP library with thread-safe connection pooling, file post support, user-friendly, and more
 """
 
 from __future__ import annotations
@@ -17,6 +17,7 @@ from ._typing import _TYPE_BODY, _TYPE_FIELDS
 from ._version import __version__
 from .backend import ConnectionInfo, HttpVersion, ResponsePromise
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
+from .contrib.resolver import ResolverDescription
 from .filepost import encode_multipart_formdata
 from .poolmanager import PoolManager, ProxyManager, proxy_from_url
 from .response import BaseHTTPResponse, HTTPResponse
@@ -68,6 +69,7 @@ __all__ = (
     "HttpVersion",
     "ConnectionInfo",
     "ResponsePromise",
+    "ResolverDescription",
 )
 
 logging.getLogger(__name__).addHandler(NullHandler())

--- a/src/urllib3/_typing.py
+++ b/src/urllib3/_typing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+from enum import Enum
 
 from .backend import LowLevelResponse
 from .fields import RequestField
@@ -68,7 +69,7 @@ try:
     from typing import TypedDict
 
     class _TYPE_SOCKS_OPTIONS(TypedDict):
-        socks_version: int
+        socks_version: int | Enum
         proxy_host: str | None
         proxy_port: str | None
         username: str | None

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.3.902"
+__version__ = "2.4.900"

--- a/src/urllib3/contrib/hface/protocols/http3/_qh3.py
+++ b/src/urllib3/contrib/hface/protocols/http3/_qh3.py
@@ -18,7 +18,7 @@ import ssl
 import typing
 from collections import deque
 from os import environ
-from time import thread_time as monotonic
+from time import time as monotonic
 from typing import Any, Iterable, Sequence
 
 if typing.TYPE_CHECKING:

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -4,8 +4,8 @@ import warnings
 
 warnings.warn(
     """'urllib3.contrib.pyopenssl' module has been removed in urllib3.future due to incompatibilities with our QUIC integration.
-While the import still work, it is rendered completely ineffective. Were you looking for in-memory client certificate?
-It is natively supported since v2.2, check the documentation.""",
+While the import proceed without error for your convenience, it is rendered completely ineffective. Were you looking for in-memory client certificate?
+See https://urllib3future.readthedocs.io/en/latest/advanced-usage.html#in-memory-client-mtls-certificate""",
     category=DeprecationWarning,
     stacklevel=2,
 )

--- a/src/urllib3/contrib/resolver/__init__.py
+++ b/src/urllib3/contrib/resolver/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from .factories import ResolverDescription, ResolverFactory
+from .protocols import BaseResolver, ManyResolver, ProtocolResolver
+
+__all__ = (
+    "ResolverFactory",
+    "ProtocolResolver",
+    "BaseResolver",
+    "ManyResolver",
+    "ResolverDescription",
+)

--- a/src/urllib3/contrib/resolver/doh/__init__.py
+++ b/src/urllib3/contrib/resolver/doh/__init__.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from ._urllib3 import (
+    AdGuardResolver,
+    CloudflareResolver,
+    GoogleResolver,
+    HTTPSResolver,
+    NextDNSResolver,
+    OpenDNSResolver,
+    Quad9Resolver,
+)
+
+__all__ = (
+    "HTTPSResolver",
+    "GoogleResolver",
+    "CloudflareResolver",
+    "AdGuardResolver",
+    "OpenDNSResolver",
+    "Quad9Resolver",
+    "NextDNSResolver",
+)

--- a/src/urllib3/contrib/resolver/doh/_urllib3.py
+++ b/src/urllib3/contrib/resolver/doh/_urllib3.py
@@ -1,0 +1,643 @@
+from __future__ import annotations
+
+import socket
+import typing
+from base64 import b64encode
+from collections import deque
+
+from ...._collections import HTTPHeaderDict
+from ....backend import ConnectionInfo, HttpVersion
+from ....connectionpool import HTTPSConnectionPool
+from ....response import HTTPResponse
+from ....util.url import parse_url
+from ..protocols import (
+    BaseResolver,
+    DomainNameServerQuery,
+    DomainNameServerReturn,
+    ProtocolResolver,
+    SupportedQueryType,
+)
+from ..utils import is_ipv4, is_ipv6, validate_length_of
+
+
+class HTTPSResolver(BaseResolver):
+    """
+    Advanced DNS over HTTPS resolver.
+    No common ground emerged from IETF w/ JSON. Following Google’s DNS over HTTPS schematics that is
+    also implemented at Cloudflare.
+
+    Support RFC 8484 without JSON. Disabled by default.
+    """
+
+    implementation = "urllib3"
+    protocol = ProtocolResolver.DOH
+
+    def __init__(
+        self,
+        server: str | None,
+        port: int | None = None,
+        *patterns: str,
+        **kwargs: typing.Any,
+    ) -> None:
+        super().__init__(server, port or 443, *patterns, **kwargs)
+
+        self._path: str = "/resolve"
+
+        if "path" in kwargs:
+            if isinstance(kwargs["path"], str) and kwargs["path"] != "/":
+                self._path = kwargs["path"]
+            kwargs.pop("path")
+
+        self._rfc8484: bool = False
+
+        if "rfc8484" in kwargs:
+            if kwargs["rfc8484"]:
+                self._rfc8484 = True
+            kwargs.pop("rfc8484")
+
+        assert self._server is not None
+
+        if "source_address" in kwargs:
+            if isinstance(kwargs["source_address"], str):
+                bind_ip, bind_port = kwargs["source_address"].split(":", 1)
+
+                if bind_ip and bind_port.isdigit():
+                    kwargs["source_address"] = (
+                        bind_ip,
+                        int(bind_port),
+                    )
+                else:
+                    raise ValueError("invalid source_address given in parameters")
+            else:
+                raise ValueError("invalid source_address given in parameters")
+
+        if "proxy" in kwargs:
+            kwargs["_proxy"] = parse_url(kwargs["proxy"])
+            kwargs.pop("proxy")
+
+        if "proxy_headers" in kwargs and "_proxy" in kwargs:
+            proxy_headers = HTTPHeaderDict()
+
+            if not isinstance(kwargs["proxy_headers"], list):
+                kwargs["proxy_headers"] = [kwargs["proxy_headers"]]
+
+            for item in kwargs["proxy_headers"]:
+                if ":" not in item:
+                    raise ValueError("Passed header is invalid in DNS parameters")
+
+                k, v = item.split(":", 1)
+                proxy_headers.add(k, v)
+
+            kwargs["_proxy_headers"] = proxy_headers
+
+        if "headers" in kwargs:
+            headers = HTTPHeaderDict()
+
+            if not isinstance(kwargs["headers"], list):
+                kwargs["headers"] = [kwargs["headers"]]
+
+            for item in kwargs["headers"]:
+                if ":" not in item:
+                    raise ValueError("Passed header is invalid in DNS parameters")
+
+                k, v = item.split(":", 1)
+                headers.add(k, v)
+
+            kwargs["headers"] = headers
+
+        if "disabled_svn" in kwargs:
+            if not isinstance(kwargs["disabled_svn"], list):
+                kwargs["disabled_svn"] = [kwargs["disabled_svn"]]
+
+            disabled_svn = set()
+
+            for svn in kwargs["disabled_svn"]:
+                svn = svn.lower()
+
+                if svn == "h2":
+                    disabled_svn.add(HttpVersion.h2)
+                elif svn == "h3":
+                    disabled_svn.add(HttpVersion.h3)
+
+            kwargs["disabled_svn"] = disabled_svn
+
+        if "on_post_connection" in kwargs and callable(kwargs["on_post_connection"]):
+            self._connection_callback: typing.Callable[
+                [ConnectionInfo], None
+            ] | None = kwargs["on_post_connection"]
+            kwargs.pop("on_post_connection")
+        else:
+            self._connection_callback = None
+
+        self._pool = HTTPSConnectionPool(self._server, self._port, **kwargs)
+        self._unconsumed: deque[HTTPResponse] = deque()
+
+    def close(self) -> None:
+        self._pool.close()
+
+    def is_available(self) -> bool:
+        return self._pool.pool is not None
+
+    def getaddrinfo(
+        self,
+        host: bytes | str | None,
+        port: str | int | None,
+        family: socket.AddressFamily,
+        type: socket.SocketKind,
+        proto: int = 0,
+        flags: int = 0,
+        *,
+        quic_upgrade_via_dns_rr: bool = False,
+    ) -> list[
+        tuple[
+            socket.AddressFamily,
+            socket.SocketKind,
+            int,
+            str,
+            tuple[str, int] | tuple[str, int, int, int],
+        ]
+    ]:
+        if host is None:
+            raise socket.gaierror("Tried to resolve 'localhost' from a HTTPSResolver")
+
+        if port is None:
+            port = 0
+        if isinstance(port, str):
+            port = int(port)
+        if port < 0:
+            raise socket.gaierror("Servname not supported for ai_socktype")
+
+        if isinstance(host, bytes):
+            host = host.decode("ascii")
+
+        if is_ipv4(host):
+            return [
+                (
+                    socket.AF_INET,
+                    type,
+                    6,
+                    "",
+                    (
+                        host,
+                        port,
+                    ),
+                )
+            ]
+        elif is_ipv6(host):
+            return [
+                (
+                    socket.AF_INET6,
+                    type,
+                    17,
+                    "",
+                    (
+                        host,
+                        port,
+                        0,
+                        0,
+                    ),
+                )
+            ]
+
+        validate_length_of(host)
+
+        promises = []
+        remote_preemptive_quic_rr = False
+
+        if quic_upgrade_via_dns_rr and type == socket.SOCK_DGRAM:
+            quic_upgrade_via_dns_rr = False
+
+        if family in [socket.AF_UNSPEC, socket.AF_INET]:
+            if not self._rfc8484:
+                promises.append(
+                    self._pool.request_encode_url(
+                        "GET",
+                        self._path,
+                        {"name": host, "type": "1"},
+                        headers={"Accept": "application/dns-json"},
+                        on_post_connection=self._connection_callback,
+                        multiplexed=True,
+                    )
+                )
+            else:
+                dns_query = DomainNameServerQuery(
+                    host, SupportedQueryType.A, override_id=0
+                )
+                dns_payload = bytes(dns_query)
+                promises.append(
+                    self._pool.request_encode_url(
+                        "GET",
+                        self._path,
+                        {
+                            "dns": b64encode(dns_payload).decode().replace("=", ""),
+                        },
+                        headers={"Accept": "application/dns-message"},
+                        on_post_connection=self._connection_callback,
+                        multiplexed=True,
+                    )
+                )
+
+        if family in [socket.AF_UNSPEC, socket.AF_INET6]:
+            if not self._rfc8484:
+                promises.append(
+                    self._pool.request_encode_url(
+                        "GET",
+                        self._path,
+                        {"name": host, "type": "28"},
+                        headers={"Accept": "application/dns-json"},
+                        on_post_connection=self._connection_callback,
+                        multiplexed=True,
+                    )
+                )
+            else:
+                dns_query = DomainNameServerQuery(
+                    host, SupportedQueryType.AAAA, override_id=0
+                )
+                dns_payload = bytes(dns_query)
+
+                promises.append(
+                    self._pool.request_encode_url(
+                        "GET",
+                        self._path,
+                        {
+                            "dns": b64encode(dns_payload).decode().replace("=", ""),
+                        },
+                        headers={"Accept": "application/dns-message"},
+                        on_post_connection=self._connection_callback,
+                        multiplexed=True,
+                    )
+                )
+
+        if quic_upgrade_via_dns_rr:
+            if not self._rfc8484:
+                promises.append(
+                    self._pool.request_encode_url(
+                        "GET",
+                        self._path,
+                        {"name": host, "type": "65"},
+                        headers={"Accept": "application/dns-json"},
+                        on_post_connection=self._connection_callback,
+                        multiplexed=True,
+                    )
+                )
+            else:
+                dns_query = DomainNameServerQuery(
+                    host, SupportedQueryType.HTTPS, override_id=0
+                )
+                dns_payload = bytes(dns_query)
+
+                promises.append(
+                    self._pool.request_encode_url(
+                        "GET",
+                        self._path,
+                        {
+                            "dns": b64encode(dns_payload).decode().replace("=", ""),
+                        },
+                        headers={"Accept": "application/dns-message"},
+                        on_post_connection=self._connection_callback,
+                        multiplexed=True,
+                    )
+                )
+
+        no_multiplexing: bool = isinstance(promises[0], HTTPResponse)
+
+        results: list[
+            tuple[
+                socket.AddressFamily,
+                socket.SocketKind,
+                int,
+                str,
+                tuple[str, int] | tuple[str, int, int, int],
+            ]
+        ] = []
+
+        while promises:
+            response = None
+
+            if no_multiplexing is False:
+                with self._lock:
+                    if self._unconsumed:
+                        for unconsumed in self._unconsumed:
+                            for pending_promise in promises:
+                                if unconsumed.is_from_promise(pending_promise):
+                                    response = unconsumed
+                                    break
+                            if response:
+                                break
+                        if response:
+                            self._unconsumed.remove(response)
+
+                if not response:
+                    response = self._pool.get_response()
+
+                if response is None:
+                    raise socket.gaierror(
+                        "DNS over HTTPS failed due to a protocol error in urllib3.future or remote peer. Expected a response, got none."
+                    )
+
+                p = None
+
+                for p in promises:
+                    if response.is_from_promise(p):
+                        break
+
+                if p is None:
+                    with self._lock:
+                        self._unconsumed.append(response)
+                    continue
+
+                promises.remove(p)
+            else:
+                response = promises.pop()  # type: ignore[assignment]
+
+            assert response is not None
+
+            if response.status >= 300:
+                raise socket.gaierror(
+                    f"DNS over HTTPS was unsuccessful, server response status {response.status}."
+                )
+
+            if not self._rfc8484:
+                payload = response.json()
+
+                assert "Status" in payload and isinstance(payload["Status"], int)
+
+                if payload["Status"] != 0:
+                    msg = (
+                        payload["Comment"]
+                        if "Comment" in payload
+                        else f"Remote DNS indicated that an error occurred while providing resolution. Status {payload['Status']}."
+                    )
+
+                    if isinstance(msg, list):
+                        msg = ", ".join(msg)
+
+                    raise socket.gaierror(msg)
+
+                assert "Question" in payload and isinstance(payload["Question"], list)
+
+                if "Answer" not in payload:
+                    continue
+
+                assert isinstance(payload["Answer"], list)
+
+                for answer in payload["Answer"]:
+                    if answer["type"] not in [1, 28, 65]:
+                        continue
+
+                    assert "data" in answer
+                    assert isinstance(answer["data"], str)
+
+                    # DNS RR/HTTPS
+                    if answer["type"] == 65:
+                        # "1 . alpn=h3,h2 ipv4hint=104.16.132.229,104.16.133.229 ipv6hint=2606:4700::6810:84e5,2606:4700::6810:85e5"
+                        # or..
+                        # "1 . alpn=h2,h3"
+                        rr: str = answer["data"]
+
+                        if rr.startswith("\\#"):  # it means, raw, bytes.
+                            rr = rr[2:].replace(" ", "")
+                            raw_record = bytes.fromhex(rr)
+
+                            if b"h3" not in raw_record:
+                                continue
+
+                            remote_preemptive_quic_rr = True
+                        else:
+                            rr_decode: dict[str, str] = dict(
+                                tuple(_.lower().split("=", 1))
+                                for _ in rr.split(" ")
+                                if "=" in _
+                            )
+
+                            if "alpn" not in rr_decode or "h3" not in rr_decode["alpn"]:
+                                continue
+
+                            remote_preemptive_quic_rr = True
+
+                            if "ipv4hint" in rr_decode and family in [
+                                socket.AF_UNSPEC,
+                                socket.AF_INET,
+                            ]:
+                                for ipv4 in rr_decode["ipv4hint"].split(","):
+                                    results.append(
+                                        (
+                                            socket.AF_INET,
+                                            socket.SOCK_DGRAM,
+                                            17,
+                                            "",
+                                            (
+                                                ipv4,
+                                                port,
+                                            ),
+                                        )
+                                    )
+                            if "ipv6hint" in rr_decode and family in [
+                                socket.AF_UNSPEC,
+                                socket.AF_INET6,
+                            ]:
+                                for ipv6 in rr_decode["ipv6hint"].split(","):
+                                    results.append(
+                                        (
+                                            socket.AF_INET6,
+                                            socket.SOCK_DGRAM,
+                                            17,
+                                            "",
+                                            (
+                                                ipv6,
+                                                port,
+                                                0,
+                                                0,
+                                            ),
+                                        )
+                                    )
+
+                            continue
+
+                    inet_type = (
+                        socket.AF_INET if answer["type"] == 1 else socket.AF_INET6
+                    )
+
+                    dst_addr: tuple[str, int] | tuple[str, int, int, int] = (
+                        (
+                            answer["data"],
+                            port,
+                        )
+                        if inet_type == socket.AF_INET
+                        else (
+                            answer["data"],
+                            port,
+                            0,
+                            0,
+                        )
+                    )
+
+                    results.append(
+                        (
+                            inet_type,
+                            type,
+                            6 if type == socket.SOCK_STREAM else 17,
+                            "",
+                            dst_addr,
+                        )
+                    )
+            else:
+                dns_resp = DomainNameServerReturn(response.data)
+
+                for record in dns_resp.records:
+                    if record[0] == SupportedQueryType.HTTPS:
+                        if "h3" in record[-1]:
+                            remote_preemptive_quic_rr = True
+                        continue
+
+                    inet_type = (
+                        socket.AF_INET
+                        if record[0] == SupportedQueryType.A
+                        else socket.AF_INET6
+                    )
+                    dst_addr = (
+                        (
+                            record[-1],
+                            port,
+                        )
+                        if inet_type == socket.AF_INET
+                        else (
+                            record[-1],
+                            port,
+                            0,
+                            0,
+                        )
+                    )
+
+                    results.append(
+                        (
+                            inet_type,
+                            type,
+                            6 if type == socket.SOCK_STREAM else 17,
+                            "",
+                            dst_addr,
+                        )
+                    )
+
+        quic_results: list[
+            tuple[
+                socket.AddressFamily,
+                socket.SocketKind,
+                int,
+                str,
+                tuple[str, int] | tuple[str, int, int, int],
+            ]
+        ] = []
+
+        if remote_preemptive_quic_rr:
+            any_specified = False
+
+            for result in results:
+                if result[1] == socket.SOCK_STREAM:
+                    quic_results.append(
+                        (result[0], socket.SOCK_DGRAM, 17, "", result[4])
+                    )
+                else:
+                    any_specified = True
+                    break
+
+            if any_specified:
+                quic_results = []
+
+        return sorted(quic_results + results, key=lambda _: _[0] + _[1], reverse=True)
+
+
+class GoogleResolver(HTTPSResolver):
+    specifier = "google"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+        if "rfc8484" in kwargs:
+            if kwargs["rfc8484"]:
+                kwargs["path"] = "/dns-query"
+        super().__init__("dns.google", port, *patterns, **kwargs)
+
+
+class CloudflareResolver(HTTPSResolver):
+    specifier = "cloudflare"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+
+        kwargs.update({"path": "/dns-query"})
+        super().__init__("cloudflare-dns.com", port, *patterns, **kwargs)
+
+
+class AdGuardResolver(HTTPSResolver):
+    specifier = "adguard"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+
+        kwargs.update({"path": "/dns-query", "rfc8484": True})
+        super().__init__("unfiltered.adguard-dns.com", port, *patterns, **kwargs)
+
+
+class OpenDNSResolver(HTTPSResolver):
+    specifier = "opendns"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+
+        kwargs.update({"path": "/dns-query", "rfc8484": True})
+        super().__init__("dns.opendns.com", port, *patterns, **kwargs)
+
+
+class Quad9Resolver(HTTPSResolver):
+    specifier = "quad9"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+
+        kwargs.update({"path": "/dns-query", "rfc8484": True})
+        super().__init__("dns11.quad9.net", port, *patterns, **kwargs)
+
+
+class NextDNSResolver(HTTPSResolver):
+    specifier = "nextdns"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+
+        super().__init__("dns.nextdns.io", port, *patterns, **kwargs)

--- a/src/urllib3/contrib/resolver/doq/__init__.py
+++ b/src/urllib3/contrib/resolver/doq/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+try:
+    from ._qh3 import AdGuardResolver, NextDNSResolver, QUICResolver
+except ImportError:
+    QUICResolver = None  # type: ignore
+    AdGuardResolver = None  # type: ignore
+    NextDNSResolver = None  # type: ignore
+
+
+__all__ = (
+    "QUICResolver",
+    "AdGuardResolver",
+    "NextDNSResolver",
+)

--- a/src/urllib3/contrib/resolver/doq/_qh3.py
+++ b/src/urllib3/contrib/resolver/doq/_qh3.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+import socket
+import ssl
+import struct
+import typing
+from collections import deque
+from ssl import SSLError
+from time import time as monotonic
+
+from qh3.quic.configuration import QuicConfiguration
+from qh3.quic.connection import QuicConnection
+from qh3.quic.events import (
+    ConnectionTerminated,
+    HandshakeCompleted,
+    QuicEvent,
+    StopSendingReceived,
+    StreamDataReceived,
+    StreamReset,
+)
+
+from ....util.ssl_ import resolve_cert_reqs
+from ..dou import PlainResolver
+from ..protocols import (
+    COMMON_RCODE_LABEL,
+    DomainNameServerQuery,
+    DomainNameServerReturn,
+    ProtocolResolver,
+    SupportedQueryType,
+)
+from ..utils import is_ipv4, is_ipv6, packet_fragment, validate_length_of
+
+
+class QUICResolver(PlainResolver):
+    protocol = ProtocolResolver.DOQ
+    implementation = "qh3"
+
+    def __init__(
+        self,
+        server: str | None,
+        port: int | None = None,
+        *patterns: str,
+        **kwargs: typing.Any,
+    ):
+        super().__init__(server, port or 853, *patterns, **kwargs)
+
+        configuration = QuicConfiguration(
+            is_client=True,
+            alpn_protocols=["doq"],
+            server_name=self._server
+            if "server_hostname" not in kwargs
+            else kwargs["server_hostname"],
+            verify_mode=resolve_cert_reqs(kwargs["cert_reqs"])
+            if "cert_reqs" in kwargs
+            else ssl.CERT_REQUIRED,
+            cadata=kwargs["ca_cert_data"].encode()
+            if "ca_cert_data" in kwargs
+            else None,
+            cafile=kwargs["ca_certs"] if "ca_certs" in kwargs else None,
+        )
+
+        if "cert_file" in kwargs:
+            configuration.load_cert_chain(
+                kwargs["cert_file"],
+                kwargs["key_file"] if "key_file" in kwargs else None,
+                kwargs["key_password"] if "key_password" in kwargs else None,
+            )
+        elif "cert_data" in kwargs:
+            configuration.load_cert_chain(
+                kwargs["cert_data"],
+                kwargs["key_data"] if "key_data" in kwargs else None,
+                kwargs["key_password"] if "key_password" in kwargs else None,
+            )
+
+        self._quic = QuicConnection(configuration=configuration)
+
+        self._quic.connect((self._server, self._port), monotonic())
+        self.__exchange_until(HandshakeCompleted, receive_first=False)
+
+        self._terminated: bool = False
+        self._should_disconnect: bool = False
+
+        # DNS over QUIC mandate the size-prefix (unsigned int, 2b)
+        self._hook_in = lambda p: p[2:]
+        self._hook_out = lambda p: struct.pack("!H", len(p)) + p
+
+        self._unconsumed: deque[DomainNameServerReturn] = deque()
+        self._pending: deque[DomainNameServerQuery] = deque()
+
+    def close(self) -> None:
+        with self._lock:
+            self._quic.close()
+
+            while True:
+                datagrams = self._quic.datagrams_to_send(monotonic())
+
+                if not datagrams:
+                    break
+
+                for datagram in datagrams:
+                    data, addr = datagram
+                    self._socket.sendall(data)
+
+            self._socket.close()
+            self._terminated = True
+
+    def is_available(self) -> bool:
+        return not self._terminated
+
+    def getaddrinfo(
+        self,
+        host: bytes | str | None,
+        port: str | int | None,
+        family: socket.AddressFamily,
+        type: socket.SocketKind,
+        proto: int = 0,
+        flags: int = 0,
+        *,
+        quic_upgrade_via_dns_rr: bool = False,
+    ) -> list[
+        tuple[
+            socket.AddressFamily,
+            socket.SocketKind,
+            int,
+            str,
+            tuple[str, int] | tuple[str, int, int, int],
+        ]
+    ]:
+        if host is None:
+            raise socket.gaierror("Tried to resolve 'localhost' using the QUICResolver")
+        if port is None:
+            port = 0
+        if isinstance(port, str):
+            port = int(port)
+        if port < 0:
+            raise socket.gaierror("Servname not supported for ai_socktype")
+
+        if isinstance(host, bytes):
+            host = host.decode("ascii")
+
+        if is_ipv4(host):
+            return [
+                (
+                    socket.AF_INET,
+                    type,
+                    6,
+                    "",
+                    (
+                        host,
+                        port,
+                    ),
+                )
+            ]
+        elif is_ipv6(host):
+            return [
+                (
+                    socket.AF_INET6,
+                    type,
+                    17,
+                    "",
+                    (
+                        host,
+                        port,
+                        0,
+                        0,
+                    ),
+                )
+            ]
+
+        validate_length_of(host)
+
+        remote_preemptive_quic_rr = False
+
+        if quic_upgrade_via_dns_rr and type == socket.SOCK_DGRAM:
+            quic_upgrade_via_dns_rr = False
+
+        tbq = []
+
+        if family in [socket.AF_UNSPEC, socket.AF_INET]:
+            tbq.append(SupportedQueryType.A)
+
+        if family in [socket.AF_UNSPEC, socket.AF_INET6]:
+            tbq.append(SupportedQueryType.AAAA)
+
+        if quic_upgrade_via_dns_rr:
+            tbq.append(SupportedQueryType.HTTPS)
+
+        queries = DomainNameServerQuery.bulk(host, *tbq)
+        open_streams = []
+
+        with self._lock:
+            for q in queries:
+                payload = bytes(q)
+
+                self._pending.append(q)
+
+                if self._hook_out is not None:
+                    payload = self._hook_out(payload)
+
+                stream_id = self._quic.get_next_available_stream_id()
+                self._quic.send_stream_data(stream_id, payload, True)
+
+                open_streams.append(stream_id)
+
+                for dg in self._quic.datagrams_to_send(monotonic()):
+                    self._socket.sendall(dg[0])
+
+        responses: list[DomainNameServerReturn] = []
+
+        while len(responses) < len(tbq):
+            with self._lock:
+                if self._unconsumed:
+                    dns_resp = None
+                    for query in queries:
+                        for unconsumed in self._unconsumed:
+                            if unconsumed.id == query.id:
+                                dns_resp = unconsumed
+                                responses.append(dns_resp)
+                                break
+                        if dns_resp:
+                            break
+                    if dns_resp:
+                        self._unconsumed.remove(dns_resp)
+                        self._pending.remove(query)
+                        continue
+
+                events: list[StreamDataReceived] = self.__exchange_until(  # type: ignore[assignment]
+                    StreamDataReceived,
+                    receive_first=True,
+                    event_type_collectable=(StreamDataReceived,),
+                )
+
+                payload = b"".join([e.data for e in events])
+
+                if not payload:
+                    continue
+
+                pending_raw_identifiers = [_.raw_id for _ in self._pending]
+
+                #: We can receive two responses at once (or more, concatenated). Let's unwrap them.
+                fragments = packet_fragment(payload, *pending_raw_identifiers)
+
+                for fragment in fragments:
+                    if self._hook_in is not None:
+                        fragment = self._hook_in(fragment)
+
+                    dns_resp = DomainNameServerReturn(fragment)
+
+                    if any(dns_resp.id == _.id for _ in queries):
+                        responses.append(dns_resp)
+
+                        query_tbr: DomainNameServerQuery | None = None
+
+                        for query_tbr in self._pending:
+                            if query_tbr.id == dns_resp.id:
+                                break
+                        if query_tbr:
+                            self._pending.remove(query_tbr)
+                    else:
+                        self._unconsumed.append(dns_resp)
+
+        if self._should_disconnect:
+            with self._lock:
+                self.close()
+                self._should_disconnect = False
+                self._terminated = True
+
+        results = []
+
+        for response in responses:
+            if not response.is_ok:
+                if response.rcode == 2:
+                    raise socket.gaierror(
+                        f"DNSSEC validation failure. Check http://dnsviz.net/d/{host}/dnssec/ and http://dnssec-debugger.verisignlabs.com/{host} for errors"
+                    )
+                raise socket.gaierror(
+                    f"DNS returned an error: {COMMON_RCODE_LABEL[response.rcode] if response.rcode in COMMON_RCODE_LABEL else f'code {response.rcode}'}"
+                )
+
+            for record in response.records:
+                if record[0] == SupportedQueryType.HTTPS:
+                    if "h3" in record[-1]:
+                        remote_preemptive_quic_rr = True
+                    continue
+
+                inet_type = (
+                    socket.AF_INET
+                    if record[0] == SupportedQueryType.A
+                    else socket.AF_INET6
+                )
+                dst_addr: tuple[str, int] | tuple[str, int, int, int] = (
+                    (
+                        record[-1],
+                        port,
+                    )
+                    if inet_type == socket.AF_INET
+                    else (
+                        record[-1],
+                        port,
+                        0,
+                        0,
+                    )
+                )
+
+                results.append(
+                    (
+                        inet_type,
+                        type,
+                        6 if type == socket.SOCK_STREAM else 17,
+                        "",
+                        dst_addr,
+                    )
+                )
+
+        quic_results = []
+
+        if remote_preemptive_quic_rr:
+            any_specified = False
+
+            for result in results:
+                if result[1] == socket.SOCK_STREAM:
+                    quic_results.append(
+                        (result[0], socket.SOCK_DGRAM, 17, "", result[4])
+                    )
+                else:
+                    any_specified = True
+                    break
+
+            if any_specified:
+                quic_results = []
+
+        return sorted(quic_results + results, key=lambda _: _[0] + _[1], reverse=True)
+
+    def __exchange_until(
+        self,
+        event_type: type[QuicEvent] | tuple[type[QuicEvent], ...],
+        *,
+        receive_first: bool = False,
+        event_type_collectable: type[QuicEvent]
+        | tuple[type[QuicEvent], ...]
+        | None = None,
+        respect_end_stream_signal: bool = True,
+    ) -> list[QuicEvent]:
+        while True:
+            if receive_first is False:
+                now = monotonic()
+                while True:
+                    datagrams = self._quic.datagrams_to_send(now)
+
+                    if not datagrams:
+                        break
+
+                    for datagram in datagrams:
+                        data, addr = datagram
+                        self._socket.sendall(data)
+
+            events = []
+
+            while True:
+                data = self._socket.recv(1500)
+
+                if not data:
+                    break
+
+                now = monotonic()
+
+                self._quic.receive_datagram(data, (self._server, self._port), now)
+
+                while True:
+                    datagrams = self._quic.datagrams_to_send(now)
+
+                    if not datagrams:
+                        break
+
+                    for datagram in datagrams:
+                        data, addr = datagram
+                        self._socket.sendall(data)
+
+                for ev in iter(self._quic.next_event, None):
+                    if isinstance(ev, ConnectionTerminated):
+                        if ev.error_code == 298:
+                            raise SSLError(
+                                "DNS over QUIC did not succeed (Error 298). Chain certificate verification failed."
+                            )
+                        raise socket.gaierror(
+                            f"DNS over QUIC encountered a unrecoverable failure (error {ev.error_code} {ev.reason_phrase})"
+                        )
+                    elif isinstance(ev, StreamReset):
+                        self._terminated = True
+                        raise socket.gaierror(
+                            "DNS over QUIC server submitted a StreamReset. A request was rejected."
+                        )
+                    elif isinstance(ev, StopSendingReceived):
+                        self._should_disconnect = True
+                        continue
+
+                    if event_type_collectable:
+                        if isinstance(ev, event_type_collectable):
+                            events.append(ev)
+                    else:
+                        events.append(ev)
+
+                    if isinstance(ev, event_type):
+                        if not respect_end_stream_signal:
+                            return events
+                        if hasattr(ev, "stream_ended") and ev.stream_ended:
+                            return events
+                        elif hasattr(ev, "stream_ended") is False:
+                            return events
+
+            return events
+
+
+class AdGuardResolver(QUICResolver):
+    specifier = "adguard"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any):
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+        super().__init__("unfiltered.adguard-dns.com", port, *patterns, **kwargs)
+
+
+class NextDNSResolver(QUICResolver):
+    specifier = "nextdns"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any):
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+        super().__init__("dns.nextdns.io", port, *patterns, **kwargs)

--- a/src/urllib3/contrib/resolver/dot/__init__.py
+++ b/src/urllib3/contrib/resolver/dot/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from ._ssl import (
+    AdGuardResolver,
+    CloudflareResolver,
+    GoogleResolver,
+    OpenDNSResolver,
+    Quad9Resolver,
+    TLSResolver,
+)
+
+__all__ = (
+    "TLSResolver",
+    "GoogleResolver",
+    "CloudflareResolver",
+    "AdGuardResolver",
+    "Quad9Resolver",
+    "OpenDNSResolver",
+)

--- a/src/urllib3/contrib/resolver/dot/_ssl.py
+++ b/src/urllib3/contrib/resolver/dot/_ssl.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import socket
+import struct
+import typing
+
+from ....util.ssl_ import resolve_cert_reqs, ssl_wrap_socket
+from ..dou import PlainResolver
+from ..protocols import ProtocolResolver
+
+
+class TLSResolver(PlainResolver):
+    """
+    Basic DNS resolver over TLS.
+    Comply with RFC 7858: https://datatracker.ietf.org/doc/html/rfc7858
+    """
+
+    protocol = ProtocolResolver.DOT
+    implementation = "ssl"
+
+    def __init__(
+        self,
+        server: str | None,
+        port: int | None = None,
+        *patterns: str,
+        **kwargs: typing.Any,
+    ) -> None:
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        if "source_address" in kwargs and isinstance(kwargs["source_address"], str):
+            bind_ip, bind_port = kwargs["source_address"].split(":", 1)
+
+            if bind_ip and bind_port.isdigit():
+                self._socket.bind((bind_ip, int(bind_port)))
+
+        self._socket.connect((server, port or 853))
+
+        super().__init__(server, port, *patterns, **kwargs)
+
+        self._socket = ssl_wrap_socket(
+            self._socket,
+            server_hostname=server
+            if "server_hostname" not in kwargs
+            else kwargs["server_hostname"],
+            keyfile=kwargs["key_file"] if "key_file" in kwargs else None,
+            certfile=kwargs["cert_file"] if "cert_file" in kwargs else None,
+            cert_reqs=resolve_cert_reqs(kwargs["cert_reqs"])
+            if "cert_reqs" in kwargs
+            else None,
+            ca_certs=kwargs["ca_certs"] if "ca_certs" in kwargs else None,
+            ssl_version=kwargs["ssl_version"] if "ssl_version" in kwargs else None,
+            ciphers=kwargs["ciphers"] if "ciphers" in kwargs else None,
+            ca_cert_dir=kwargs["ca_cert_dir"] if "ca_cert_dir" in kwargs else None,
+            key_password=kwargs["key_password"] if "key_password" in kwargs else None,
+            ca_cert_data=kwargs["ca_cert_data"] if "ca_cert_data" in kwargs else None,
+            certdata=kwargs["cert_data"] if "cert_data" in kwargs else None,
+            keydata=kwargs["key_data"] if "key_data" in kwargs else None,
+        )
+
+        if "timeout" in kwargs and isinstance(kwargs["timeout"], (int, float)):
+            self._socket.settimeout(kwargs["timeout"])
+
+        # DNS over TLS mandate the size-prefix (unsigned int, 2 bytes)
+        self._hook_in = lambda p: p[2:]
+        self._hook_out = lambda p: struct.pack("!H", len(p)) + p
+
+
+class GoogleResolver(TLSResolver):
+    specifier = "google"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+
+        super().__init__("dns.google", port, *patterns, **kwargs)
+
+
+class CloudflareResolver(TLSResolver):
+    specifier = "cloudflare"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+
+        super().__init__("1.1.1.1", port, *patterns, **kwargs)
+
+
+class AdGuardResolver(TLSResolver):
+    specifier = "adguard"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+
+        super().__init__("unfiltered.adguard-dns.com", port, *patterns, **kwargs)
+
+
+class OpenDNSResolver(TLSResolver):
+    specifier = "opendns"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+
+        super().__init__("dns.opendns.com", port, *patterns, **kwargs)
+
+
+class Quad9Resolver(TLSResolver):
+    specifier = "quad9"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+
+        super().__init__("dns11.quad9.net", port, *patterns, **kwargs)

--- a/src/urllib3/contrib/resolver/dou/__init__.py
+++ b/src/urllib3/contrib/resolver/dou/__init__.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from ._socket import (
+    AdGuardResolver,
+    CloudflareResolver,
+    GoogleResolver,
+    PlainResolver,
+    Quad9Resolver,
+)
+
+__all__ = (
+    "PlainResolver",
+    "CloudflareResolver",
+    "GoogleResolver",
+    "Quad9Resolver",
+    "AdGuardResolver",
+)

--- a/src/urllib3/contrib/resolver/dou/_socket.py
+++ b/src/urllib3/contrib/resolver/dou/_socket.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import socket
+import typing
+from collections import deque
+
+from ..protocols import (
+    COMMON_RCODE_LABEL,
+    BaseResolver,
+    DomainNameServerQuery,
+    DomainNameServerReturn,
+    ProtocolResolver,
+    SupportedQueryType,
+)
+from ..utils import is_ipv4, is_ipv6, packet_fragment, validate_length_of
+
+
+class PlainResolver(BaseResolver):
+    """
+    Minimalist DNS resolver over UDP
+    Comply with RFC 1035: https://datatracker.ietf.org/doc/html/rfc1035
+
+    EDNS is not supported, yet. But we plan to. Willing to contribute?
+    """
+
+    protocol = ProtocolResolver.DOU
+    implementation = "socket"
+
+    def __init__(
+        self,
+        server: str | None,
+        port: int | None = None,
+        *patterns: str,
+        **kwargs: typing.Any,
+    ) -> None:
+        super().__init__(server, port, *patterns, **kwargs)
+
+        if not hasattr(self, "_socket"):
+            self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+            if "source_address" in kwargs and isinstance(kwargs["source_address"], str):
+                bind_ip, bind_port = kwargs["source_address"].split(":", 1)
+
+                if bind_ip and bind_port.isdigit():
+                    self._socket.bind((bind_ip, int(bind_port)))
+
+            self._socket.connect((server, port or 53))
+
+        if "timeout" in kwargs and isinstance(
+            kwargs["timeout"],
+            (
+                float,
+                int,
+            ),
+        ):
+            self._socket.settimeout(kwargs["timeout"])
+
+        #: Only useful for inheritance, e.g. DNS over TLS support dns-message but require a prefix.
+        self._hook_out: typing.Callable[[bytes], bytes] | None = None
+        self._hook_in: typing.Callable[[bytes], bytes] | None = None
+
+        self._unconsumed: deque[DomainNameServerReturn] = deque()
+        self._pending: deque[DomainNameServerQuery] = deque()
+
+        self._terminated: bool = False
+
+    def close(self) -> None:
+        with self._lock:
+            self._socket.close()
+            self._terminated = True
+
+    def is_available(self) -> bool:
+        return not self._terminated
+
+    def getaddrinfo(
+        self,
+        host: bytes | str | None,
+        port: str | int | None,
+        family: socket.AddressFamily,
+        type: socket.SocketKind,
+        proto: int = 0,
+        flags: int = 0,
+        *,
+        quic_upgrade_via_dns_rr: bool = False,
+    ) -> list[
+        tuple[
+            socket.AddressFamily,
+            socket.SocketKind,
+            int,
+            str,
+            tuple[str, int] | tuple[str, int, int, int],
+        ]
+    ]:
+        if host is None:
+            raise socket.gaierror("Tried to resolve 'localhost' from a PlainResolver")
+
+        if port is None:
+            port = 0
+        if isinstance(port, str):
+            port = int(port)
+        if port < 0:
+            raise socket.gaierror("Servname not supported for ai_socktype")
+
+        if isinstance(host, bytes):
+            host = host.decode("ascii")
+
+        if is_ipv4(host):
+            return [
+                (
+                    socket.AF_INET,
+                    type,
+                    6,
+                    "",
+                    (
+                        host,
+                        port,
+                    ),
+                )
+            ]
+        elif is_ipv6(host):
+            return [
+                (
+                    socket.AF_INET6,
+                    type,
+                    17,
+                    "",
+                    (
+                        host,
+                        port,
+                        0,
+                        0,
+                    ),
+                )
+            ]
+
+        validate_length_of(host)
+
+        remote_preemptive_quic_rr = False
+
+        if quic_upgrade_via_dns_rr and type == socket.SOCK_DGRAM:
+            quic_upgrade_via_dns_rr = False
+
+        tbq = []
+
+        if family in [socket.AF_UNSPEC, socket.AF_INET]:
+            tbq.append(SupportedQueryType.A)
+
+        if family in [socket.AF_UNSPEC, socket.AF_INET6]:
+            tbq.append(SupportedQueryType.AAAA)
+
+        if quic_upgrade_via_dns_rr:
+            tbq.append(SupportedQueryType.HTTPS)
+
+        queries = DomainNameServerQuery.bulk(host, *tbq)
+
+        with self._lock:
+            for q in queries:
+                payload = bytes(q)
+                self._pending.append(q)
+
+                if self._hook_out is not None:
+                    payload = self._hook_out(payload)
+
+                self._socket.sendall(payload)
+
+        responses: list[DomainNameServerReturn] = []
+
+        while len(responses) < len(tbq):
+            with self._lock:
+                #: There we want to verify if another thread got a response that belong to this thread.
+                if self._unconsumed:
+                    dns_resp = None
+
+                    for query in queries:
+                        for unconsumed in self._unconsumed:
+                            if unconsumed.id == query.id:
+                                dns_resp = unconsumed
+                                responses.append(dns_resp)
+                                break
+                        if dns_resp:
+                            break
+
+                    if dns_resp:
+                        self._pending.remove(query)
+                        self._unconsumed.remove(dns_resp)
+                        continue
+
+                payload = self._socket.recv(1500)
+
+                if not payload:
+                    self._terminated = True
+                    raise socket.gaierror(
+                        "Got unexpectedly disconnected while waiting for name resolution"
+                    )
+
+                pending_raw_identifiers = [_.raw_id for _ in self._pending]
+
+                #: We can receive two responses at once (or more, concatenated). Let's unwrap them.
+                fragments = packet_fragment(payload, *pending_raw_identifiers)
+
+                for fragment in fragments:
+                    if self._hook_in is not None:
+                        fragment = self._hook_in(fragment)
+
+                    dns_resp = DomainNameServerReturn(fragment)
+
+                    if any(dns_resp.id == _.id for _ in queries):
+                        responses.append(dns_resp)
+
+                        query_tbr: DomainNameServerQuery | None = None
+
+                        for query_tbr in self._pending:
+                            if query_tbr.id == dns_resp.id:
+                                break
+
+                        if query_tbr:
+                            self._pending.remove(query_tbr)
+                    else:
+                        self._unconsumed.append(dns_resp)
+
+        results = []
+
+        for response in responses:
+            if not response.is_ok:
+                if response.rcode == 2:
+                    raise socket.gaierror(
+                        f"DNSSEC validation failure. Check http://dnsviz.net/d/{host}/dnssec/ and http://dnssec-debugger.verisignlabs.com/{host} for errors"
+                    )
+                raise socket.gaierror(
+                    f"DNS returned an error: {COMMON_RCODE_LABEL[response.rcode] if response.rcode in COMMON_RCODE_LABEL else f'code {response.rcode}'}"
+                )
+
+            for record in response.records:
+                if record[0] == SupportedQueryType.HTTPS:
+                    if "h3" in record[-1]:
+                        remote_preemptive_quic_rr = True
+                    continue
+
+                inet_type = (
+                    socket.AF_INET
+                    if record[0] == SupportedQueryType.A
+                    else socket.AF_INET6
+                )
+                dst_addr: tuple[str, int] | tuple[str, int, int, int] = (
+                    (
+                        record[-1],
+                        port,
+                    )
+                    if inet_type == socket.AF_INET
+                    else (
+                        record[-1],
+                        port,
+                        0,
+                        0,
+                    )
+                )
+
+                results.append(
+                    (
+                        inet_type,
+                        type,
+                        6 if type == socket.SOCK_STREAM else 17,
+                        "",
+                        dst_addr,
+                    )
+                )
+
+        quic_results = []
+
+        if remote_preemptive_quic_rr:
+            any_specified = False
+
+            for result in results:
+                if result[1] == socket.SOCK_STREAM:
+                    quic_results.append(
+                        (result[0], socket.SOCK_DGRAM, 17, "", result[4])
+                    )
+                else:
+                    any_specified = True
+                    break
+
+            if any_specified:
+                quic_results = []
+
+        return sorted(quic_results + results, key=lambda _: _[0] + _[1], reverse=True)
+
+
+class CloudflareResolver(PlainResolver):
+    specifier = "cloudflare"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+
+        super().__init__("1.1.1.1", port, *patterns, **kwargs)
+
+
+class GoogleResolver(PlainResolver):
+    specifier = "google"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+
+        super().__init__("8.8.8.8", port, *patterns, **kwargs)
+
+
+class Quad9Resolver(PlainResolver):
+    specifier = "quad9"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+
+        super().__init__("9.9.9.9", port, *patterns, **kwargs)
+
+
+class AdGuardResolver(PlainResolver):
+    specifier = "adguard"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            port = kwargs["port"]
+            kwargs.pop("port")
+        else:
+            port = None
+
+        super().__init__("94.140.14.140", port, *patterns, **kwargs)

--- a/src/urllib3/contrib/resolver/factories.py
+++ b/src/urllib3/contrib/resolver/factories.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+import typing
+from abc import ABCMeta
+from base64 import b64encode
+from typing import Any
+from urllib.parse import parse_qs
+
+from ...util import parse_url
+from .protocols import BaseResolver, ProtocolResolver
+
+
+class ResolverFactory(metaclass=ABCMeta):
+    @staticmethod
+    def has(
+        protocol: ProtocolResolver,
+        specifier: str | None = None,
+        implementation: str | None = None,
+    ) -> bool:
+        package_name: str = __name__.split(".")[0]
+        module_expr = f".{protocol.value.replace('-', '_')}"
+
+        if implementation:
+            module_expr += f"._{implementation.replace('-', '_').lower()}"
+
+        try:
+            resolver_module = importlib.import_module(
+                module_expr, f"{package_name}.contrib.resolver"
+            )
+        except ImportError:
+            return False
+
+        implementations: list[tuple[str, type[BaseResolver]]] = inspect.getmembers(
+            resolver_module,
+            lambda e: isinstance(e, type)
+            and issubclass(e, BaseResolver)
+            and (
+                (specifier is None and e.specifier is None) or specifier == e.specifier
+            ),
+        )
+
+        if not implementations:
+            return False
+
+        return True
+
+    @staticmethod
+    def new(
+        protocol: ProtocolResolver,
+        specifier: str | None = None,
+        implementation: str | None = None,
+        **kwargs: Any,
+    ) -> BaseResolver:
+        package_name: str = __name__.split(".")[0]
+
+        module_expr = f".{protocol.value.replace('-', '_')}"
+
+        if implementation:
+            module_expr += f"._{implementation.replace('-', '_').lower()}"
+
+        spe_msg = " " if specifier is None else f' (w/ specifier "{specifier}") '
+
+        try:
+            resolver_module = importlib.import_module(
+                module_expr, f"{package_name}.contrib.resolver"
+            )
+        except ImportError as e:
+            raise NotImplementedError(
+                f"{protocol}{spe_msg}cannot be loaded. Tried to import '{module_expr}'. Did you specify a non-existent implementation?"
+            ) from e
+
+        implementations: list[tuple[str, type[BaseResolver]]] = inspect.getmembers(
+            resolver_module,
+            lambda e: isinstance(e, type)
+            and issubclass(e, BaseResolver)
+            and (
+                (specifier is None and e.specifier is None) or specifier == e.specifier
+            ),
+        )
+
+        if not implementations:
+            raise NotImplementedError(
+                f"{protocol}{spe_msg}cannot be loaded. "
+                "No compatible implementation available. "
+                "Make sure your implementation inherit from BaseResolver."
+            )
+
+        implementation_target: type[BaseResolver] = implementations.pop()[1]
+
+        return implementation_target(**kwargs)
+
+
+class ResolverDescription:
+    """Describe how a BaseResolver must be instantiated."""
+
+    def __init__(
+        self,
+        protocol: ProtocolResolver,
+        specifier: str | None = None,
+        implementation: str | None = None,
+        server: str | None = None,
+        port: int | None = None,
+        *host_patterns: str,
+        **kwargs: typing.Any,
+    ) -> None:
+        self.protocol = protocol
+        self.specifier = specifier
+        self.implementation = implementation
+        self.server = server
+        self.port = port
+        self.host_patterns = host_patterns
+        self.kwargs = kwargs
+
+    def __setitem__(self, key: str, value: typing.Any) -> None:
+        self.kwargs[key] = value
+
+    def __contains__(self, item: str) -> bool:
+        return item in self.kwargs
+
+    def new(self) -> BaseResolver:
+        kwargs = {**self.kwargs}
+
+        if self.server:
+            kwargs["server"] = self.server
+        if self.port:
+            kwargs["port"] = self.port
+        if self.host_patterns:
+            kwargs["patterns"] = self.host_patterns
+
+        return ResolverFactory.new(
+            self.protocol,
+            self.specifier,
+            self.implementation,
+            **kwargs,
+        )
+
+    @staticmethod
+    def from_url(url: str) -> ResolverDescription:
+        parsed_url = parse_url(url)
+
+        schema = parsed_url.scheme
+
+        if schema is None:
+            raise ValueError("Given DNS url is missing a protocol")
+
+        specifier = None
+        implementation = None
+
+        if "+" in schema:
+            schema, specifier = tuple(schema.lower().split("+", 1))
+
+        protocol = ProtocolResolver(schema)
+        kwargs: dict[str, typing.Any] = {}
+
+        if parsed_url.path:
+            kwargs["path"] = parsed_url.path
+
+        if parsed_url.auth:
+            kwargs["headers"] = dict()
+            if ":" in parsed_url.auth:
+                username, password = parsed_url.auth.split(":")
+
+                username = username.strip("'\"")
+                password = password.strip("'\"")
+
+                kwargs["headers"][
+                    "Authorization"
+                ] = f"Basic {b64encode(f'{username}:{password}'.encode()).decode()}"
+            else:
+                kwargs["headers"]["Authorization"] = f"Bearer {parsed_url.auth}"
+
+        if parsed_url.query:
+            parameters = parse_qs(parsed_url.query)
+
+            for parameter in parameters:
+                if not parameters[parameter]:
+                    continue
+
+                parameter_insensible = parameter.lower()
+
+                if (
+                    isinstance(parameters[parameter], list)
+                    and len(parameters[parameter]) > 1
+                ):
+                    if parameter == "implementation":
+                        raise ValueError("Only one implementation can be passed to URL")
+
+                    values = []
+
+                    for e in parameters[parameter]:
+                        if "," in e:
+                            values.extend(e.split(","))
+                        else:
+                            values.append(e)
+
+                    if parameter_insensible in kwargs:
+                        if isinstance(kwargs[parameter_insensible], list):
+                            kwargs[parameter_insensible].extend(values)
+                        else:
+                            values.append(kwargs[parameter_insensible])
+                            kwargs[parameter_insensible] = values
+                        continue
+
+                    kwargs[parameter_insensible] = values
+                    continue
+
+                value: str = parameters[parameter][0].lower().strip(" ")
+
+                if parameter == "implementation":
+                    implementation = value
+                    continue
+
+                if "," in value:
+                    list_of_values = value.split(",")
+
+                    if parameter_insensible in kwargs:
+                        if isinstance(kwargs[parameter_insensible], list):
+                            kwargs[parameter_insensible].extend(list_of_values)
+                        else:
+                            list_of_values.append(kwargs[parameter_insensible])
+                        continue
+
+                    kwargs[parameter_insensible] = list_of_values
+                    continue
+
+                value_converted: bool | int | float | None = None
+
+                if value in ["false", "true"]:
+                    value_converted = True if value == "true" else False
+                elif value.isdigit():
+                    value_converted = int(value)
+                elif (
+                    value.count(".") == 1
+                    and value.index(".") > 0
+                    and value.replace(".", "").isdigit()
+                ):
+                    value_converted = float(value)
+
+                kwargs[parameter_insensible] = (
+                    value if value_converted is None else value_converted
+                )
+
+        host_patterns = []
+
+        if "hosts" in kwargs:
+            host_patterns = (
+                kwargs["hosts"].split(",")
+                if isinstance(kwargs["hosts"], str)
+                else kwargs["hosts"]
+            )
+            del kwargs["hosts"]
+
+        return ResolverDescription(
+            protocol,
+            specifier,
+            implementation,
+            parsed_url.host,
+            parsed_url.port,
+            *host_patterns,
+            **kwargs,
+        )

--- a/src/urllib3/contrib/resolver/in_memory/__init__.py
+++ b/src/urllib3/contrib/resolver/in_memory/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from ._dict import InMemoryResolver
+
+__all__ = ("InMemoryResolver",)

--- a/src/urllib3/contrib/resolver/in_memory/_dict.py
+++ b/src/urllib3/contrib/resolver/in_memory/_dict.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import socket
+import typing
+
+from ....util.url import _IPV6_ADDRZ_RE
+from ..protocols import BaseResolver, ProtocolResolver
+from ..utils import is_ipv4, is_ipv6
+
+
+class InMemoryResolver(BaseResolver):
+    protocol = ProtocolResolver.MANUAL
+    implementation = "dict"
+
+    def __init__(self, maxsize: int = 65535, **kwargs: typing.Any):
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            kwargs.pop("port")
+        super().__init__(None, None, **kwargs)
+        self._maxsize = maxsize
+        self._hosts: dict[str, list[tuple[socket.AddressFamily, str]]] = {}
+
+        if self._host_patterns:
+            for record in self._host_patterns:
+                if ":" not in record:
+                    continue
+                hostname, addr = record.split(":", 1)
+                self.register(hostname, addr)
+            self._host_patterns = tuple([])
+
+    def close(self) -> None:
+        pass  # no-op
+
+    def is_available(self) -> bool:
+        return True
+
+    def have_constraints(self) -> bool:
+        return True
+
+    def support(self, hostname: str | bytes | None) -> bool | None:
+        if hostname is None:
+            hostname = "localhost"
+        if isinstance(hostname, bytes):
+            hostname = hostname.decode("ascii")
+        return hostname in self._hosts
+
+    def register(self, hostname: str, ipaddr: str) -> None:
+        with self._lock:
+            if hostname not in self._hosts:
+                self._hosts[hostname] = []
+            else:
+                for e in self._hosts[hostname]:
+                    t, addr = e
+                    if ipaddr == addr:
+                        return
+
+            if _IPV6_ADDRZ_RE.match(ipaddr):
+                self._hosts[hostname].append((socket.AF_INET6, ipaddr))
+                return
+
+            self._hosts[hostname].append((socket.AF_INET, ipaddr))
+
+            if len(self._hosts) > self._maxsize:
+                k = None
+                for k in self._hosts.keys():
+                    break
+                if k:
+                    self._hosts.pop(k)
+
+    def clear(self, hostname: str) -> None:
+        with self._lock:
+            if hostname in self._hosts:
+                del self._hosts[hostname]
+
+    def getaddrinfo(
+        self,
+        host: bytes | str | None,
+        port: str | int | None,
+        family: socket.AddressFamily,
+        type: socket.SocketKind,
+        proto: int = 0,
+        flags: int = 0,
+        *,
+        quic_upgrade_via_dns_rr: bool = False,
+    ) -> list[
+        tuple[
+            socket.AddressFamily,
+            socket.SocketKind,
+            int,
+            str,
+            tuple[str, int] | tuple[str, int, int, int],
+        ]
+    ]:
+        if host is None:
+            host = "localhost"
+
+        if port is None:
+            port = 0
+        if isinstance(port, str):
+            port = int(port)
+        if port < 0:
+            raise socket.gaierror("Servname not supported for ai_socktype")
+
+        if isinstance(host, bytes):
+            host = host.decode("ascii")
+
+        if is_ipv4(host):
+            return [
+                (
+                    socket.AF_INET,
+                    type,
+                    6,
+                    "",
+                    (
+                        host,
+                        port,
+                    ),
+                )
+            ]
+        elif is_ipv6(host):
+            return [
+                (
+                    socket.AF_INET6,
+                    type,
+                    17,
+                    "",
+                    (
+                        host,
+                        port,
+                        0,
+                        0,
+                    ),
+                )
+            ]
+
+        results: list[
+            tuple[
+                socket.AddressFamily,
+                socket.SocketKind,
+                int,
+                str,
+                tuple[str, int] | tuple[str, int, int, int],
+            ]
+        ] = []
+
+        with self._lock:
+            if host not in self._hosts:
+                raise socket.gaierror(f"no records found for hostname {host} in-memory")
+
+            for entry in self._hosts[host]:
+                addr_type, addr_target = entry
+
+                if family != socket.AF_UNSPEC:
+                    if family != addr_type:
+                        continue
+
+                results.append(
+                    (
+                        addr_type,
+                        type,
+                        6 if type == socket.SOCK_STREAM else 17,
+                        "",
+                        (addr_target, port)
+                        if addr_type == socket.AF_INET
+                        else (addr_target, port, 0, 0),
+                    )
+                )
+
+        if not results:
+            raise socket.gaierror(f"no records found for hostname {host} in-memory")
+
+        return results

--- a/src/urllib3/contrib/resolver/null/__init__.py
+++ b/src/urllib3/contrib/resolver/null/__init__.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import socket
+import typing
+
+from ..protocols import BaseResolver, ProtocolResolver
+from ..utils import is_ipv4, is_ipv6
+
+
+class NullResolver(BaseResolver):
+    protocol = ProtocolResolver.NULL
+    implementation = "dummy"
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any):
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            kwargs.pop("port")
+        super().__init__(None, None, *patterns, **kwargs)
+
+    def close(self) -> None:
+        pass  # no-op
+
+    def is_available(self) -> bool:
+        return True
+
+    def getaddrinfo(
+        self,
+        host: bytes | str | None,
+        port: str | int | None,
+        family: socket.AddressFamily,
+        type: socket.SocketKind,
+        proto: int = 0,
+        flags: int = 0,
+        *,
+        quic_upgrade_via_dns_rr: bool = False,
+    ) -> list[
+        tuple[
+            socket.AddressFamily,
+            socket.SocketKind,
+            int,
+            str,
+            tuple[str, int] | tuple[str, int, int, int],
+        ]
+    ]:
+        if host is None:
+            host = "localhost"
+
+        if port is None:
+            port = 0
+        if isinstance(port, str):
+            port = int(port)
+        if port < 0:
+            raise socket.gaierror("Servname not supported for ai_socktype")
+
+        if isinstance(host, bytes):
+            host = host.decode("ascii")
+
+        if is_ipv4(host):
+            return [
+                (
+                    socket.AF_INET,
+                    type,
+                    6,
+                    "",
+                    (
+                        host,
+                        port,
+                    ),
+                )
+            ]
+        elif is_ipv6(host):
+            return [
+                (
+                    socket.AF_INET6,
+                    type,
+                    17,
+                    "",
+                    (
+                        host,
+                        port,
+                        0,
+                        0,
+                    ),
+                )
+            ]
+
+        raise socket.gaierror(f"Tried to resolve '{host}' using the NullResolver")
+
+
+__all__ = ("NullResolver",)

--- a/src/urllib3/contrib/resolver/protocols.py
+++ b/src/urllib3/contrib/resolver/protocols.py
@@ -1,0 +1,576 @@
+from __future__ import annotations
+
+import socket
+import struct
+import threading
+import typing
+from abc import ABCMeta, abstractmethod
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from random import randint
+
+from ..._typing import _TYPE_SOCKET_OPTIONS, _TYPE_TIMEOUT_INTERNAL
+from ...exceptions import LocationParseError
+from ...util.connection import _set_socket_options, allowed_gai_family
+from ...util.ssl_match_hostname import CertificateError, match_hostname
+from ...util.timeout import _DEFAULT_TIMEOUT
+from .utils import inet4_ntoa, inet6_ntoa
+
+
+class ProtocolResolver(str, Enum):
+    """
+    At urllib3.future we aim to propose a wide range of DNS-protocols.
+    The most used techniques are available.
+    """
+
+    #: Ask the OS native DNS layer
+    SYSTEM = "system"
+    #: DNS over HTTPS
+    DOH = "doh"
+    #: DNS over QUIC
+    DOQ = "doq"
+    #: DNS over TLS
+    DOT = "dot"
+    #: DNS over UDP (insecure)
+    DOU = "dou"
+    #: Manual (e.g. hosts)
+    MANUAL = "in-memory"
+    #: Void (e.g. purposely disable resolution)
+    NULL = "null"
+    #: Custom (e.g. your own implementation, use this when it does not suit any of the protocols specified)
+    CUSTOM = "custom"
+
+
+class BaseResolver(metaclass=ABCMeta):
+    protocol: typing.ClassVar[ProtocolResolver]
+    specifier: typing.ClassVar[str | None] = None
+
+    implementation: typing.ClassVar[str]
+
+    def __init__(
+        self,
+        server: str | None,
+        port: int | None = None,
+        *patterns: str,
+        **kwargs: typing.Any,
+    ) -> None:
+        self._server = server
+        self._port = port
+        self._host_patterns: tuple[str, ...] = patterns
+        self._lock = threading.Lock()
+        self._kwargs = kwargs
+
+        if not self._host_patterns and "patterns" in kwargs:
+            self._host_patterns = kwargs["patterns"]
+
+    def recycle(self) -> BaseResolver:
+        if self.is_available():
+            raise RuntimeError("Attempting to recycle a Resolver that was not closed")
+
+        return self.__class__(
+            self._server, self._port, *self._host_patterns, **self._kwargs
+        )
+
+    @property
+    def server(self) -> str | None:
+        return self._server
+
+    @property
+    def port(self) -> int | None:
+        return self._port
+
+    def have_constraints(self) -> bool:
+        return bool(self._host_patterns)
+
+    def support(self, hostname: str | bytes | None) -> bool | None:
+        """
+        Determine if given hostname is especially resolvable by given resolver.
+        If this resolver does not have any constrained list of host, it returns None. Meaning
+        it support any hostname for resolution.
+        """
+        if not self._host_patterns:
+            return None
+        if hostname is None:
+            hostname = "localhost"
+        if isinstance(hostname, bytes):
+            hostname = hostname.decode("ascii")
+        try:
+            match_hostname(
+                {"subjectAltName": (tuple(("DNS", e) for e in self._host_patterns))},
+                hostname,
+            )
+        except CertificateError:
+            return False
+        return True
+
+    @abstractmethod
+    def close(self) -> None:
+        """Terminate the given resolver instance. This should render it unusable. Further inquiries should raise an exception."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Determine if Resolver can receive inquiries."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def getaddrinfo(
+        self,
+        host: bytes | str | None,
+        port: str | int | None,
+        family: socket.AddressFamily,
+        type: socket.SocketKind,
+        proto: int = 0,
+        flags: int = 0,
+        *,
+        quic_upgrade_via_dns_rr: bool = False,
+    ) -> list[
+        tuple[
+            socket.AddressFamily,
+            socket.SocketKind,
+            int,
+            str,
+            tuple[str, int] | tuple[str, int, int, int],
+        ]
+    ]:
+        """This method align itself on the standard library socket.getaddrinfo(). It must be implemented as-is on your Resolver."""
+        raise NotImplementedError
+
+    # This function is copied from socket.py in the Python 2.7 standard
+    # library test suite. Added to its signature is only `socket_options`.
+    # One additional modification is that we avoid binding to IPv6 servers
+    # discovered in DNS if the system doesn't have IPv6 functionality.
+    def create_connection(
+        self,
+        address: tuple[str, int],
+        timeout: _TYPE_TIMEOUT_INTERNAL = _DEFAULT_TIMEOUT,
+        source_address: tuple[str, int] | None = None,
+        socket_options: _TYPE_SOCKET_OPTIONS | None = None,
+        socket_kind: socket.SocketKind = socket.SOCK_STREAM,
+        *,
+        quic_upgrade_via_dns_rr: bool = False,
+        timing_hook: typing.Callable[[tuple[timedelta, timedelta, datetime]], None]
+        | None = None,
+        default_socket_family: socket.AddressFamily = socket.AF_UNSPEC,
+    ) -> socket.socket:
+        """Connect to *address* and return the socket object.
+
+        Convenience function.  Connect to *address* (a 2-tuple ``(host,
+        port)``) and return the socket object.  Passing the optional
+        *timeout* parameter will set the timeout on the socket instance
+        before attempting to connect.  If no *timeout* is supplied, the
+        global default timeout setting returned by :func:`socket.getdefaulttimeout`
+        is used.  If *source_address* is set it must be a tuple of (host, port)
+        for the socket to bind as a source address before making the connection.
+        An host of '' or port 0 tells the OS to use the default.
+        """
+
+        host, port = address
+        if host.startswith("["):
+            host = host.strip("[]")
+        err = None
+
+        # Using the value from allowed_gai_family() in the context of getaddrinfo lets
+        # us select whether to work with IPv4 DNS records, IPv6 records, or both.
+        # The original create_connection function always returns all records.
+        family = allowed_gai_family()
+
+        if family != socket.AF_UNSPEC:
+            default_socket_family = family
+
+        try:
+            host.encode("idna")
+        except UnicodeError:
+            raise LocationParseError(f"'{host}', label empty or too long") from None
+
+        dt_pre_resolve = datetime.now(tz=timezone.utc)
+        records = self.getaddrinfo(
+            host,
+            port,
+            default_socket_family,
+            socket_kind,
+            quic_upgrade_via_dns_rr=quic_upgrade_via_dns_rr,
+        )
+        delta_post_resolve = datetime.now(tz=timezone.utc) - dt_pre_resolve
+
+        dt_pre_established = datetime.now(tz=timezone.utc)
+        for res in records:
+            af, socktype, proto, canonname, sa = res
+            sock = None
+            try:
+                sock = socket.socket(af, socktype, proto)
+
+                # If provided, set socket level options before connecting.
+                _set_socket_options(sock, socket_options)
+
+                if timeout is not _DEFAULT_TIMEOUT:
+                    sock.settimeout(timeout)
+                if source_address:
+                    sock.bind(source_address)
+                sock.connect(sa)
+                # Break explicitly a reference cycle
+                err = None
+
+                delta_post_established = (
+                    datetime.now(tz=timezone.utc) - dt_pre_established
+                )
+
+                if timing_hook is not None:
+                    timing_hook(
+                        (
+                            delta_post_resolve,
+                            delta_post_established,
+                            datetime.now(tz=timezone.utc),
+                        )
+                    )
+
+                return sock
+            except OSError as _:
+                err = _
+                if sock is not None:
+                    sock.close()
+
+        if err is not None:
+            try:
+                raise err
+            finally:
+                # Break explicitly a reference cycle
+                err = None
+        else:
+            raise OSError("getaddrinfo returns an empty list")
+
+
+class ManyResolver(BaseResolver):
+    """
+    Special resolver that use many child resolver. Priorities
+    are based on given order (list of BaseResolver).
+    """
+
+    def __init__(self, *resolvers: BaseResolver) -> None:
+        super().__init__(None, None)
+
+        self._size = len(resolvers)
+
+        self._unconstrained: list[BaseResolver] = [
+            _ for _ in resolvers if not _.have_constraints()
+        ]
+        self._constrained: list[BaseResolver] = [
+            _ for _ in resolvers if _.have_constraints()
+        ]
+
+        self._concurrent: int = 0
+        self._terminated: bool = False
+
+    def recycle(self) -> BaseResolver:
+        resolvers = []
+
+        for resolver in self._unconstrained + self._constrained:
+            resolvers.append(resolver.recycle())
+
+        return ManyResolver(*resolvers)
+
+    def close(self) -> None:
+        for resolver in self._unconstrained + self._constrained:
+            resolver.close()
+
+        self._terminated = True
+
+    def is_available(self) -> bool:
+        return not self._terminated
+
+    def __resolvers(
+        self, constrained: bool = False
+    ) -> typing.Generator[BaseResolver, None, None]:
+        resolvers = self._unconstrained if not constrained else self._constrained
+
+        if not resolvers:
+            return
+
+        with self._lock:
+            self._concurrent += 1
+
+        try:
+            resolver_count = len(resolvers)
+            start_idx = (self._concurrent - 1) % resolver_count
+
+            for idx in range(start_idx, resolver_count):
+                if not resolvers[idx].is_available():
+                    with self._lock:
+                        resolvers[idx] = resolvers[idx].recycle()
+                yield resolvers[idx]
+
+            if start_idx > 0:
+                for idx in range(0, start_idx):
+                    if not resolvers[idx].is_available():
+                        with self._lock:
+                            resolvers[idx] = resolvers[idx].recycle()
+                    yield resolvers[idx]
+        finally:
+            with self._lock:
+                self._concurrent -= 1
+
+    def getaddrinfo(
+        self,
+        host: bytes | str | None,
+        port: str | int | None,
+        family: socket.AddressFamily,
+        type: socket.SocketKind,
+        proto: int = 0,
+        flags: int = 0,
+        *,
+        quic_upgrade_via_dns_rr: bool = False,
+    ) -> list[
+        tuple[
+            socket.AddressFamily,
+            socket.SocketKind,
+            int,
+            str,
+            tuple[str, int] | tuple[str, int, int, int],
+        ]
+    ]:
+        if isinstance(host, bytes):
+            host = host.decode("ascii")
+        if host is None:
+            host = "localhost"
+
+        tested_resolvers = []
+
+        any_constrained_tried: bool = False
+
+        for resolver in self.__resolvers(True):
+            can_resolve = resolver.support(host)
+
+            if can_resolve is True:
+                any_constrained_tried = True
+
+                try:
+                    results = resolver.getaddrinfo(
+                        host,
+                        port,
+                        family,
+                        type,
+                        proto,
+                        flags,
+                        quic_upgrade_via_dns_rr=quic_upgrade_via_dns_rr,
+                    )
+
+                    if results:
+                        return results
+                except socket.gaierror as exc:
+                    if isinstance(exc.args[0], str) and (
+                        "DNSSEC" in exc.args[0] or "DNSKEY" in exc.args[0]
+                    ):
+                        raise
+                    continue
+            elif can_resolve is False:
+                tested_resolvers.append(resolver)
+
+        if any_constrained_tried:
+            raise socket.gaierror(
+                f"Name or service not known: {host} using {self._size - len(self._unconstrained)} resolver(s)"
+            )
+
+        for resolver in self.__resolvers():
+            try:
+                results = resolver.getaddrinfo(
+                    host,
+                    port,
+                    family,
+                    type,
+                    proto,
+                    flags,
+                    quic_upgrade_via_dns_rr=quic_upgrade_via_dns_rr,
+                )
+
+                if results:
+                    return results
+            except socket.gaierror as exc:
+                if isinstance(exc.args[0], str) and (
+                    "DNSSEC" in exc.args[0] or "DNSKEY" in exc.args[0]
+                ):
+                    raise
+                continue
+
+        raise socket.gaierror(
+            f"Name or service not known: {host} using {self._size - len(self._constrained)} resolver(s)"
+        )
+
+
+class SupportedQueryType(int, Enum):
+    """
+    urllib3.future does not need anything else so far. let's be pragmatic.
+    Each type is associated with its hex value as per the RFC.
+    """
+
+    A = 0x0001
+    AAAA = 0x001C
+    HTTPS = 0x0041
+
+
+class DomainNameServerQuery:
+    """
+    Minimalist DNS query/message to ask for A, AAAA and HTTPS records.
+    Only meant for urllib3.future use. Does not cover all of possible extent of use.
+    """
+
+    def __init__(
+        self, host: str, query_type: SupportedQueryType, override_id: int | None = None
+    ) -> None:
+        self._id = struct.pack(
+            "!H", randint(0x0000, 0xFFFF) if override_id is None else override_id
+        )
+        self._host = host
+        self._query = query_type
+        self._flags = struct.pack("!H", 0x0100)
+        self._qd_count = struct.pack("!H", 1)
+
+        self._cached: bytes | None = None
+
+    @property
+    def id(self) -> int:
+        return struct.unpack("!H", self._id)[0]  # type: ignore[no-any-return]
+
+    @property
+    def raw_id(self) -> bytes:
+        return self._id
+
+    def __repr__(self) -> str:
+        return f"<Query '{self._host}' IN {self._query.name}>"
+
+    def __bytes__(self) -> bytes:
+        if self._cached:
+            return self._cached
+
+        payload = b""
+
+        payload += self._id
+        payload += self._flags
+        payload += self._qd_count
+        payload += b"\x00\x00"
+        payload += b"\x00\x00"
+        payload += b"\x00\x00"
+
+        for ext in self._host.split("."):
+            payload += struct.pack("!B", len(ext))
+            payload += ext.encode("ascii")
+
+        payload += b"\x00"
+        payload += struct.pack("!H", self._query.value)
+        payload += struct.pack("!H", 0x0001)
+
+        self._cached = payload
+
+        return payload
+
+    @staticmethod
+    def bulk(host: str, *types: SupportedQueryType) -> list[DomainNameServerQuery]:
+        queries = []
+
+        for query_type in types:
+            queries.append(DomainNameServerQuery(host, query_type=query_type))
+
+        return queries
+
+
+#: Most common status code, not exhaustive at all.
+COMMON_RCODE_LABEL: dict[int, str] = {
+    0: "No Error",
+    1: "Format Error",
+    2: "Server Failure",
+    3: "Non-Existent Domain",
+    5: "Query Refused",
+    9: "Not Authorized",
+}
+
+
+class DomainNameServerReturn:
+    """
+    Minimalist DNS response parser. Allow to quickly extract key-data out of it.
+    Meant for A, AAAA and HTTPS records. Basically only what we need.
+    """
+
+    def __init__(self, payload: bytes) -> None:
+        up = struct.unpack("!HHHHHH", payload[:12])
+
+        self._id = up[0]
+        self._flags = up[1]
+        self._qd_count = up[2]
+        self._an_count = up[3]
+
+        self._rcode = int(f"0x{hex(payload[3])[-1]}", 16)
+
+        self._hostname: str = ""
+
+        idx = 12
+
+        while True:
+            c = payload[idx]
+
+            if c == 0:
+                idx += 1
+                break
+
+            self._hostname += payload[idx + 1 : idx + 1 + c].decode("ascii") + "."
+
+            idx += c + 1
+
+        self._records: list[tuple[SupportedQueryType, int, str]] = []
+
+        if self._an_count:
+            idx += 4
+
+            while idx < len(payload):
+                up = struct.unpack("!HHHI", payload[idx : idx + 10])
+                entry_size = struct.unpack("!H", payload[idx + 10 : idx + 12])[0]
+
+                data = payload[idx + 12 : idx + 12 + entry_size]
+
+                if len(data) == 4:
+                    decoded_data = inet4_ntoa(data)
+                elif len(data) == 16:
+                    decoded_data = inet6_ntoa(data)
+                else:
+                    alpn = []
+                    if b"h2" in data:
+                        alpn.append("h2")
+                    if b"h3" in data:
+                        alpn.append("h3")
+                    decoded_data = f"alpn={','.join(alpn)}"
+
+                try:
+                    self._records.append(
+                        (SupportedQueryType(up[1]), up[-1], decoded_data)
+                    )
+                except ValueError:
+                    pass
+
+                idx += 12 + entry_size
+
+    @property
+    def id(self) -> int:
+        return self._id  # type: ignore[no-any-return]
+
+    @property
+    def hostname(self) -> str:
+        return self._hostname
+
+    @property
+    def records(self) -> list[tuple[SupportedQueryType, int, str]]:
+        return self._records
+
+    @property
+    def is_found(self) -> bool:
+        return bool(self._records)
+
+    @property
+    def rcode(self) -> int:
+        return self._rcode
+
+    @property
+    def is_ok(self) -> bool:
+        return self._rcode == 0
+
+    def __repr__(self) -> str:
+        if self.is_ok:
+            return f"<Records '{self.hostname}' {self._records}>"
+        return f"<DNS Error '{self.hostname}' with Status {self.rcode} ({COMMON_RCODE_LABEL[self.rcode] if self.rcode in COMMON_RCODE_LABEL else 'Unknown'})>"

--- a/src/urllib3/contrib/resolver/system/__init__.py
+++ b/src/urllib3/contrib/resolver/system/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from ._socket import SystemResolver
+
+__all__ = ("SystemResolver",)

--- a/src/urllib3/contrib/resolver/system/_socket.py
+++ b/src/urllib3/contrib/resolver/system/_socket.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import socket
+import typing
+
+from ..protocols import BaseResolver, ProtocolResolver
+
+
+class SystemResolver(BaseResolver):
+    implementation = "socket"
+    protocol = ProtocolResolver.SYSTEM
+
+    def __init__(self, *patterns: str, **kwargs: typing.Any):
+        if "server" in kwargs:
+            kwargs.pop("server")
+        if "port" in kwargs:
+            kwargs.pop("port")
+        super().__init__(None, None, *patterns, **kwargs)
+
+    def support(self, hostname: str | bytes | None) -> bool | None:
+        if hostname is None:
+            return True
+        if isinstance(hostname, bytes):
+            hostname = hostname.decode("ascii")
+        if hostname == "localhost":
+            return True
+        return super().support(hostname)
+
+    def close(self) -> None:
+        pass  # no-op!
+
+    def is_available(self) -> bool:
+        return True
+
+    def getaddrinfo(
+        self,
+        host: bytes | str | None,
+        port: str | int | None,
+        family: socket.AddressFamily,
+        type: socket.SocketKind,
+        proto: int = 0,
+        flags: int = 0,
+        *,
+        quic_upgrade_via_dns_rr: bool = False,
+    ) -> list[
+        tuple[
+            socket.AddressFamily,
+            socket.SocketKind,
+            int,
+            str,
+            tuple[str, int] | tuple[str, int, int, int],
+        ]
+    ]:
+        return socket.getaddrinfo(
+            host=host,
+            port=port,
+            family=family,
+            type=type,
+            proto=proto,
+            flags=flags,
+        )

--- a/src/urllib3/contrib/resolver/utils.py
+++ b/src/urllib3/contrib/resolver/utils.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import binascii
+import socket
+
+
+def inet4_ntoa(address: bytes) -> str:
+    """
+    Convert an IPv4 address from bytes to str.
+    """
+    if len(address) != 4:
+        raise ValueError(
+            f"IPv4 addresses are 4 bytes long, got {len(address)} byte(s) instead"
+        )
+
+    return "%u.%u.%u.%u" % (address[0], address[1], address[2], address[3])
+
+
+def inet6_ntoa(address: bytes) -> str:
+    """
+    Convert an IPv6 address from bytes to str.
+    """
+    if len(address) != 16:
+        raise ValueError(
+            f"IPv6 addresses are 16 bytes long, got {len(address)} byte(s) instead"
+        )
+
+    hex = binascii.hexlify(address)
+    chunks = []
+
+    i = 0
+    length = len(hex)
+
+    while i < length:
+        chunk = hex[i : i + 4].decode().lstrip("0") or "0"
+        chunks.append(chunk)
+        i += 4
+
+    # Compress the longest subsequence of 0-value chunks to ::
+    best_start = 0
+    best_len = 0
+    start = -1
+    last_was_zero = False
+
+    for i in range(8):
+        if chunks[i] != "0":
+            if last_was_zero:
+                end = i
+                current_len = end - start
+                if current_len > best_len:
+                    best_start = start
+                    best_len = current_len
+                last_was_zero = False
+        elif not last_was_zero:
+            start = i
+            last_was_zero = True
+    if last_was_zero:
+        end = 8
+        current_len = end - start
+        if current_len > best_len:
+            best_start = start
+            best_len = current_len
+    if best_len > 1:
+        if best_start == 0 and (best_len == 6 or best_len == 5 and chunks[5] == "ffff"):
+            # We have an embedded IPv4 address
+            if best_len == 6:
+                prefix = "::"
+            else:
+                prefix = "::ffff:"
+            thex = prefix + inet4_ntoa(address[12:])
+        else:
+            thex = (
+                ":".join(chunks[:best_start])
+                + "::"
+                + ":".join(chunks[best_start + best_len :])
+            )
+    else:
+        thex = ":".join(chunks)
+
+    return thex
+
+
+def packet_fragment(payload: bytes, *identifiers: bytes) -> tuple[bytes, ...]:
+    results = []
+
+    offset = 0
+
+    start_packet_idx = []
+    lead_identifier = None
+
+    for identifier in identifiers:
+        idx = payload[:12].find(identifier)
+
+        if idx == -1:
+            continue
+
+        if idx != 0:
+            offset = idx
+
+        start_packet_idx.append(idx - offset)
+
+        lead_identifier = identifier
+        break
+
+    for identifier in identifiers:
+        if identifier == lead_identifier:
+            continue
+
+        if offset == 0:
+            idx = payload.find(b"\x02" + identifier)
+        else:
+            idx = payload.find(identifier)
+
+        if idx == -1:
+            continue
+
+        start_packet_idx.append(idx - offset)
+
+    if not start_packet_idx:
+        raise ValueError(
+            "no identifiable dns message emerged from given payload. "
+            "this should not happen at all. networking issue?"
+        )
+
+    if len(start_packet_idx) == 1:
+        return (payload,)
+
+    start_packet_idx = sorted(start_packet_idx)
+
+    previous_idx = None
+
+    for idx in start_packet_idx:
+        if previous_idx is None:
+            previous_idx = idx
+            continue
+        results.append(payload[previous_idx:idx])
+        previous_idx = idx
+
+    results.append(payload[previous_idx:])
+
+    return tuple(results)
+
+
+def is_ipv4(addr: str) -> bool:
+    try:
+        socket.inet_aton(addr)
+        return True
+    except OSError:
+        return False
+
+
+def is_ipv6(addr: str) -> bool:
+    try:
+        socket.inet_pton(socket.AF_INET6, addr)
+        return True
+    except OSError:
+        return False
+
+
+def validate_length_of(hostname: str) -> None:
+    """RFC 1035 impose a limit on a domain name length. We verify it there."""
+    if len(hostname.strip(".")) > 253:
+        raise UnicodeError("hostname to resolve exceed 253 characters")
+    elif any([len(_) > 63 for _ in hostname.split(".")]):
+        raise UnicodeError("at least one label to resolve exceed 63 characters")
+
+
+__all__ = (
+    "inet4_ntoa",
+    "inet6_ntoa",
+    "packet_fragment",
+    "is_ipv4",
+    "is_ipv6",
+    "validate_length_of",
+)

--- a/src/urllib3/fields.py
+++ b/src/urllib3/fields.py
@@ -167,9 +167,9 @@ class RequestField:
 
         if isinstance(value, tuple):
             if len(value) == 3:
-                filename, data, content_type = value  # type: ignore[misc]
+                filename, data, content_type = value
             else:
-                filename, data = value  # type: ignore[misc]
+                filename, data = value
                 content_type = guess_content_type(filename)
         else:
             filename = None

--- a/test/contrib/test_resolver.py
+++ b/test/contrib/test_resolver.py
@@ -1,0 +1,756 @@
+from __future__ import annotations
+
+import os
+import socket
+from concurrent.futures import ThreadPoolExecutor
+from socket import AddressFamily, SocketKind
+from test import requires_network
+
+import pytest
+
+from urllib3 import ConnectionInfo
+from urllib3.contrib.resolver import (
+    BaseResolver,
+    ManyResolver,
+    ProtocolResolver,
+    ResolverDescription,
+)
+from urllib3.contrib.resolver.doh import HTTPSResolver
+from urllib3.contrib.resolver.doq import QUICResolver
+from urllib3.contrib.resolver.dot import TLSResolver
+from urllib3.contrib.resolver.dou import PlainResolver
+from urllib3.contrib.resolver.in_memory import InMemoryResolver
+from urllib3.contrib.resolver.null import NullResolver
+from urllib3.contrib.resolver.system import SystemResolver
+
+
+@pytest.mark.parametrize(
+    "hostname, expect_error",
+    [
+        ("abc.com", True),
+        ("1.1.1.1", False),
+        ("8.8.8.com", True),
+        ("cloudflare.com", True),
+    ],
+)
+def test_null_resolver(hostname: str, expect_error: bool) -> None:
+    null_resolver = ResolverDescription(ProtocolResolver.NULL).new()
+
+    if expect_error:
+        with pytest.raises(socket.gaierror):
+            null_resolver.getaddrinfo(
+                hostname,
+                80,
+                socket.AF_UNSPEC,
+                socket.SOCK_STREAM,
+            )
+    else:
+        res = null_resolver.getaddrinfo(
+            hostname,
+            80,
+            socket.AF_UNSPEC,
+            socket.SOCK_STREAM,
+        )
+
+        assert len(res)
+
+
+@pytest.mark.parametrize(
+    "url, expected_resolver_class",
+    [
+        ("dou://1.1.1.1", PlainResolver),
+        ("dox://ooooo.com", None),
+        ("doh://dns.google/resolve", HTTPSResolver),
+        pytest.param(
+            "doq://dns.nextdns.io/?timeout=1",
+            QUICResolver,
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None,
+                reason="Github Action CI Unpredictable",
+                strict=False,
+            ),
+        ),
+        ("dns://dns.nextdns.io", None),
+        ("null://default", NullResolver),
+        ("default://null", None),
+        ("system://default", SystemResolver),
+        ("system://noop", SystemResolver),
+        ("in-memory://noop", InMemoryResolver),
+        ("in-memory://default", InMemoryResolver),
+        ("DoU://1.1.1.1", PlainResolver),
+        ("DOH+GOOGLE://default", HTTPSResolver),
+        ("doT://1.1.1.1", TLSResolver),
+        ("dot://1.1.1.1/?implementation=nonexistent", None),
+        ("system://", SystemResolver),
+        ("dot://", None),
+        pytest.param(
+            "doq://dns.nextdns.io/?implementation=qh3&timeout=1",
+            QUICResolver,
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None,
+                reason="Github Action CI Unpredictable",
+                strict=False,
+            ),
+        ),
+    ],
+)
+def test_url_resolver(
+    url: str, expected_resolver_class: type[BaseResolver] | None
+) -> None:
+    if expected_resolver_class is None:
+        with pytest.raises(
+            (
+                NotImplementedError,
+                ValueError,
+                TypeError,
+            )
+        ):
+            ResolverDescription.from_url(url).new()
+        return
+
+    resolver = ResolverDescription.from_url(url).new()
+
+    assert isinstance(resolver, expected_resolver_class)
+    resolver.close()
+
+
+@requires_network()
+@pytest.mark.parametrize(
+    "dns_url",
+    [
+        "dou://1.1.1.1",
+        "dou://one.one.one.one",
+        "dou://dns.google",
+        "doh://cloudflare-dns.com/dns-query",
+        "doh://dns.google",
+        "system://default",
+        "dot://dns.google",
+        "dot://one.one.one.one",
+        pytest.param(
+            "doq://dns.nextdns.io/?timeout=1",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None,
+                reason="Github Action CI Unpredictable",
+                strict=False,
+            ),
+        ),
+        "doh+google://",
+        "doh+cloudflare://default",
+    ],
+)
+def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
+    resolver = ResolverDescription.from_url(dns_url).new()
+
+    res = resolver.getaddrinfo(
+        "one.one.one.one",
+        443,
+        socket.AF_INET,
+        socket.SOCK_STREAM,
+        quic_upgrade_via_dns_rr=False,
+    )
+
+    assert any([_[-1][0] == "1.1.1.1" for _ in res])
+    resolver.close()
+
+
+@requires_network()
+@pytest.mark.parametrize(
+    "dns_url",
+    [
+        "dou://1.1.1.1",
+        "dou://one.one.one.one",
+        "dou://dns.google",
+        "doh://cloudflare-dns.com/dns-query",
+        "doh://dns.google",
+        "dot://dns.google",
+        "dot://one.one.one.one",
+        pytest.param(
+            "doq://dns.nextdns.io/?timeout=1",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None,
+                reason="Github Action CI Unpredictable",
+                strict=False,
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "hostname, expected_failure",
+    [
+        ("brokendnssec.net", True),
+        ("one.one.one.one", False),
+        ("google.com", False),
+    ],
+)
+def test_dnssec_exception(dns_url: str, hostname: str, expected_failure: bool) -> None:
+    resolver = ResolverDescription.from_url(dns_url).new()
+
+    if expected_failure:
+        with pytest.raises(socket.gaierror, match="DNSSEC|DNSKEY"):
+            resolver.getaddrinfo(
+                hostname,
+                443,
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                quic_upgrade_via_dns_rr=False,
+            )
+        resolver.close()
+        return
+
+    res = resolver.getaddrinfo(
+        hostname,
+        443,
+        socket.AF_INET,
+        socket.SOCK_STREAM,
+        quic_upgrade_via_dns_rr=False,
+    )
+
+    assert len(res)
+    resolver.close()
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    [
+        ("a" * 253) + ".com",
+        ("b" * 64) + "aa.fr",
+    ],
+)
+@pytest.mark.parametrize(
+    "dns_url",
+    [
+        "system://",
+        "dou://localhost",
+    ],
+)
+def test_hostname_too_long(dns_url: str, hostname: str) -> None:
+    resolver = ResolverDescription.from_url(dns_url).new()
+
+    with pytest.raises(
+        UnicodeError, match="exceed 63 characters|exceed 253 characters|too long"
+    ):
+        resolver.getaddrinfo(
+            hostname,
+            80,
+            socket.AF_UNSPEC,
+            socket.SOCK_STREAM,
+        )
+
+    resolver.close()
+
+
+def test_many_resolver_host_constraint_distribution() -> None:
+    resolvers = [
+        ResolverDescription.from_url("system://default?hosts=localhost").new(),
+        ResolverDescription.from_url("dou://127.0.0.1").new(),
+        ResolverDescription.from_url("in-memory://").new(),
+    ]
+
+    assert resolvers[0].have_constraints()
+    assert not resolvers[1].have_constraints()
+    assert resolvers[2].have_constraints()
+
+    imr = resolvers[-1]
+
+    imr.register("notlocalhost", "127.5.5.1")  # type: ignore[attr-defined]
+    imr.register("c.localhost.eu", "127.8.8.1")  # type: ignore[attr-defined]
+    imr.register("c.localhost.eu", "::1")  # type: ignore[attr-defined]
+
+    resolver = ManyResolver(*resolvers)
+
+    res = resolver.getaddrinfo(
+        "localhost",
+        80,
+        socket.AF_UNSPEC,
+        socket.SOCK_STREAM,
+    )
+
+    assert len(res)
+    assert any(_[-1][0] == "127.0.0.1" for _ in res)
+
+    res = resolver.getaddrinfo(
+        "notlocalhost",
+        80,
+        socket.AF_UNSPEC,
+        socket.SOCK_STREAM,
+    )
+
+    assert len(res) == 1
+    assert any(_[-1][0] == "127.5.5.1" for _ in res)
+
+    res = resolver.getaddrinfo(
+        "c.localhost.eu",
+        80,
+        socket.AF_UNSPEC,
+        socket.SOCK_STREAM,
+    )
+
+    assert len(res) == 2
+    assert any(_[-1][0] == "127.8.8.1" for _ in res)
+    assert any(_[-1][0] == "::1" for _ in res)
+
+    resolver.close()
+
+
+@requires_network()
+@pytest.mark.parametrize(
+    "dns_url",
+    [
+        "doh+google://",
+        "doh+cloudflare://",
+        pytest.param(
+            "doq://dns.nextdns.io/?timeout=1",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None,
+                reason="Github Action CI Unpredictable",
+                strict=False,
+            ),
+        ),
+        "dot://one.one.one.one",
+        "dou://one.one.one.one",
+    ],
+)
+def test_short_endurance_sprint(dns_url: str) -> None:
+    resolver = ResolverDescription.from_url(dns_url).new()
+
+    for host in [
+        "www.google.com",
+        "www.google.fr",
+        "www.cloudflare.com",
+        "youtube.com",
+    ]:
+        for addr_type in [socket.AF_UNSPEC, socket.AF_INET, socket.AF_INET6]:
+            res = resolver.getaddrinfo(
+                host,
+                443,
+                addr_type,
+                socket.SOCK_STREAM,
+            )
+
+            assert len(res)
+
+            if addr_type == socket.AF_UNSPEC:
+                assert any(_[0] == socket.AF_INET6 for _ in res)
+                assert any(_[0] == socket.AF_INET for _ in res)
+            elif addr_type == socket.AF_INET:
+                assert all(_[0] == socket.AF_INET for _ in res)
+            elif addr_type == socket.AF_INET6:
+                assert all(_[0] == socket.AF_INET6 for _ in res)
+
+    resolver.close()
+
+
+@requires_network()
+@pytest.mark.parametrize(
+    "dns_url",
+    [
+        "doh+google://default?rfc8484=true",
+        "doh+cloudflare://default?rfc8484=true",
+        "doh://dns.nextdns.io/dns-query?rfc8484=true",
+        "doh+adguard://",
+    ],
+)
+def test_doh_rfc8484(dns_url: str) -> None:
+    resolver = ResolverDescription.from_url(dns_url).new()
+
+    for host in [
+        "www.google.com",
+        "www.google.fr",
+        "www.cloudflare.com",
+        "youtube.com",
+    ]:
+        for addr_type in [socket.AF_UNSPEC, socket.AF_INET, socket.AF_INET6]:
+            res = resolver.getaddrinfo(
+                host,
+                443,
+                addr_type,
+                socket.SOCK_STREAM,
+            )
+
+            assert len(res)
+
+            if addr_type == socket.AF_UNSPEC:
+                assert any(_[0] == socket.AF_INET6 for _ in res)
+                assert any(_[0] == socket.AF_INET for _ in res)
+            elif addr_type == socket.AF_INET:
+                assert all(_[0] == socket.AF_INET for _ in res)
+            elif addr_type == socket.AF_INET6:
+                assert all(_[0] == socket.AF_INET6 for _ in res)
+
+    resolver.close()
+
+
+@requires_network()
+@pytest.mark.parametrize(
+    "dns_url",
+    [
+        "doh+google://",
+        "doh+cloudflare://",
+        pytest.param(
+            "doq://dns.nextdns.io/?timeout=1",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None,
+                reason="Github Action CI Unpredictable",
+                strict=False,
+            ),
+        ),
+        "dot://one.one.one.one",
+        "dou://one.one.one.one",
+    ],
+)
+def test_thread_safe_resolver(dns_url: str) -> None:
+    resolver = ResolverDescription.from_url(dns_url).new()
+
+    def _run(
+        target_name: str,
+    ) -> list[
+        tuple[
+            AddressFamily,
+            SocketKind,
+            int,
+            str,
+            tuple[str, int] | tuple[str, int, int, int],
+        ]
+    ]:
+        return resolver.getaddrinfo(
+            target_name,
+            443,
+            socket.AF_UNSPEC,
+            socket.SOCK_STREAM,
+        )
+
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        f = []
+
+        for name in [
+            "www.google.com",
+            "www.cloudflare.com",
+            "youtube.com",
+            "github.com",
+            "api.github.com",
+        ]:
+            f.append(executor.submit(_run, name))
+
+        for ff, idx in zip(f, range(0, len(f))):
+            ff.result()
+
+    resolver.close()
+
+
+@requires_network()
+def test_many_resolver_thread_safe() -> None:
+    resolvers = [
+        ResolverDescription.from_url("doh+google://").new(),
+        ResolverDescription.from_url("doh+cloudflare://").new(),
+        ResolverDescription.from_url("doh+adguard://").new(),
+        ResolverDescription.from_url("dot+google://").new(),
+        ResolverDescription.from_url("doh+google://").new(),
+    ]
+
+    resolver = ManyResolver(*resolvers)
+
+    def _run(
+        target_name: str,
+    ) -> list[
+        tuple[
+            AddressFamily,
+            SocketKind,
+            int,
+            str,
+            tuple[str, int] | tuple[str, int, int, int],
+        ]
+    ]:
+        return resolver.getaddrinfo(
+            target_name,
+            443,
+            socket.AF_UNSPEC,
+            socket.SOCK_STREAM,
+        )
+
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        f = []
+
+        for name in [
+            "www.google.com",
+            "www.cloudflare.com",
+            "youtube.com",
+            "github.com",
+            "api.github.com",
+            "gist.github.com",
+        ]:
+            f.append(executor.submit(_run, name))
+
+        for ff, idx in zip(f, range(0, len(f))):
+            ff.result()
+
+    resolver.close()
+
+
+@requires_network()
+@pytest.mark.parametrize(
+    "dns_url",
+    [
+        "doh+google://",
+        "doh+cloudflare://",
+        pytest.param(
+            "doq://dns.nextdns.io/?timeout=1",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None,
+                reason="Github Action CI Unpredictable",
+                strict=False,
+            ),
+        ),
+        "dot://one.one.one.one",
+        "dou://one.one.one.one",
+    ],
+)
+def test_resolver_recycle(dns_url: str) -> None:
+    resolver = ResolverDescription.from_url(dns_url).new()
+
+    resolver.close()
+
+    old_resolver, resolver = resolver, resolver.recycle()
+
+    assert type(old_resolver) is type(resolver)
+
+    assert resolver.protocol == old_resolver.protocol
+    assert resolver.specifier == old_resolver.specifier
+    assert resolver.implementation == old_resolver.implementation
+
+    assert resolver.is_available()
+    assert not old_resolver.is_available()
+
+    resolver.close()
+
+    assert not resolver.is_available()
+
+
+@requires_network()
+@pytest.mark.parametrize(
+    "dns_url",
+    [
+        "doh+google://",
+        "doh+cloudflare://",
+        pytest.param(
+            "doq://dns.nextdns.io/?timeout=1",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None,
+                reason="Github Action CI Unpredictable",
+                strict=False,
+            ),
+        ),
+        "dot://one.one.one.one",
+        "dou://one.one.one.one",
+    ],
+)
+def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
+    resolver = ResolverDescription.from_url(dns_url).new()
+
+    with pytest.raises(RuntimeError):
+        resolver.recycle()
+
+    resolver.close()
+
+
+@requires_network()
+@pytest.mark.parametrize(
+    "dns_url",
+    [
+        "doh+google://",
+        "doh+cloudflare://",
+        pytest.param(
+            "doq://dns.nextdns.io/?timeout=1",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None,
+                reason="Github Action CI Unpredictable",
+                strict=False,
+            ),
+        ),
+        "dot://one.one.one.one",
+        "dou://one.one.one.one",
+    ],
+)
+def test_ipv6_always_preferred(dns_url: str) -> None:
+    """Our resolvers must place IPV6 address in the beginning of returned list."""
+    resolver = ResolverDescription.from_url(dns_url).new()
+
+    inet_classes = []
+
+    res = resolver.getaddrinfo(
+        "www.cloudflare.com",
+        443,
+        socket.AF_UNSPEC,
+        socket.SOCK_STREAM,
+    )
+
+    for r in res:
+        if r[0] not in inet_classes:
+            inet_classes.append(r[0])
+
+    assert inet_classes[0] == socket.AF_INET6
+    assert inet_classes[1] == socket.AF_INET
+
+    resolver.close()
+
+
+@requires_network()
+@pytest.mark.parametrize(
+    "dns_url",
+    [
+        "doh+google://",
+        "doh+cloudflare://",
+        pytest.param(
+            "doq://dns.nextdns.io/?timeout=1",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None,
+                reason="Github Action CI Unpredictable",
+                strict=False,
+            ),
+        ),
+        "dot://one.one.one.one",
+        "dou://one.one.one.one",
+    ],
+)
+def test_dgram_upgrade(dns_url: str) -> None:
+    """www.cloudflare.com records HTTPS exist, we know it. This verify that we are able to propose a DGRAM upgrade."""
+    resolver = ResolverDescription.from_url(dns_url).new()
+
+    sock_types = []
+
+    res = resolver.getaddrinfo(
+        "www.cloudflare.com",
+        443,
+        socket.AF_UNSPEC,
+        socket.SOCK_STREAM,
+        quic_upgrade_via_dns_rr=True,
+    )
+
+    for r in res:
+        if r[1] not in sock_types:
+            sock_types.append(r[1])
+
+    assert sock_types[0] == socket.SOCK_DGRAM
+    assert sock_types[1] == socket.SOCK_STREAM
+
+    resolver.close()
+
+
+@pytest.mark.parametrize(
+    "dns_url, hostname, expected_addr",
+    [
+        (
+            "in-memory://default/?hosts=abc.tld:1.1.1.1,def.tld:8.8.8.8",
+            "abc.tld",
+            "1.1.1.1",
+        ),
+        (
+            "in-memory://default/?hosts=abc.tld:1.1.1.1,def.tld:8.8.8.8",
+            "def.tld",
+            "8.8.8.8",
+        ),
+        (
+            "in-memory://default/?hosts=abc.tld:1.1.1.1,def.tld:8.8.8.8",
+            "defe.tld",
+            None,
+        ),
+        (
+            "in-memory://default/?hosts=abc.tld:1.1.1.1,def.tld:8.8.8.8&hosts=a.company.internal:1.1.1.8",
+            "a.company.internal",
+            "1.1.1.8",
+        ),
+        (
+            "in-memory://default/?hosts=abc.tld:1.1.1.1,def.tld:8.8.8.8&hosts=a.company.internal:1.1.1.8",
+            "def.tld",
+            "8.8.8.8",
+        ),
+        (
+            "in-memory://default",
+            "abc.tld",
+            None,
+        ),
+        (
+            "in-memory://default/?hosts=x",
+            "abc.tld",
+            None,
+        ),
+        (
+            "in-memory://default/?hosts=x",
+            "x",
+            None,
+        ),
+        (
+            "in-memory://default/?hosts=abc.tld:::1,def.tld:8.8.8.8",
+            "abc.tld",
+            "::1",
+        ),
+    ],
+)
+def test_in_memory_resolver(
+    dns_url: str, hostname: str, expected_addr: str | None
+) -> None:
+    resolver = ResolverDescription.from_url(dns_url).new()
+
+    assert resolver.have_constraints()
+
+    if expected_addr is None:
+        with pytest.raises(socket.gaierror):
+            resolver.getaddrinfo(
+                hostname,
+                80,
+                socket.AF_UNSPEC,
+                socket.SOCK_STREAM,
+            )
+        return
+
+    res = resolver.getaddrinfo(
+        hostname,
+        80,
+        socket.AF_UNSPEC,
+        socket.SOCK_STREAM,
+    )
+
+    assert any([_[-1][0] == expected_addr for _ in res])
+
+
+@requires_network()
+def test_doh_http11() -> None:
+    """Ensure we can do DoH over HTTP/1.1 even if... that's absolutely not recommended!"""
+    resolver = ResolverDescription.from_url(
+        "doh+google://default/?disabled_svn=h2,h3"
+    ).new()
+
+    res = resolver.getaddrinfo(
+        "www.cloudflare.com",
+        80,
+        socket.AF_UNSPEC,
+        socket.SOCK_STREAM,
+    )
+
+    assert len(res)
+
+
+@requires_network()
+def test_doh_on_connection_callback() -> None:
+    """Ensure we can inspect the resolver connection with a callback."""
+    resolver_description = ResolverDescription.from_url("doh+google://")
+
+    toggle_witness: bool = False
+
+    def callback(conn_info: ConnectionInfo) -> None:
+        nonlocal toggle_witness
+        if conn_info:
+            toggle_witness = True
+
+    resolver_description["on_post_connection"] = callback
+
+    resolver = resolver_description.new()
+
+    res = resolver.getaddrinfo(
+        "www.cloudflare.com",
+        80,
+        socket.AF_UNSPEC,
+        socket.SOCK_STREAM,
+    )
+
+    assert len(res)
+    assert toggle_witness

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -400,7 +400,7 @@ class TestPoolManager:
             "http://[a::b%25zone]",
         ],
     )
-    @patch("urllib3.util.connection.create_connection")
+    @patch("urllib3.contrib.resolver.BaseResolver.create_connection")
     def test_e2e_connect_to_ipv6_scoped(
         self, create_connection: MagicMock, url: str
     ) -> None:
@@ -418,7 +418,7 @@ class TestPoolManager:
         assert create_connection.call_args[0][0] == ("a::b%zone", 80)
 
     @patch("urllib3.connection.ssl_wrap_socket")
-    @patch("urllib3.util.connection.create_connection")
+    @patch("urllib3.contrib.resolver.BaseResolver.create_connection")
     def test_e2e_connect_to_ipv6_scoped_tls(
         self, create_connection: MagicMock, ssl_wrap_socket: MagicMock
     ) -> None:


### PR DESCRIPTION
2.4.900 (2023-12-30)
=================

- Added issuer certificate extraction from SSLSocket with native calls with Python 3.10+ in ``ConnectionInfo``.
- Added support for DNS over TLS, DNS over HTTPS, DNS over QUIC, DNS over UDP, and local hosts-like DNS. ``PoolManager``, and ``HTTPPoolManager`` constructor now expose an additional keyword argument, ``resolver=...``. You can assign to it one of the presented protocols. Also, you may chain a list of resolvers, each can be limited to a list of host-pattern or not. The default is the system DNS. Our thread-safety promise covers this new feature.

  You can now do the following: ``PoolManage(resolver="doh://dns.google")`` for example. Please take a look at the official documentation to learn about the full capabilities.
- Support for SOCKS proxies is now provided by `python-socks` instead of `PySocks` due to being largely unmaintained within a reasonable period. This change is made completely transparent.
- Added details in ``ConnectionInfo`` about detailed timings and other details. 
  ``established_latency`` is a _timedelta_ that represents the amount of time consumed to get an ESTABLISHED network link. 
  ``resolution_latency`` is a _timedelta_ that represents the amount of time consumed for the hostname resolution.      
  ``tls_handshake_latency`` is a _timedelta_ that represents the amount of time consumed for the TLS handshake. 
   ``request_sent_latency`` is a _timedelta_ that represents the amount of time consumed to encode and send the whole request through the socket.
- Fixed a rare thread safety issue when using at least one HTTP/3 multiplexed connection.
- Deprecated function ``util.connection.create_connection(..)`` in favor of newly added ``contrib.resolver`` that will host from now on that function within ``BaseResolver`` as a method. Users are encouraged to migrate as soon as possible.
- Support for preemptively negotiating HTTP/3 over QUIC based on RFC 9460 via an HTTPS DNS record.
- Added support for enforcing IPv6, and/or IPv4 using the keyword parameter ``socket_family`` that can be provided in
  ``PoolManager``, ``HTTP(S)ConnectionPool`` and ``HTTP(S)Connection``. The three accepted values are ``socket.AF_UNSPEC``
  ``socket.AF_INET``, and ``socket.AF_INET6``. Respectively, allow all, ipv4 only, and ipv6 only. Anything else will raise
  **ValueError**.
