### PR TITLE
:zap: Various performance improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+2.6.902 (2024-03-04)
+====================
+
+- Fixed PyPy error when running asynchronous code on Windows after trying to create a datagram socket.
+  This error is due to an incomplete implementation of the Windows socket API. We silently disabled HTTP/3
+  if running PyPy+Windows+asyncio until upstream issue resolution.
+- Overall performance improvements for both async and sync calls.
+- Fixed ProtocolError (No recent network activity after XYZ) error when it should recycle the connection automatically (sync only).
+- Added a user-friendly error message when invoking ``get_response`` from either ``PoolManager`` or ``ConnectionPool`` with anything
+  else than a ``ResponsePromise``.
+
 2.6.901 (2024-02-28)
 ====================
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,4 +156,5 @@ nitpick_ignore = [
     ("py:class", "AsyncBaseResolver"),
     ("py:class", "AsyncTrafficPolice"),
     ("py:attr", "HTTPResponse.data"),
+    ("py:class", "_TYPE_PEER_CERT_RET_DICT"),
 ]

--- a/docs/reference/contrib/index.rst
+++ b/docs/reference/contrib/index.rst
@@ -1,10 +1,11 @@
-Third-Party Modules
-===================
+Extra Features
+==============
 
-These modules implement various extra features, that may not be ready for
-prime time or that require optional third-party dependencies.
+These modules implement various extra features, that aren't core feature per say
+or that require optional third-party dependencies.
 
 .. toctree::
 
    socks
    resolver
+   ssa

--- a/docs/reference/contrib/resolver.rst
+++ b/docs/reference/contrib/resolver.rst
@@ -5,3 +5,8 @@ DNS Resolver
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. automodule:: urllib3.contrib.resolver._async
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/reference/contrib/ssa.rst
+++ b/docs/reference/contrib/ssa.rst
@@ -1,0 +1,7 @@
+Simplified Async Socket
+=======================
+
+.. automodule:: urllib3.contrib.ssa
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/reference/urllib3.connectionpool.rst
+++ b/docs/reference/urllib3.connectionpool.rst
@@ -29,3 +29,5 @@ Connection Pools
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. autofunction:: urllib3.async_connection_from_url

--- a/docs/reference/urllib3.util.rst
+++ b/docs/reference/urllib3.util.rst
@@ -1,15 +1,11 @@
 Utilities
 =========
 
-Useful methods for working with :mod:`http.client`, completely decoupled from
-code specific to **urllib3**.
+Useful methods completely decoupled from code specific to **urllib3**.
 
-At the very core, just like its predecessors, urllib3 is built on top of
-:mod:`http.client` -- the lowest level HTTP library included in the Python
-standard library.
+.. warning:: **urllib3.future** does not depends on :mod:`http.client` whereas urllib3 does.
 
-To aid the limited functionality of the :mod:`http.client` module, urllib3
-provides various helper methods which are used with the higher level components
+urllib3.future provides various helper methods which are used with the higher level components
 but can also be used independently.
 
 .. automodule:: urllib3.util

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -827,18 +827,26 @@ async def _ssl_wrap_socket_and_match_hostname(
     that both proxies and targets have the same behavior when connecting via TLS.
     """
     default_ssl_context = False
+    sharable_ext_options: dict[str, int | str | None] = {
+        "ssl_version": resolve_ssl_version(ssl_version),
+        "ssl_minimum_version": ssl_minimum_version,
+        "ssl_maximum_version": ssl_maximum_version,
+        "cert_reqs": resolve_cert_reqs(cert_reqs),
+    }
+
     if ssl_context is None:
         default_ssl_context = True
-        context = create_urllib3_context(
-            ssl_version=resolve_ssl_version(ssl_version),
-            ssl_minimum_version=ssl_minimum_version,
-            ssl_maximum_version=ssl_maximum_version,
-            cert_reqs=resolve_cert_reqs(cert_reqs),
+        context = create_urllib3_context(**sharable_ext_options)  # type: ignore[arg-type]
+        sharable_ext_options.update(
+            {
+                "assert_fingerprint": assert_fingerprint,
+                "assert_hostname": assert_hostname,
+            }
         )
     else:
         context = ssl_context
 
-    context.verify_mode = resolve_cert_reqs(cert_reqs)
+    context.verify_mode = sharable_ext_options["cert_reqs"]  # type: ignore[assignment]
 
     # In some cases, we want to verify hostnames ourselves
     if (
@@ -888,6 +896,7 @@ async def _ssl_wrap_socket_and_match_hostname(
         alpn_protocols=alpn_protocols,
         certdata=cert_data,
         keydata=key_data,
+        sharable_ssl_context=sharable_ext_options if default_ssl_context else None,
     )
 
     try:

--- a/src/urllib3/_async/poolmanager.py
+++ b/src/urllib3/_async/poolmanager.py
@@ -392,6 +392,12 @@ class AsyncPoolManager(AsyncRequestMethods):
         This method should be called after issuing at least one request with ``multiplexed=True``.
         If none available, return None.
         """
+        if promise is not None and not isinstance(promise, ResponsePromise):
+            raise TypeError(
+                f"get_response only support ResponsePromise but received {type(promise)} instead. "
+                f"This may occur if you expected the remote peer to support multiplexing but did not."
+            )
+
         try:
             async with self.pools.borrow(
                 promise or ResponsePromise, block=False, not_idle_only=True

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.6.901"
+__version__ = "2.6.902"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -35,7 +35,7 @@ from ...contrib.hface.events import (
     HeadersReceived,
     StreamResetReceived,
 )
-from ...contrib.ssa import AsyncSocket, SSLAsyncSocket
+from ...contrib.ssa import AsyncSocket, SSLAsyncSocket, _has_complete_support_dgram
 from ...exceptions import (
     EarlyResponse,
     IncompleteRead,
@@ -57,6 +57,8 @@ from ._base import AsyncBaseBackend, AsyncLowLevelResponse
 if typing.TYPE_CHECKING:
     from ..._typing import _TYPE_SOCKET_OPTIONS
 
+_HAS_DGRAM_SUPPORT = _has_complete_support_dgram()
+
 
 class AsyncHfaceBackend(AsyncBaseBackend):
     supported_svn = [HttpVersion.h11, HttpVersion.h2, HttpVersion.h3]
@@ -74,7 +76,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         disabled_svn: set[HttpVersion] | None = None,
         preemptive_quic_cache: QuicPreemptiveCacheType | None = None,
     ):
-        if not _HAS_HTTP3_SUPPORT:
+        if not _HAS_HTTP3_SUPPORT or not _HAS_DGRAM_SUPPORT:
             if disabled_svn is None:
                 disabled_svn = set()
             disabled_svn.add(HttpVersion.h3)
@@ -731,11 +733,30 @@ class AsyncHfaceBackend(AsyncBaseBackend):
 
         encoded_header = header.encode("ascii") if isinstance(header, str) else header
 
+        # only h11 support chunked transfer encoding, we internally translate
+        # it to the right method for h2 and h3.
+        support_te_chunked: bool = self._svn == HttpVersion.h11
+
+        # We MUST never use that header in h2 and h3 over quic.
+        # It may(should) break the connection.
+        if not support_te_chunked and encoded_header == b"transfer-encoding":
+            return
+
         for value in values:
+            encoded_value = (
+                value.encode("iso-8859-1") if isinstance(value, str) else value
+            )
+
+            # Passing 'Connection' header is actually a protocol violation above h11.
+            # We assume it is passed as-is (meaning 'keep-alive' lower-cased)
+            if not support_te_chunked and encoded_header == b"connection":
+                if encoded_value.lower() == b"keep-alive":
+                    continue
+
             self.__headers.append(
                 (
                     encoded_header,
-                    value.encode("iso-8859-1") if isinstance(value, str) else value,
+                    encoded_value,
                 )
             )
 
@@ -757,54 +778,45 @@ class AsyncHfaceBackend(AsyncBaseBackend):
 
         # unless anything hint the opposite, the request head frame is the end stream
         should_end_stream: bool = expect_body_afterward is False
-        # only h11 support chunked transfer encoding, we internally translate
-        # it to the right method for h2 and h3.
-        support_te_chunked: bool = self._svn == HttpVersion.h11
+        authority_set_bit: bool = False
+        legacy_host_entry: bytes | None = None
 
         # determine if stream should end there (absent body case)
         for raw_header, raw_value in self.__headers:
             # Some programs does set value to None, and that is... an issue here. We ignore those key, value.
             if raw_value is None:
                 continue
-            header: str = raw_header.decode("ascii").lower().replace("_", "-")
-            value: str = raw_value.decode("iso-8859-1")
-            if header.startswith(":"):
+            if raw_header == b":authority":
+                authority_set_bit = True
                 continue
+            elif raw_header.startswith(b":"):
+                continue
+
+            header: str = raw_header.decode("ascii").lower().replace("_", "-")
+
             if header == "content-length":
-                if value.isdigit():
+                value: str = raw_value.decode("iso-8859-1")
+                try:
                     self.__expected_body_length = int(value)
-                break
+                except ValueError:
+                    raise ProtocolError(
+                        f"Invalid content-length set. Given '{value}' when only digits are allowed."
+                    )
+            elif legacy_host_entry is None and header == "host":
+                legacy_host_entry = raw_value
 
         # handle cases where 'Host' header is set manually
-        if any(k == b":authority" for k, v in self.__headers) is False:
-            for raw_header, raw_value in self.__headers:
-                header = raw_header.decode("ascii").lower().replace("_", "-")
+        if authority_set_bit is False and legacy_host_entry is not None:
+            self.__headers.append((b":authority", legacy_host_entry))
+            authority_set_bit = True
 
-                if header == "host":
-                    self.__headers.append((b":authority", raw_value))
-                    break
-        if any(k == b":authority" for k, v in self.__headers) is False:
+        if authority_set_bit is False:
             raise ProtocolError(
                 (
                     "urllib3.future do not support emitting HTTP requests without the `Host` header",
-                    "It was only permitted in HTTP/1.0 and prior. This implementation ship with HTTP/1.1+.",
+                    "It was only permitted in HTTP/1.0 and prior. This client support HTTP/1.1+.",
                 )
             )
-
-        if not support_te_chunked:
-            # We MUST never use that header in h2 and h3 over quic.
-            # It may(should) break the connection.
-            try:
-                self.__headers.remove((b"transfer-encoding", b"chunked"))
-            except ValueError:
-                pass
-
-            # Passing 'Connection' header is actually a protocol violation above h11.
-            # We assume it is passed as-is (meaning 'keep-alive' lower-cased)
-            try:
-                self.__headers.remove((b"connection", b"keep-alive"))
-            except ValueError:
-                pass
 
         try:
             self._protocol.submit_headers(
@@ -821,6 +833,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         except BrokenPipeError as e:
             rp = ResponsePromise(self, self._stream_id, self.__headers)
             self._promises[rp.uid] = rp
+            self._promises_per_stream[rp.stream_id] = rp
             e.promise = rp  # type: ignore[attr-defined]
 
             raise e
@@ -833,6 +846,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
 
             rp = ResponsePromise(self, self._stream_id, self.__headers)
             self._promises[rp.uid] = rp
+            self._promises_per_stream[rp.stream_id] = rp
             return rp
 
         return None
@@ -903,7 +917,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
 
                 # special headers that represent (usually) the HTTP response status, version and reason.
                 if header.startswith(":"):
-                    if header == ":status" and value.isdigit():
+                    if header == ":status":
                         status = int(value)
                         continue
                     # this should be unreachable.
@@ -915,14 +929,12 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                 headers.add(header, value)
 
         if promise is None:
-            for p in self._promises.values():
-                if p.stream_id == events[-1].stream_id:
-                    promise = p
-                    break
-            if promise is None:
+            if events[-1].stream_id not in self._promises_per_stream:
                 raise ProtocolError(
                     f"Response received (stream: {events[-1].stream_id}) but no promise in-flight"
                 )
+
+            promise = self._promises_per_stream[events[-1].stream_id]
 
         # this should be unreachable
         if status is None:
@@ -932,8 +944,15 @@ class AsyncHfaceBackend(AsyncBaseBackend):
 
         eot = events[-1].end_stream is True
 
+        http_verb = b""
+
+        for raw_header, raw_value in promise.request_headers:
+            if raw_header == b":method":
+                http_verb = raw_value
+                break
+
         response = AsyncLowLevelResponse(
-            dict(promise.request_headers)[b":method"].decode("ascii"),
+            http_verb.decode("ascii"),
             status,
             self._http_vsn,
             responses[status] if status in responses else "Unknown",
@@ -949,6 +968,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
 
         # we delivered a response, we can safely remove the promise from queue.
         del self._promises[promise.uid]
+        del self._promises_per_stream[promise.stream_id]
 
         # keep last response
         self._response = response
@@ -1014,6 +1034,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
 
                         rp = ResponsePromise(self, self._stream_id, self.__headers)
                         self._promises[rp.uid] = rp
+                        self._promises_per_stream[rp.stream_id] = rp
 
                         raise EarlyResponse(promise=rp)
 
@@ -1058,6 +1079,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
 
                 rp = ResponsePromise(self, self._stream_id, self.__headers)
                 self._promises[rp.uid] = rp
+                self._promises_per_stream[rp.stream_id] = rp
                 if remote_pipe_shutdown:
                     remote_pipe_shutdown.promise = rp  # type: ignore[attr-defined]
                     raise remote_pipe_shutdown
@@ -1094,6 +1116,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         self._protocol = None
         self._stream_id = None
         self._promises = {}
+        self._promises_per_stream = {}
         self._pending_responses = {}
         self.__custom_tls_settings = None
         self.conn_info = None

--- a/src/urllib3/backend/_base.py
+++ b/src/urllib3/backend/_base.py
@@ -313,6 +313,7 @@ class BaseBackend:
         self.conn_info: ConnectionInfo | None = None
 
         self._promises: dict[str, ResponsePromise] = {}
+        self._promises_per_stream: dict[int, ResponsePromise] = {}
         self._pending_responses: dict[
             int, LowLevelResponse | AsyncLowLevelResponse
         ] = {}

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -479,6 +479,12 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         if self.pool is None:
             raise ClosedPoolError(self, "Pool is closed")
 
+        if promise is not None and not isinstance(promise, ResponsePromise):
+            raise TypeError(
+                f"get_response only support ResponsePromise but received {type(promise)} instead. "
+                f"This may occur if you expected the remote peer to support multiplexing but did not."
+            )
+
         try:
             with self.pool.borrow(
                 promise or ResponsePromise,

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -111,7 +111,6 @@ class PoolKey(typing.NamedTuple):
     key_disabled_svn: set[HttpVersion] | None
     key_cert_data: str | bytes | None
     key_key_data: str | bytes | None
-    key_multiplexed: bool
 
 
 def _default_key_normalizer(
@@ -518,6 +517,12 @@ class PoolManager(RequestMethods):
         This method should be called after issuing at least one request with ``multiplexed=True``.
         If none available, return None.
         """
+        if promise is not None and not isinstance(promise, ResponsePromise):
+            raise TypeError(
+                f"get_response only support ResponsePromise but received {type(promise)} instead. "
+                f"This may occur if you expected the remote peer to support multiplexing but did not."
+            )
+
         try:
             with self.pools.borrow(
                 promise or ResponsePromise, block=False, not_idle_only=True

--- a/test/with_dummyserver/asynchronous/test_connectionpool.py
+++ b/test/with_dummyserver/asynchronous/test_connectionpool.py
@@ -28,7 +28,6 @@ from urllib3.exceptions import (
     MaxRetryError,
     NameResolutionError,
     NewConnectionError,
-    ReadTimeoutError,
     TimeoutError,
     UnrewindableBodyError,
 )

--- a/test/with_traefik/asynchronous/test_proxy.py
+++ b/test/with_traefik/asynchronous/test_proxy.py
@@ -4,6 +4,7 @@ import pytest
 
 from dummyserver.server import DEFAULT_CA
 from urllib3 import ConnectionInfo, HttpVersion, async_proxy_from_url
+from urllib3.util._async.ssl_ import _SSLContextCache
 
 from .. import TraefikWithProxyTestCase
 
@@ -30,6 +31,8 @@ class TestProxyToTraefik(TraefikWithProxyTestCase):
             with open(DEFAULT_CA, "wb") as fp:
                 fp.write(trustme_ca)
                 fp.write(trustme_traefik_ca)
+
+        _SSLContextCache.clear()
 
     @classmethod
     def teardown_class(cls) -> None:

--- a/test/with_traefik/test_proxy.py
+++ b/test/with_traefik/test_proxy.py
@@ -4,6 +4,7 @@ import pytest
 
 from dummyserver.server import DEFAULT_CA
 from urllib3 import ConnectionInfo, HttpVersion, proxy_from_url
+from urllib3.util.ssl_ import _SSLContextCache
 
 from . import TraefikWithProxyTestCase
 
@@ -29,6 +30,8 @@ class TestProxyToTraefik(TraefikWithProxyTestCase):
             with open(DEFAULT_CA, "wb") as fp:
                 fp.write(trustme_ca)
                 fp.write(trustme_traefik_ca)
+
+        _SSLContextCache.clear()
 
     @classmethod
     def teardown_class(cls) -> None:


### PR DESCRIPTION
2.6.902 (2024-03-04)
====================

- Fixed PyPy error when running asynchronous code on Windows after trying to create a datagram socket.
  This error is due to an incomplete implementation of the Windows socket API. We silently disabled HTTP/3
  if running PyPy+Windows+asyncio until upstream issue resolution.
- Overall performance improvements for both async and sync calls.
- Fixed ProtocolError (No recent network activity after XYZ) error when it should recycle the connection automatically (sync only).
- Added a user-friendly error message when invoking ``get_response`` from either ``PoolManager`` or ``ConnectionPool`` with anything
  else than a ``ResponsePromise``.
