### PR TITLE
:bookmark: Release 2.4.906

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+2.4.906 (2024-01-19)
+====================
+
+- Fixed a rare case of HTTP/3 being disabled when forwarding a custom SSLContext created.
+- Re-introduce ``DEFAULT_CIPHERS`` constant in ``urllib3.util.ssl_`` due to the demands.
+  It contains the Mozilla recommended cipher suite that was introduced in version 2.2.900.
+- Fixed handling of OpenSSL 3.2.0 new error message for misconfiguring an HTTP proxy as HTTPS.
+  Ported from urllib3/3271.
+- Fixed ``request_sent_latency`` that wasn't computed when request was stopped early (prior to sending the
+  complete body).
+
 2.4.905 (2024-01-16)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.4.905"
+__version__ = "2.4.906"

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -1041,6 +1041,11 @@ class HfaceBackend(BaseBackend):
 
                     # this is a bad sign. we should stop sending and instead retrieve the response.
                     if self._protocol.has_pending_event(stream_id=self._stream_id):
+                        if self._start_last_request and self.conn_info:
+                            self.conn_info.request_sent_latency = (
+                                datetime.now(tz=timezone.utc) - self._start_last_request
+                            )
+
                         rp = ResponsePromise(self, self._stream_id, self.__headers)
                         self._promises[rp.uid] = rp
 

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -958,6 +958,7 @@ def _wrap_proxy_error(err: Exception, proxy_scheme: str | None) -> ProxyError:
     is_likely_http_proxy = (
         "wrong version number" in error_normalized
         or "unknown protocol" in error_normalized
+        or "record layer failure" in error_normalized
     )
     http_proxy_warning = (
         ". Your proxy appears to only use HTTP and not HTTPS, "

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -19,6 +19,7 @@ SSLContext = None
 SSLTransport = None
 HAS_NEVER_CHECK_COMMON_NAME = False
 ALPN_PROTOCOLS = ["http/1.1"]
+DEFAULT_CIPHERS = MOZ_INTERMEDIATE_CIPHERS
 
 _TYPE_VERSION_INFO = typing.Tuple[int, int, int, str, int]
 
@@ -545,11 +546,12 @@ def is_capable_for_quic(
     quic_disable: bool = False
 
     if ctx is not None:
-        if (
-            isinstance(ctx.maximum_version, ssl.TLSVersion)
-            and ctx.maximum_version <= ssl.TLSVersion.TLSv1_2
-        ):
-            quic_disable = True
+        if isinstance(ctx.maximum_version, ssl.TLSVersion):
+            if (
+                ctx.maximum_version != ssl.TLSVersion.MAXIMUM_SUPPORTED
+                and ctx.maximum_version <= ssl.TLSVersion.TLSv1_2
+            ):
+                quic_disable = True
         else:
             any_capable_cipher: bool = False
             for cipher_dict in ctx.get_ciphers():

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1315,7 +1315,8 @@ class TestSSL(SocketDummyServerTestCase):
         self._start_server(socket_handler)
         with HTTPSConnectionPool(self.host, self.port, ca_certs=DEFAULT_CA) as pool:
             with pytest.raises(
-                SSLError, match=r"(wrong version number|record overflow)"
+                SSLError,
+                match=r"(wrong version number|record overflow|record layer failure)",
             ):
                 pool.request("GET", "/", retries=False)
 


### PR DESCRIPTION
- Fixed a rare case of HTTP/3 being disabled when forwarding a custom SSLContext created.
- Re-introduce ``DEFAULT_CIPHERS`` constant in ``urllib3.util.ssl_`` due to the demands. It contains the Mozilla recommended cipher suite that was introduced in version 2.2.900.
- Fixed handling of OpenSSL 3.2.0 new error message for misconfiguring an HTTP proxy as HTTPS. Ported from urllib3/3271.
- Fixed ``request_sent_latency`` that wasn't computed when request was stopped early (prior to sending the complete body).
