### PR TITLE
:bug: Fix two minor issues with resolvers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.4.901 (2023-12-31)
+====================
+
+- Fixed an issue where a stateless resolver (e.g. nullresolver) could not be recycled.
+- Fixed an issue where one would attempt to close a resolver multiple times.
+
 2.4.900 (2023-12-30)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.4.900"
+__version__ = "2.4.901"

--- a/src/urllib3/contrib/resolver/dou/_socket.py
+++ b/src/urllib3/contrib/resolver/dou/_socket.py
@@ -65,9 +65,10 @@ class PlainResolver(BaseResolver):
         self._terminated: bool = False
 
     def close(self) -> None:
-        with self._lock:
-            self._socket.close()
-            self._terminated = True
+        if not self._terminated:
+            with self._lock:
+                self._socket.close()
+                self._terminated = True
 
     def is_available(self) -> bool:
         return not self._terminated

--- a/src/urllib3/contrib/resolver/in_memory/_dict.py
+++ b/src/urllib3/contrib/resolver/in_memory/_dict.py
@@ -29,6 +29,9 @@ class InMemoryResolver(BaseResolver):
                 self.register(hostname, addr)
             self._host_patterns = tuple([])
 
+    def recycle(self) -> BaseResolver:
+        return self
+
     def close(self) -> None:
         pass  # no-op
 

--- a/src/urllib3/contrib/resolver/null/__init__.py
+++ b/src/urllib3/contrib/resolver/null/__init__.py
@@ -18,6 +18,9 @@ class NullResolver(BaseResolver):
             kwargs.pop("port")
         super().__init__(None, None, *patterns, **kwargs)
 
+    def recycle(self) -> BaseResolver:
+        return self
+
     def close(self) -> None:
         pass  # no-op
 

--- a/src/urllib3/contrib/resolver/system/_socket.py
+++ b/src/urllib3/contrib/resolver/system/_socket.py
@@ -26,6 +26,9 @@ class SystemResolver(BaseResolver):
             return True
         return super().support(hostname)
 
+    def recycle(self) -> BaseResolver:
+        return self
+
     def close(self) -> None:
         pass  # no-op!
 

--- a/test/contrib/test_resolver.py
+++ b/test/contrib/test_resolver.py
@@ -754,3 +754,16 @@ def test_doh_on_connection_callback() -> None:
 
     assert len(res)
     assert toggle_witness
+
+
+@pytest.mark.parametrize("dns_url", ["system://", "in-memory://", "null://"])
+def test_not_closeable_recycle(dns_url: str) -> None:
+    r = ResolverDescription.from_url(dns_url).new()
+
+    r.close()
+
+    assert r.is_available()
+
+    rr = r.recycle()
+
+    assert rr == r


### PR DESCRIPTION
- Fixed an issue where a stateless resolver (e.g. nullresolver) could not be recycled.
- Fixed an issue where one would attempt to close a resolver multiple times.
