### PR TITLE
:bug: Fixed compatibility with older PyPy 3.7 interpreters when HTTP/3 (qh3) can be unavailable.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.4.902 (2024-01-01)
+====================
+
+- Fixed compatibility with older PyPy 3.7 interpreters when HTTP/3 (qh3) can be unavailable.
+- Fixed undesired DGRAM/QUIC preemptive upgrade using insecure protocol.
+
 2.4.901 (2023-12-31)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.4.901"
+__version__ = "2.4.902"

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -61,7 +61,7 @@ if typing.TYPE_CHECKING:
     from .._typing import _TYPE_SOCKET_OPTIONS
 
 _HAS_SYS_AUDIT = hasattr(sys, "audit")
-_HAS_QH3 = HTTPProtocolFactory.has(HTTP3Protocol)  # type: ignore[type-abstract]
+_HAS_HTTP3_SUPPORT = HTTPProtocolFactory.has(HTTP3Protocol)  # type: ignore[type-abstract]
 
 
 class HfaceBackend(BaseBackend):
@@ -80,6 +80,11 @@ class HfaceBackend(BaseBackend):
         disabled_svn: set[HttpVersion] | None = None,
         preemptive_quic_cache: QuicPreemptiveCacheType | None = None,
     ):
+        if not _HAS_HTTP3_SUPPORT:
+            if disabled_svn is None:
+                disabled_svn = set()
+            disabled_svn.add(HttpVersion.h3)
+
         super().__init__(
             host,
             port,
@@ -158,7 +163,7 @@ class HfaceBackend(BaseBackend):
         assert self.sock is not None
         assert self._svn is not None
 
-        if not _HAS_QH3:
+        if not _HAS_HTTP3_SUPPORT:
             return
 
         # do not upgrade if not coming from TLS already.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -214,7 +214,8 @@ class HTTPConnection(HfaceBackend):
                 source_address=self.source_address,
                 socket_options=self.socket_options,
                 socket_kind=self.socket_kind,
-                quic_upgrade_via_dns_rr=HttpVersion.h3 not in self._disabled_svn
+                quic_upgrade_via_dns_rr=self.scheme == "https"
+                and HttpVersion.h3 not in self._disabled_svn
                 and self.socket_kind != socket.SOCK_DGRAM,
                 timing_hook=lambda _: setattr(self, "_connect_timings", _),
                 default_socket_family=self._socket_family,


### PR DESCRIPTION
w/ Fixed undesired DGRAM/QUIC preemptive upgrade using insecure protocol.

