### PR TITLE
Bugfix poolmanager map cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
             experimental: false
             nox-session: test-pypy
             traefik-server: true
-          - python-version: "pypy-3.9"
+          - python-version: "pypy-3.9-v7.3.13"  # urllib3#3308
             os: ubuntu-latest
             experimental: false
             nox-session: test-pypy

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.5.902 (2024-02-04)
+====================
+
+- Fixed missed cleanup of unused PoolKey stored in ``PoliceTraffic`` upon a full ``PoolManager``.
+
 2.5.901 (2024-02-02)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.5.901"
+__version__ = "2.5.902"

--- a/src/urllib3/util/traffic_police.py
+++ b/src/urllib3/util/traffic_police.py
@@ -104,7 +104,7 @@ class TrafficPolice(typing.Generic[T]):
         with self._map_lock:
             outdated_keys = []
             for key, val in self._map.items():
-                if id(val) == id(value):
+                if id(val) == obj_id:
                     outdated_keys.append(key)
 
             for key in outdated_keys:
@@ -179,7 +179,7 @@ class TrafficPolice(typing.Generic[T]):
                     break
 
             if eligible_obj_id is not None and eligible_conn_or_pool is not None:
-                eligible_conn_or_pool.close()
+                self._map_clear(eligible_conn_or_pool)
 
                 del self._registry[eligible_obj_id]
                 del self._states[eligible_obj_id]

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -11,7 +11,7 @@ from urllib3 import connection_from_url
 from urllib3._constant import DEFAULT_BLOCKSIZE
 from urllib3.connectionpool import HTTPSConnectionPool
 from urllib3.exceptions import LocationValueError
-from urllib3.poolmanager import PoolManager, key_fn_by_scheme
+from urllib3.poolmanager import PoolKey, PoolManager, key_fn_by_scheme
 from urllib3.util import retry, timeout
 from urllib3.util.url import Url
 
@@ -62,6 +62,20 @@ class TestPoolManager:
             connections.add(conn)
 
         assert len(connections) == 5
+
+    def test_full_manager(self) -> None:
+        urls = [
+            "http://yahoo.com",
+            "http://bing.com",
+            "http://yahoo.co.jp/",
+        ]
+
+        p = PoolManager(2)
+
+        for url in urls:
+            p.connection_from_url(url)
+
+        assert len([e for e in p.pools._map if isinstance(e, PoolKey)]) == 2
 
     def test_manager_clear(self) -> None:
         p = PoolManager(5)


### PR DESCRIPTION
2.5.902 (2024-02-04)
====================

- Fixed missed cleanup of unused PoolKey stored in ``PoliceTraffic`` upon a full ``PoolManager``.

