### PR TITLE
:bug: Fix edge case where a simultaneous call to get_response() 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.5.903 (2024-02-20)
+====================
+
+- Fixed an edge case where a simultaneous call to ``get_response()`` without a specific promise could lead to a non-thread safe operation.
+
 2.5.902 (2024-02-04)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.5.902"
+__version__ = "2.5.903"


### PR DESCRIPTION
2.5.903 (2024-02-20)
====================

- Fixed an edge case where a simultaneous call to ``get_response()`` without a specific promise could lead to a non-thread safe operation.
