### PR TITLE
:wrench: Few async improvements (HTTP 3 / DGRAM Sock)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.6.901 (2024-02-28)
+====================
+
+- Fixed blocking IO just after HTTP/3 is negotiated in an asynchronous context.
+- Added explicit warning in case your pool of connections is insufficiently sized for the given charge in an asynchronous context.
+- Fixed automatic retrieval of the issuer certificate in an asynchronous context (``ConnectionInfo``).
+
 2.6.900 (2024-02-26)
 ====================
 

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -127,7 +127,7 @@ _blocking_errnos = {errno.EAGAIN, errno.EWOULDBLOCK}
 
 class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
     """
-    Thread-safe connection pool for one host.
+    Task-safe async connection pool for one host.
 
     :param host:
         Host used for this HTTP Connection (e.g. "localhost"), passed into
@@ -170,11 +170,11 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
 
     :param _proxy_headers:
         A dictionary with proxy headers, should not be used directly,
-        instead, see :class:`urllib3.ProxyManager`
+        instead, see :class:`urllib3.AsyncProxyManager`
 
     :param \\**conn_kw:
-        Additional parameters are used to create fresh :class:`urllib3.connection.HTTPConnection`,
-        :class:`urllib3.connection.HTTPSConnection` instances.
+        Additional parameters are used to create fresh :class:`urllib3._async.connection.AsyncHTTPConnection`,
+        :class:`urllib3._async.connection.AsyncHTTPSConnection` instances.
     """
 
     scheme = "http"

--- a/src/urllib3/_async/poolmanager.py
+++ b/src/urllib3/_async/poolmanager.py
@@ -54,7 +54,7 @@ pool_classes_by_scheme = {
 
 class AsyncPoolManager(AsyncRequestMethods):
     """
-    Allows for arbitrary requests while transparently keeping track of
+    Allows for arbitrary async requests while transparently keeping track of
     necessary connection pools for you.
 
     :param num_pools:
@@ -67,7 +67,7 @@ class AsyncPoolManager(AsyncRequestMethods):
 
     :param \\**connection_pool_kw:
         Additional parameters are used to create fresh
-        :class:`urllib3.connectionpool.ConnectionPool` instances.
+        :class:`urllib3._async.connectionpool.AsyncConnectionPool` instances.
 
     Example:
 
@@ -75,11 +75,11 @@ class AsyncPoolManager(AsyncRequestMethods):
 
         import urllib3
 
-        http = urllib3.PoolManager(num_pools=2)
+        http = urllib3.AsyncPoolManager(num_pools=2)
 
-        resp1 = http.request("GET", "https://google.com/")
-        resp2 = http.request("GET", "https://google.com/mail")
-        resp3 = http.request("GET", "https://yahoo.com/")
+        resp1 = await http.request("GET", "https://google.com/")
+        resp2 = await http.request("GET", "https://google.com/mail")
+        resp3 = await http.request("GET", "https://yahoo.com/")
 
         print(len(http.pools))
         # 2
@@ -194,7 +194,7 @@ class AsyncPoolManager(AsyncRequestMethods):
         request_context: dict[str, typing.Any] | None = None,
     ) -> AsyncHTTPConnectionPool:
         """
-        Create a new :class:`urllib3.connectionpool.ConnectionPool` based on host, port, scheme, and
+        Create a new :class:`urllib3._async.connectionpool.AsyncConnectionPool` based on host, port, scheme, and
         any additional pool keyword arguments.
 
         If ``request_context`` is provided, it is provided as keyword arguments
@@ -255,7 +255,7 @@ class AsyncPoolManager(AsyncRequestMethods):
         pool_kwargs: dict[str, typing.Any] | None = None,
     ) -> AsyncHTTPConnectionPool:
         """
-        Get a :class:`urllib3.connectionpool.ConnectionPool` based on the host, port, and scheme.
+        Get a :class:`urllib3._async.connectionpool.AsyncConnectionPool` based on the host, port, and scheme.
 
         If ``port`` isn't given, it will be derived from the ``scheme`` using
         ``urllib3.connectionpool.port_by_scheme``. If ``pool_kwargs`` is
@@ -280,7 +280,7 @@ class AsyncPoolManager(AsyncRequestMethods):
         self, request_context: dict[str, typing.Any]
     ) -> AsyncHTTPConnectionPool:
         """
-        Get a :class:`urllib3.connectionpool.ConnectionPool` based on the request context.
+        Get a :class:`urllib3._async.connectionpool.AsyncConnectionPool` based on the request context.
 
         ``request_context`` must at least contain the ``scheme`` key and its
         value must be a key in ``key_fn_by_scheme`` instance variable.
@@ -305,7 +305,7 @@ class AsyncPoolManager(AsyncRequestMethods):
         self, pool_key: PoolKey, request_context: dict[str, typing.Any]
     ) -> AsyncHTTPConnectionPool:
         """
-        Get a :class:`urllib3.connectionpool.ConnectionPool` based on the provided pool key.
+        Get a :class:`urllib3._async.connectionpool.AsyncConnectionPool` based on the provided pool key.
 
         ``pool_key`` should be a namedtuple that only contains immutable
         objects. At a minimum it must have the ``scheme``, ``host``, and
@@ -335,7 +335,7 @@ class AsyncPoolManager(AsyncRequestMethods):
         self, url: str, pool_kwargs: dict[str, typing.Any] | None = None
     ) -> AsyncHTTPConnectionPool:
         """
-        Similar to :func:`urllib3.connectionpool.connection_from_url`.
+        Similar to :func:`urllib3.async_connection_from_url`.
 
         If ``pool_kwargs`` is not provided and a new pool needs to be
         constructed, ``self.connection_pool_kw`` is used to initialize
@@ -576,12 +576,12 @@ class AsyncPoolManager(AsyncRequestMethods):
         self, method: str, url: str, redirect: bool = True, **kw: typing.Any
     ) -> AsyncHTTPResponse | ResponsePromise:
         """
-        Same as :meth:`urllib3.HTTPConnectionPool.urlopen`
+        Same as :meth:`urllib3.AsyncHTTPConnectionPool.urlopen`
         with custom cross-host redirect logic and only sends the request-uri
         portion of the ``url``.
 
         The given ``url`` parameter must be absolute, such that an appropriate
-        :class:`urllib3.connectionpool.ConnectionPool` can be chosen for it.
+        :class:`urllib3._async.connectionpool.AsyncConnectionPool` can be chosen for it.
         """
         u = parse_url(url)
 
@@ -711,16 +711,16 @@ class AsyncProxyManager(AsyncPoolManager):
 
         import urllib3
 
-        proxy = urllib3.ProxyManager("https://localhost:3128/")
+        proxy = urllib3.AsyncProxyManager("https://localhost:3128/")
 
-        resp1 = proxy.request("GET", "https://google.com/")
-        resp2 = proxy.request("GET", "https://httpbin.org/")
+        resp1 = await proxy.request("GET", "https://google.com/")
+        resp2 = await proxy.request("GET", "https://httpbin.org/")
 
         print(len(proxy.pools))
         # 1
 
-        resp3 = proxy.request("GET", "https://httpbin.org/")
-        resp4 = proxy.request("GET", "https://twitter.com/")
+        resp3 = await proxy.request("GET", "https://httpbin.org/")
+        resp4 = await proxy.request("GET", "https://twitter.com/")
 
         print(len(proxy.pools))
         # 3

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.6.900"
+__version__ = "2.6.901"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -335,38 +335,10 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                 cipher_tuple = self.sock.sslobj.cipher()
 
                 # Python 3.10+
-                if hasattr(self.sock.sslobj, "get_verified_chain"):
-                    chain = self.sock.sslobj.get_verified_chain()
-
-                    if (
-                        len(chain) > 1
-                        and Certificate is not None
-                        and isinstance(chain[1], Certificate)
-                        and hasattr(ssl, "PEM_cert_to_DER_cert")
-                    ):
-                        self.conn_info.issuer_certificate_der = (
-                            ssl.PEM_cert_to_DER_cert(chain[1].public_bytes())
-                        )
-                        self.conn_info.issuer_certificate_dict = chain[1].get_info()
-
-            elif hasattr(self.sock, "getpeercert"):
-                self.conn_info.certificate_der = self.sock.getpeercert(binary_form=True)
-                try:
-                    self.conn_info.certificate_dict = self.sock.getpeercert(
-                        binary_form=False
-                    )
-                except ValueError:
-                    # not supported on MacOS!
-                    self.conn_info.certificate_dict = None
-                cipher_tuple = (
-                    self.sock.cipher() if hasattr(self.sock, "cipher") else None
-                )
-
-                # Python 3.10+
-                if hasattr(self.sock, "_sslobj") and hasattr(
-                    self.sock._sslobj, "get_verified_chain"
+                if hasattr(self.sock.sslobj, "_sslobj") and hasattr(
+                    self.sock.sslobj._sslobj, "get_verified_chain"
                 ):
-                    chain = self.sock._sslobj.get_verified_chain()
+                    chain = self.sock.sslobj._sslobj.get_verified_chain()
 
                     if (
                         len(chain) > 1


### PR DESCRIPTION
2.6.901 (2024-02-28)
====================

- Fixed blocking IO just after HTTP/3 is negotiated in an asynchronous context.
- Added explicit warning in case your pool of connections is insufficiently sized for the given charge in an asynchronous context.
- Fixed automatic retrieval of the issuer certificate in an asynchronous context (``ConnectionInfo``).

