### PR TITLE
🔖 Release 2.6.904

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.6.904 (2024-03-17)
+====================
+
+- Overall performance improvements for both async and sync calls.
+- Removed ``TrafficPolice`` internal caching for obj states of contained elements due to its inability to be up-to-date in some cases.
+- Fixed SSLError wrong message displayed when using the underlying ``qh3`` library (HTTP/3 only).
+- Fixed graceful shutdown for rare HTTP/2 servers configured to immediately forbid opening new streams.
+
 2.6.903 (2024-03-10)
 ====================
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,13 +1,13 @@
-coverage==7.0.4
-tornado==6.2
+coverage>=7.2.7,<=7.4
+tornado>=6.2,<=6.4
 python-socks==2.4.4
-pytest==7.2.0
-pytest-timeout==2.1.0
+pytest==7.4.4
+pytest-timeout==2.3.1
 trustme==0.9.0
 # We have to install at most cryptography 39.0.2 for PyPy<7.3.10
 # versions of Python 3.7, 3.8, and 3.9.
 cryptography==39.0.2;implementation_name=="pypy" and implementation_version<"7.3.10"
-cryptography==41.0.2;implementation_name!="pypy" or implementation_version>="7.3.10"
+cryptography==42.0.5;implementation_name!="pypy" or implementation_version>="7.3.10"
 backports.zoneinfo==0.2.1;python_version<"3.9"
 towncrier==21.9.0
-pytest-asyncio>=0.21.1,<=0.23.5
+pytest-asyncio>=0.21.1,<=0.23.5.post1

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -28,12 +28,8 @@ from ..util.util import to_str
 try:  # Compiled with SSL?
     import ssl
 
-    BaseSSLError = ssl.SSLError
 except (ImportError, AttributeError):
     ssl = None  # type: ignore[assignment]
-
-    class BaseSSLError(BaseException):  # type: ignore[no-redef]
-        pass
 
 
 from ..backend import HttpVersion, QuicPreemptiveCacheType, ResponsePromise
@@ -47,9 +43,13 @@ from ..connection import (
 )
 from ..contrib.resolver._async import AsyncBaseResolver, AsyncResolverDescription
 from ..contrib.ssa import AsyncSocket, SSLAsyncSocket
-from ..exceptions import ConnectTimeoutError, EarlyResponse
+from ..exceptions import BaseSSLError, ConnectTimeoutError, EarlyResponse  # noqa: F401
 from ..exceptions import HTTPError as HTTPException  # noqa
-from ..exceptions import NameResolutionError, NewConnectionError, ResponseNotReady
+from ..exceptions import (  # noqa: F401
+    NameResolutionError,
+    NewConnectionError,
+    ResponseNotReady,
+)
 from ..util import SKIP_HEADER, SKIPPABLE_HEADERS, ssl_
 from ..util._async.ssl_ import ssl_wrap_socket
 from ..util.request import body_to_chunks

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -23,6 +23,7 @@ from ..contrib.resolver._async import (
     AsyncResolverDescription,
 )
 from ..exceptions import (
+    BaseSSLError,
     ClosedPoolError,
     EmptyPoolError,
     FullPoolError,
@@ -54,7 +55,6 @@ from ..util.util import to_str
 from .connection import (
     AsyncHTTPConnection,
     AsyncHTTPSConnection,
-    BaseSSLError,
     BrokenPipeError,
     DummyConnection,
 )
@@ -530,36 +530,40 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
 
         # Retrieve request ctx
         method = typing.cast(str, from_promise.get_parameter("method"))
-        url = typing.cast(str, from_promise.get_parameter("url"))
-        body = typing.cast(
-            typing.Optional[_TYPE_BODY], from_promise.get_parameter("body")
-        )
-        headers = typing.cast(HTTPHeaderDict, from_promise.get_parameter("headers"))
-        retries = typing.cast(Retry, from_promise.get_parameter("retries"))
-        preload_content = typing.cast(
-            bool, from_promise.get_parameter("preload_content")
-        )
-        decode_content = typing.cast(bool, from_promise.get_parameter("decode_content"))
-        timeout = typing.cast(
-            typing.Optional[_TYPE_TIMEOUT], from_promise.get_parameter("timeout")
-        )
         redirect = typing.cast(bool, from_promise.get_parameter("redirect"))
-        assert_same_host = typing.cast(
-            bool, from_promise.get_parameter("assert_same_host")
-        )
-        pool_timeout = from_promise.get_parameter("pool_timeout")
-        response_kw = typing.cast(
-            typing.MutableMapping[str, typing.Any],
-            from_promise.get_parameter("response_kw"),
-        )
-        chunked = typing.cast(bool, from_promise.get_parameter("chunked"))
-        body_pos = typing.cast(
-            _TYPE_BODY_POSITION, from_promise.get_parameter("body_pos")
-        )
 
         # Handle redirect?
         redirect_location = redirect and response.get_redirect_location()
         if redirect_location:
+            url = typing.cast(str, from_promise.get_parameter("url"))
+            body = typing.cast(
+                typing.Optional[_TYPE_BODY], from_promise.get_parameter("body")
+            )
+            headers = typing.cast(HTTPHeaderDict, from_promise.get_parameter("headers"))
+            preload_content = typing.cast(
+                bool, from_promise.get_parameter("preload_content")
+            )
+            decode_content = typing.cast(
+                bool, from_promise.get_parameter("decode_content")
+            )
+            timeout = typing.cast(
+                typing.Optional[_TYPE_TIMEOUT], from_promise.get_parameter("timeout")
+            )
+
+            assert_same_host = typing.cast(
+                bool, from_promise.get_parameter("assert_same_host")
+            )
+            pool_timeout = from_promise.get_parameter("pool_timeout")
+            response_kw = typing.cast(
+                typing.MutableMapping[str, typing.Any],
+                from_promise.get_parameter("response_kw"),
+            )
+            chunked = typing.cast(bool, from_promise.get_parameter("chunked"))
+            body_pos = typing.cast(
+                _TYPE_BODY_POSITION, from_promise.get_parameter("body_pos")
+            )
+            retries = typing.cast(Retry, from_promise.get_parameter("retries"))
+
             if response.status == 303:
                 method = "GET"
                 body = None
@@ -602,7 +606,37 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
 
         # Check if we should retry the HTTP response.
         has_retry_after = bool(response.headers.get("Retry-After"))
+        retries = typing.cast(Retry, from_promise.get_parameter("retries"))
+
         if retries.is_retry(method, response.status, has_retry_after):
+            url = typing.cast(str, from_promise.get_parameter("url"))
+            body = typing.cast(
+                typing.Optional[_TYPE_BODY], from_promise.get_parameter("body")
+            )
+            headers = typing.cast(HTTPHeaderDict, from_promise.get_parameter("headers"))
+            preload_content = typing.cast(
+                bool, from_promise.get_parameter("preload_content")
+            )
+            decode_content = typing.cast(
+                bool, from_promise.get_parameter("decode_content")
+            )
+            timeout = typing.cast(
+                typing.Optional[_TYPE_TIMEOUT], from_promise.get_parameter("timeout")
+            )
+
+            assert_same_host = typing.cast(
+                bool, from_promise.get_parameter("assert_same_host")
+            )
+            pool_timeout = from_promise.get_parameter("pool_timeout")
+            response_kw = typing.cast(
+                typing.MutableMapping[str, typing.Any],
+                from_promise.get_parameter("response_kw"),
+            )
+            chunked = typing.cast(bool, from_promise.get_parameter("chunked"))
+            body_pos = typing.cast(
+                _TYPE_BODY_POSITION, from_promise.get_parameter("body_pos")
+            )
+
             try:
                 retries = retries.increment(method, url, response=response, _pool=self)
             except MaxRetryError:
@@ -1238,20 +1272,24 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
                 multiplexed = False
 
             if multiplexed:
-                response.set_parameter("method", method)
-                response.set_parameter("url", url)
-                response.set_parameter("body", body)
-                response.set_parameter("headers", headers)
-                response.set_parameter("retries", retries)
-                response.set_parameter("preload_content", preload_content)
-                response.set_parameter("decode_content", decode_content)
-                response.set_parameter("timeout", timeout_obj)
-                response.set_parameter("redirect", redirect)
-                response.set_parameter("response_kw", response_kw)
-                response.set_parameter("pool_timeout", pool_timeout)
-                response.set_parameter("assert_same_host", assert_same_host)
-                response.set_parameter("chunked", chunked)
-                response.set_parameter("body_pos", body_pos)
+                response.update_parameters(
+                    {
+                        "method": method,
+                        "url": url,
+                        "body": body,
+                        "headers": headers,
+                        "retries": retries,
+                        "preload_content": preload_content,
+                        "decode_content": decode_content,
+                        "timeout": timeout,
+                        "redirect": redirect,
+                        "response_kw": response_kw,
+                        "pool_timeout": pool_timeout,
+                        "assert_same_host": assert_same_host,
+                        "chunked": chunked,
+                        "body_pos": body_pos,
+                    }
+                )
                 release_this_conn = True if not conn.is_saturated else False
 
             # Everything went great!

--- a/src/urllib3/_async/poolmanager.py
+++ b/src/urllib3/_async/poolmanager.py
@@ -361,14 +361,14 @@ class AsyncPoolManager(AsyncRequestMethods):
         """
         base_pool_kwargs = self.connection_pool_kw.copy()
         if override:
-            for key, value in override.items():
-                if value is None:
-                    try:
-                        del base_pool_kwargs[key]
-                    except KeyError:
-                        pass
-                else:
-                    base_pool_kwargs[key] = value
+            base_pool_kwargs.update(
+                {k: v for k, v in override.items() if v is not None}
+            )
+            return {
+                k: v
+                for k, v in base_pool_kwargs.items()
+                if k not in override or override[k] is not None
+            }
         return base_pool_kwargs
 
     def _proxy_requires_url_absolute_form(self, parsed_url: Url) -> bool:
@@ -435,37 +435,41 @@ class AsyncPoolManager(AsyncRequestMethods):
 
         # Retrieve request ctx
         method = typing.cast(str, from_promise.get_parameter("method"))
-        url = typing.cast(str, from_promise.get_parameter("pm_url"))
-        body = typing.cast(
-            typing.Union[_TYPE_BODY, None], from_promise.get_parameter("body")
-        )
-        headers = typing.cast(
-            typing.Union[HTTPHeaderDict, None], from_promise.get_parameter("headers")
-        )
-        retries = typing.cast(Retry, from_promise.get_parameter("retries"))
-        preload_content = typing.cast(
-            bool, from_promise.get_parameter("preload_content")
-        )
-        decode_content = typing.cast(bool, from_promise.get_parameter("decode_content"))
-        timeout = typing.cast(
-            typing.Union[_TYPE_TIMEOUT, None], from_promise.get_parameter("timeout")
-        )
         redirect = typing.cast(bool, from_promise.get_parameter("pm_redirect"))
-        assert_same_host = typing.cast(
-            bool, from_promise.get_parameter("assert_same_host")
-        )
-        pool_timeout = from_promise.get_parameter("pool_timeout")
-        response_kw = typing.cast(
-            typing.MutableMapping[str, typing.Any],
-            from_promise.get_parameter("response_kw"),
-        )
-        chunked = typing.cast(bool, from_promise.get_parameter("chunked"))
-        body_pos = typing.cast(
-            _TYPE_BODY_POSITION, from_promise.get_parameter("body_pos")
-        )
 
         # Handle redirect?
         if redirect and response.get_redirect_location():
+            url = typing.cast(str, from_promise.get_parameter("pm_url"))
+            body = typing.cast(
+                typing.Union[_TYPE_BODY, None], from_promise.get_parameter("body")
+            )
+            headers = typing.cast(
+                typing.Union[HTTPHeaderDict, None],
+                from_promise.get_parameter("headers"),
+            )
+            preload_content = typing.cast(
+                bool, from_promise.get_parameter("preload_content")
+            )
+            decode_content = typing.cast(
+                bool, from_promise.get_parameter("decode_content")
+            )
+            timeout = typing.cast(
+                typing.Union[_TYPE_TIMEOUT, None], from_promise.get_parameter("timeout")
+            )
+            assert_same_host = typing.cast(
+                bool, from_promise.get_parameter("assert_same_host")
+            )
+            pool_timeout = from_promise.get_parameter("pool_timeout")
+            response_kw = typing.cast(
+                typing.MutableMapping[str, typing.Any],
+                from_promise.get_parameter("response_kw"),
+            )
+            chunked = typing.cast(bool, from_promise.get_parameter("chunked"))
+            body_pos = typing.cast(
+                _TYPE_BODY_POSITION, from_promise.get_parameter("body_pos")
+            )
+            retries = typing.cast(Retry, from_promise.get_parameter("retries"))
+
             redirect_location = response.get_redirect_location()
             assert isinstance(redirect_location, str)
 
@@ -514,7 +518,38 @@ class AsyncPoolManager(AsyncRequestMethods):
 
         # Check if we should retry the HTTP response.
         has_retry_after = bool(response.headers.get("Retry-After"))
+        retries = typing.cast(Retry, from_promise.get_parameter("retries"))
+
         if retries.is_retry(method, response.status, has_retry_after):
+            url = typing.cast(str, from_promise.get_parameter("pm_url"))
+            body = typing.cast(
+                typing.Union[_TYPE_BODY, None], from_promise.get_parameter("body")
+            )
+            headers = typing.cast(
+                typing.Union[HTTPHeaderDict, None],
+                from_promise.get_parameter("headers"),
+            )
+            preload_content = typing.cast(
+                bool, from_promise.get_parameter("preload_content")
+            )
+            decode_content = typing.cast(
+                bool, from_promise.get_parameter("decode_content")
+            )
+            timeout = typing.cast(
+                typing.Union[_TYPE_TIMEOUT, None], from_promise.get_parameter("timeout")
+            )
+            assert_same_host = typing.cast(
+                bool, from_promise.get_parameter("assert_same_host")
+            )
+            pool_timeout = from_promise.get_parameter("pool_timeout")
+            response_kw = typing.cast(
+                typing.MutableMapping[str, typing.Any],
+                from_promise.get_parameter("response_kw"),
+            )
+            chunked = typing.cast(bool, from_promise.get_parameter("chunked"))
+            body_pos = typing.cast(
+                _TYPE_BODY_POSITION, from_promise.get_parameter("body_pos")
+            )
             redirect_location = response.get_redirect_location()
             assert isinstance(redirect_location, str)
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.6.903"
+__version__ = "2.6.904"

--- a/src/urllib3/backend/_base.py
+++ b/src/urllib3/backend/_base.py
@@ -237,6 +237,9 @@ class ResponsePromise:
     def get_parameter(self, key: str) -> typing.Any | None:
         return self._parameters[key] if key in self._parameters else None
 
+    def update_parameters(self, data: dict[str, typing.Any]) -> None:
+        self._parameters.update(data)
+
 
 _HostPortType: typing.TypeAlias = typing.Tuple[str, int]
 QuicPreemptiveCacheType: typing.TypeAlias = typing.MutableMapping[

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -108,6 +108,8 @@ class HfaceBackend(BaseBackend):
         self.__headers: list[tuple[bytes, bytes]] = []
         self.__expected_body_length: int | None = None
         self.__remaining_body_length: int | None = None
+        self.__authority_bit_set: bool = False
+        self.__legacy_host_entry: bytes | None = None
 
         # h3 specifics
         self.__custom_tls_settings: QuicTLSConfig | None = None
@@ -168,7 +170,7 @@ class HfaceBackend(BaseBackend):
 
         # do not upgrade if not coming from TLS already.
         # we exclude SSLTransport, HTTP/3 is not supported in that condition anyway.
-        if type(self.sock) == socket.socket:
+        if type(self.sock) is socket.socket:
             return
 
         if self._svn == HttpVersion.h3:
@@ -443,6 +445,9 @@ class HfaceBackend(BaseBackend):
                 binary_form=True
             )
 
+            # save the quic ticket for session resumption
+            self.__session_ticket = self._protocol.session_ticket
+
         if hasattr(self, "_connect_timings"):
             self.conn_info.tls_handshake_latency = (
                 datetime.now(tz=timezone.utc) - self._connect_timings[-1]
@@ -548,11 +553,11 @@ class HfaceBackend(BaseBackend):
     ) -> list[Event]:
         """This method simplify socket exchange in/out based on what the protocol state machine orders.
         Can be used for the initial handshake for instance."""
-        assert self._protocol is not None
-        assert self.sock is not None
-        assert maximal_data_in_read is None or (
-            maximal_data_in_read >= 0 or maximal_data_in_read == -1
-        )
+        assert self.sock is not None and self._protocol is not None
+
+        if maximal_data_in_read is not None:
+            if not (maximal_data_in_read >= 0 or maximal_data_in_read == -1):
+                maximal_data_in_read = None
 
         data_out: bytes
         data_in: bytes
@@ -629,15 +634,10 @@ class HfaceBackend(BaseBackend):
 
                         self.sock.sendall(data_out)
 
-            for event in iter(
-                lambda: self._protocol.next_event(stream_id=stream_id), None  # type: ignore[union-attr]
-            ):  # type: Event
-                if stream_id is not None and hasattr(event, "stream_id"):
-                    if event.stream_id != stream_id:
-                        reshelve_events.append(event)
-                        continue
+            for event in self._protocol.events(stream_id=stream_id):  # type: Event
+                stream_related_event: bool = hasattr(event, "stream_id")
 
-                if isinstance(event, ConnectionTerminated):
+                if not stream_related_event and isinstance(event, ConnectionTerminated):
                     if (
                         event.error_code == 400
                         and event.message
@@ -648,9 +648,15 @@ class HfaceBackend(BaseBackend):
                     # We have to forward the error so that users aren't caught off guard when the connection
                     # unexpectedly close.
                     elif event.error_code == 298 and self._svn == HttpVersion.h3:
-                        raise SSLError(
-                            "TLS over QUIC did not succeed (Error 298). Chain certificate verification failed."
-                        )
+                        if event.message and "Fingerprint" in event.message:
+                            raise SSLError(
+                                f"TLS over QUIC did not succeed. {event.message}"
+                            )
+                        else:
+                            raise SSLError(
+                                "TLS over QUIC did not succeed. Chain certificate verification failed "
+                                "or client cert validation failed."
+                            )
 
                     # we shall convert the ProtocolError to IncompleteRead
                     # so that users aren't caught off guard.
@@ -678,19 +684,19 @@ class HfaceBackend(BaseBackend):
                         pass
 
                     raise ProtocolError(event.message)
-                elif isinstance(event, StreamResetReceived):
+                elif stream_related_event and isinstance(event, StreamResetReceived):
                     raise ProtocolError(
                         f"Stream {event.stream_id} was reset by remote peer. Reason: {hex(event.error_code)}."
                     )
-
-                if data_in_len_from:
-                    data_in_len += data_in_len_from(event)
 
                 if not event_type_collectable:
                     events.append(event)
                 else:
                     if isinstance(event, event_type_collectable):
                         events.append(event)
+
+                        if data_in_len_from is not None:
+                            data_in_len += data_in_len_from(event)
                     else:
                         reshelve_events.append(event)
 
@@ -705,9 +711,9 @@ class HfaceBackend(BaseBackend):
                     if (
                         target_cap_reached is False
                         and respect_end_stream_signal
-                        and hasattr(event, "end_stream")
+                        and stream_related_event
                     ):
-                        if event.end_stream is True:
+                        if event.end_stream is True:  # type: ignore[attr-defined]
                             if reshelve_events:
                                 self._protocol.reshelve(*reshelve_events)
                             return events
@@ -728,6 +734,8 @@ class HfaceBackend(BaseBackend):
         self.__headers = []
         self.__expected_body_length = None
         self.__remaining_body_length = None
+        self.__legacy_host_entry = None
+        self.__authority_bit_set = False
 
         self._start_last_request = datetime.now(tz=timezone.utc)
 
@@ -735,8 +743,6 @@ class HfaceBackend(BaseBackend):
             host, port = self._tunnel_host, self._tunnel_port
         else:
             host, port = self.host, self.port
-
-        authority: bytes = host.encode("idna")
 
         self.__headers = [
             (b":method", method.encode("ascii")),
@@ -748,6 +754,7 @@ class HfaceBackend(BaseBackend):
         ]
 
         if not skip_host:
+            authority: bytes = host.encode("idna")
             self.__headers.append(
                 (
                     b":authority",
@@ -756,9 +763,15 @@ class HfaceBackend(BaseBackend):
                     else authority + f":{port}".encode(),
                 ),
             )
+            self.__authority_bit_set = True
 
         if not skip_accept_encoding:
-            self.putheader("Accept-Encoding", "identity")
+            self.__headers.append(
+                (
+                    b"accept-encoding",
+                    b"identity",
+                )
+            )
 
     def putheader(self, header: str, *values: str) -> None:
         # note: requests allow passing headers as bytes (seen in requests/tests)
@@ -772,20 +785,29 @@ class HfaceBackend(BaseBackend):
         support_te_chunked: bool = self._svn == HttpVersion.h11
 
         # We MUST never use that header in h2 and h3 over quic.
+        # Passing 'Connection' header is actually a protocol violation above h11.
+        # We assume it is passed as-is (meaning 'keep-alive' lower-cased)
         # It may(should) break the connection.
-        if not support_te_chunked and encoded_header == b"transfer-encoding":
-            return
+        if not support_te_chunked:
+            if encoded_header in {b"transfer-encoding", b"connection"}:
+                return
+
+        if self.__expected_body_length is None and encoded_header == b"content-length":
+            try:
+                self.__expected_body_length = int(values[0])
+            except ValueError:
+                raise ProtocolError(
+                    f"Invalid content-length set. Given '{values[0]}' when only digits are allowed."
+                )
+        elif self.__legacy_host_entry is None and encoded_header == b"host":
+            self.__legacy_host_entry = (
+                values[0].encode("idna") if isinstance(values[0], str) else values[0]
+            )
 
         for value in values:
             encoded_value = (
                 value.encode("iso-8859-1") if isinstance(value, str) else value
             )
-
-            # Passing 'Connection' header is actually a protocol violation above h11.
-            # We assume it is passed as-is (meaning 'keep-alive' lower-cased)
-            if not support_te_chunked and encoded_header == b"connection":
-                if encoded_value.lower() == b"keep-alive":
-                    continue
 
             self.__headers.append(
                 (
@@ -804,58 +826,19 @@ class HfaceBackend(BaseBackend):
         if self.sock is None:
             self.connect()  # type: ignore[attr-defined]
 
-        assert self.sock is not None
-        assert self._protocol is not None
+        assert self.sock is not None and self._protocol is not None
 
         # only h2 and h3 support streams, it is faked/simulated for h1.
         self._stream_id = self._protocol.get_available_stream_id()
-
         # unless anything hint the opposite, the request head frame is the end stream
         should_end_stream: bool = expect_body_afterward is False
-        authority_set_bit: bool = False
-        legacy_host_entry: bytes | None = None
-
-        # determine if stream should end there (absent body case)
-        for raw_header, raw_value in self.__headers:
-            # Some programs does set value to None, and that is... an issue here. We ignore those key, value.
-            if raw_value is None:
-                continue
-            if raw_header.startswith(b":"):
-                if not authority_set_bit and raw_header[1:] == b"authority":
-                    authority_set_bit = True
-                continue
-
-            if (
-                expect_body_afterward
-                and self.__expected_body_length is None
-                and raw_header == b"content-length"
-            ):
-                try:
-                    self.__expected_body_length = int(raw_value)
-                except ValueError:
-                    raise ProtocolError(
-                        f"Invalid content-length set. Given '{raw_value.decode()}' when only digits are allowed."
-                    )
-
-            if (
-                not authority_set_bit
-                and legacy_host_entry is None
-                and raw_header == b"host"
-            ):
-                legacy_host_entry = raw_value
-
-            # evaluated cond verify if we still have something to find in headers.
-            if (authority_set_bit or legacy_host_entry is not None) and (
-                not expect_body_afterward or self.__expected_body_length is not None
-            ):
-                break
 
         # handle cases where 'Host' header is set manually
-        if authority_set_bit is False and legacy_host_entry is not None:
-            self.__headers.append((b":authority", legacy_host_entry))
-            authority_set_bit = True
+        if self.__authority_bit_set is False and self.__legacy_host_entry is not None:
+            self.__headers.append((b":authority", self.__legacy_host_entry))
+            self.__authority_bit_set = True
 
-        if authority_set_bit is False:
+        if self.__authority_bit_set is False:
             raise ProtocolError(
                 (
                     "urllib3.future do not support emitting HTTP requests without the `Host` header ",
@@ -901,7 +884,7 @@ class HfaceBackend(BaseBackend):
         return None
 
     def __read_st(
-        self, __amt: int | None = None, __stream_id: int | None = None
+        self, __amt: int | None, __stream_id: int | None
     ) -> tuple[bytes, bool]:
         """Allows us to defer the body loading after constructing the response object."""
         eot = False
@@ -910,30 +893,29 @@ class HfaceBackend(BaseBackend):
             DataReceived,
             receive_first=True,
             # we ignore Trailers even if provided in response.
-            event_type_collectable=(DataReceived, HeadersReceived),
+            event_type_collectable=(DataReceived,),
             maximal_data_in_read=__amt,
-            data_in_len_from=lambda x: len(x.data)
-            if isinstance(x, DataReceived)
-            else 0,
+            data_in_len_from=lambda x: len(x.data),  # type: ignore[attr-defined]
             stream_id=__stream_id,
         )
 
         if events and events[-1].end_stream:
             eot = True
 
-            if __stream_id in self._pending_responses:
-                del self._pending_responses[__stream_id]
+            try:
+                del self._pending_responses[__stream_id]  # type: ignore[arg-type]
+            except KeyError:
+                pass  # Hmm... this should be impossible.
 
-            if self.is_idle:
+            # remote can refuse future inquiries, so no need to go further with this conn.
+            if self._protocol.has_expired():  # type: ignore[union-attr]
+                self.close()
+            elif self.is_idle:
                 # probe for h3/quic if available, and remember it.
                 self._upgrade()
 
-            # remote can refuse future inquiries, so no need to go further with this conn.
-            if self._protocol and self._protocol.has_expired():
-                self.close()
-
         return (
-            b"".join(e.data for e in events if isinstance(e, DataReceived)),
+            b"".join(e.data for e in events) if len(events) > 1 else events[0].data,
             eot,
         )
 
@@ -941,46 +923,41 @@ class HfaceBackend(BaseBackend):
         self, *, promise: ResponsePromise | None = None
     ) -> LowLevelResponse:
         if (
-            self.sock is None
-            or self._protocol is None
-            or self._svn is None
-            or not self._promises
+            self.sock is None  # Didn't we establish a connection?
+            or self._protocol is None  # Did we initialize the state-machine protocol?
+            or not self._promises  # Do we have at least one ResponsePromise pending?
         ):
-            raise ResponseNotReady()  # Defensive: Comply with http.client, actually tested but not reported?
+            raise ResponseNotReady()  # Defensive: Comply with http.client behavior.
 
-        headers = HTTPHeaderDict()
-        status: int | None = None
-
-        events: list[HeadersReceived] = self.__exchange_until(  # type: ignore[assignment]
+        # Usually, will be a single event in array. We should be able to handle the case >1 too, but we actually don't.
+        head_event: HeadersReceived = self.__exchange_until(  # type: ignore[assignment]
             HeadersReceived,
             receive_first=True,
             event_type_collectable=(HeadersReceived,),
             respect_end_stream_signal=False,
             stream_id=promise.stream_id if promise else None,
-        )
+        ).pop()
 
-        for event in events:
-            for raw_header, raw_value in event.headers:
-                # special headers that represent (usually) the HTTP response status, version and reason.
-                if raw_header.startswith(b":"):
-                    if raw_header[1:] == b"status":
-                        status = int(raw_value)
-                        continue
-                    # this should be unreachable.
-                    # it is designed to detect eventual changes lower in the stack.
-                    raise ProtocolError(  # Defensive:
-                        f"Unhandled special header '{raw_header.decode()}'"
-                    )
+        headers = HTTPHeaderDict()
+        status: int | None = None
 
+        for raw_header, raw_value in head_event.headers:
+            # special headers that represent (usually) the HTTP response status, version and reason.
+            if raw_header.startswith(b":"):
+                if status is None and raw_header == b":status":
+                    status = int(raw_value)
+            else:
                 headers.add(raw_header.decode("ascii"), raw_value.decode("iso-8859-1"))
 
         if promise is None:
-            if events[-1].stream_id not in self._promises_per_stream:
+            try:
+                promise = self._promises_per_stream.pop(head_event.stream_id)
+            except KeyError as e:
                 raise ProtocolError(
-                    f"Response received (stream: {events[-1].stream_id}) but no promise in-flight"
-                )
-
-            promise = self._promises_per_stream[events[-1].stream_id]
+                    f"Response received (stream: {head_event.stream_id}) but no promise in-flight"
+                ) from e
+        else:
+            del self._promises_per_stream[promise.stream_id]
 
         # this should be unreachable
         if status is None:
@@ -988,8 +965,7 @@ class HfaceBackend(BaseBackend):
                 "Got an HTTP response without a status code. This is a violation."
             )
 
-        eot = events[-1].end_stream is True
-
+        eot = head_event.end_stream is True
         http_verb = b""
 
         for raw_header, raw_value in promise.request_headers:
@@ -997,11 +973,16 @@ class HfaceBackend(BaseBackend):
                 http_verb = raw_value
                 break
 
-        response = LowLevelResponse(
+        try:
+            reason: str = responses[status]
+        except KeyError:
+            reason = "Unknown"
+
+        self._response: LowLevelResponse = LowLevelResponse(
             http_verb.decode("ascii"),
             status,
             self._http_vsn,
-            responses[status] if status in responses else "Unknown",
+            reason,
             headers,
             self.__read_st if not eot else None,
             authority=self.host,
@@ -1009,31 +990,22 @@ class HfaceBackend(BaseBackend):
             stream_id=promise.stream_id,
         )
 
-        promise.response = response
-        response.from_promise = promise
+        promise.response = self._response
+        self._response.from_promise = promise
 
         # we delivered a response, we can safely remove the promise from queue.
         del self._promises[promise.uid]
-        del self._promises_per_stream[promise.stream_id]
-
-        # keep last response
-        self._response: LowLevelResponse = response
-
-        # save the quic ticket for session resumption
-        if self._svn == HttpVersion.h3 and hasattr(self._protocol, "session_ticket"):
-            self.__session_ticket = self._protocol.session_ticket
 
         if eot:
-            if self.is_idle:
-                self._upgrade()
-
             # remote can refuse future inquiries, so no need to go further with this conn.
-            if self._protocol and self._protocol.has_expired():
+            if self._protocol.has_expired():
                 self.close()
+            elif self.is_idle:
+                self._upgrade()
         else:
-            self._pending_responses[promise.stream_id] = response
+            self._pending_responses[promise.stream_id] = self._response
 
-        return response
+        return self._response
 
     def send(
         self,

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -15,7 +15,6 @@ from ._request_methods import RequestMethods
 from ._typing import _TYPE_BODY, _TYPE_BODY_POSITION, _TYPE_TIMEOUT, ProxyConfig
 from .backend import ConnectionInfo, ResponsePromise
 from .connection import (
-    BaseSSLError,
     BrokenPipeError,
     DummyConnection,
     HTTPConnection,
@@ -30,6 +29,7 @@ from .contrib.resolver import (
     ResolverDescription,
 )
 from .exceptions import (
+    BaseSSLError,
     ClosedPoolError,
     EmptyPoolError,
     FullPoolError,
@@ -524,36 +524,39 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         # Retrieve request ctx
         method = typing.cast(str, from_promise.get_parameter("method"))
-        url = typing.cast(str, from_promise.get_parameter("url"))
-        body = typing.cast(
-            typing.Optional[_TYPE_BODY], from_promise.get_parameter("body")
-        )
-        headers = typing.cast(HTTPHeaderDict, from_promise.get_parameter("headers"))
-        retries = typing.cast(Retry, from_promise.get_parameter("retries"))
-        preload_content = typing.cast(
-            bool, from_promise.get_parameter("preload_content")
-        )
-        decode_content = typing.cast(bool, from_promise.get_parameter("decode_content"))
-        timeout = typing.cast(
-            typing.Optional[_TYPE_TIMEOUT], from_promise.get_parameter("timeout")
-        )
         redirect = typing.cast(bool, from_promise.get_parameter("redirect"))
-        assert_same_host = typing.cast(
-            bool, from_promise.get_parameter("assert_same_host")
-        )
-        pool_timeout = from_promise.get_parameter("pool_timeout")
-        response_kw = typing.cast(
-            typing.MutableMapping[str, typing.Any],
-            from_promise.get_parameter("response_kw"),
-        )
-        chunked = typing.cast(bool, from_promise.get_parameter("chunked"))
-        body_pos = typing.cast(
-            _TYPE_BODY_POSITION, from_promise.get_parameter("body_pos")
-        )
 
         # Handle redirect?
         redirect_location = redirect and response.get_redirect_location()
         if redirect_location:
+            url = typing.cast(str, from_promise.get_parameter("url"))
+            body = typing.cast(
+                typing.Optional[_TYPE_BODY], from_promise.get_parameter("body")
+            )
+            headers = typing.cast(HTTPHeaderDict, from_promise.get_parameter("headers"))
+            preload_content = typing.cast(
+                bool, from_promise.get_parameter("preload_content")
+            )
+            decode_content = typing.cast(
+                bool, from_promise.get_parameter("decode_content")
+            )
+            timeout = typing.cast(
+                typing.Optional[_TYPE_TIMEOUT], from_promise.get_parameter("timeout")
+            )
+            assert_same_host = typing.cast(
+                bool, from_promise.get_parameter("assert_same_host")
+            )
+            pool_timeout = from_promise.get_parameter("pool_timeout")
+            response_kw = typing.cast(
+                typing.MutableMapping[str, typing.Any],
+                from_promise.get_parameter("response_kw"),
+            )
+            chunked = typing.cast(bool, from_promise.get_parameter("chunked"))
+            body_pos = typing.cast(
+                _TYPE_BODY_POSITION, from_promise.get_parameter("body_pos")
+            )
+            retries = typing.cast(Retry, from_promise.get_parameter("retries"))
+
             if response.status == 303:
                 method = "GET"
                 body = None
@@ -596,7 +599,36 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         # Check if we should retry the HTTP response.
         has_retry_after = bool(response.headers.get("Retry-After"))
+        retries = typing.cast(Retry, from_promise.get_parameter("retries"))
+
         if retries.is_retry(method, response.status, has_retry_after):
+            url = typing.cast(str, from_promise.get_parameter("url"))
+            body = typing.cast(
+                typing.Optional[_TYPE_BODY], from_promise.get_parameter("body")
+            )
+            headers = typing.cast(HTTPHeaderDict, from_promise.get_parameter("headers"))
+            preload_content = typing.cast(
+                bool, from_promise.get_parameter("preload_content")
+            )
+            decode_content = typing.cast(
+                bool, from_promise.get_parameter("decode_content")
+            )
+            timeout = typing.cast(
+                typing.Optional[_TYPE_TIMEOUT], from_promise.get_parameter("timeout")
+            )
+            assert_same_host = typing.cast(
+                bool, from_promise.get_parameter("assert_same_host")
+            )
+            pool_timeout = from_promise.get_parameter("pool_timeout")
+            response_kw = typing.cast(
+                typing.MutableMapping[str, typing.Any],
+                from_promise.get_parameter("response_kw"),
+            )
+            chunked = typing.cast(bool, from_promise.get_parameter("chunked"))
+            body_pos = typing.cast(
+                _TYPE_BODY_POSITION, from_promise.get_parameter("body_pos")
+            )
+
             try:
                 retries = retries.increment(method, url, response=response, _pool=self)
             except MaxRetryError:

--- a/src/urllib3/contrib/hface/protocols/_protocols.py
+++ b/src/urllib3/contrib/hface/protocols/_protocols.py
@@ -263,6 +263,20 @@ class HTTPProtocol(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    def events(self, stream_id: int | None = None) -> typing.Iterator[Event]:
+        """
+        Consume available HTTP events.
+
+        :return: an iterator that unpack "next_event" until exhausted.
+        """
+        while True:
+            ev = self.next_event(stream_id=stream_id)
+
+            if ev is None:
+                break
+
+            yield ev
+
     @abstractmethod
     def has_pending_event(self, *, stream_id: int | None = None) -> bool:
         """Verify if there is queued event waiting to be consumed."""

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -16,6 +16,15 @@ if typing.TYPE_CHECKING:
     from .util.retry import Retry
 
 # Base Exceptions
+try:  # Compiled with SSL?
+    import ssl
+
+    BaseSSLError = ssl.SSLError
+except (ImportError, AttributeError):
+    ssl = None  # type: ignore[assignment]
+
+    class BaseSSLError(BaseException):  # type: ignore[no-redef]
+        pass
 
 
 class HTTPError(Exception):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import platform
 import socket
 import ssl
 import typing
@@ -374,12 +373,3 @@ def requires_traefik() -> None:
     else:
         _TRAEFIK_AVAILABLE = True
         sock.close()
-
-
-if platform.system() == "Windows":
-
-    @pytest.fixture
-    def event_loop() -> typing.Generator[asyncio.AbstractEventLoop, None, None]:
-        loop = asyncio.get_event_loop_policy().new_event_loop()
-        yield loop
-        loop.close()

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -212,10 +212,7 @@ class TestHTTPHeaderDict:
 
     def test_setitem(self, d: HTTPHeaderDict) -> None:
         d["Cookie"] = "foo"
-        # The bytes value gets converted to str. The API is typed for str only,
-        # but the implementation continues supports bytes.
-        d[b"Cookie"] = "bar"  # type: ignore[index]
-        assert d["cookie"] == "bar"
+        assert d["cookie"] == "foo"
         d["cookie"] = "with, comma"
         assert d.getlist("cookie") == ["with, comma"]
 
@@ -237,12 +234,9 @@ class TestHTTPHeaderDict:
 
     def test_add_comma_separated_multiheader(self, d: HTTPHeaderDict) -> None:
         d.add("bar", "foo")
-        # The bytes value gets converted to str. The API is typed for str only,
-        # but the implementation continues supports bytes.
-        d.add(b"BAR", "bar")  # type: ignore[arg-type]
         d.add("Bar", "asdf")
-        assert d.getlist("bar") == ["foo", "bar", "asdf"]
-        assert d["bar"] == "foo, bar, asdf"
+        assert d.getlist("bar") == ["foo", "asdf"]
+        assert d["bar"] == "foo, asdf"
 
     def test_extend_from_list(self, d: HTTPHeaderDict) -> None:
         d.extend([("set-cookie", "100"), ("set-cookie", "200"), ("set-cookie", "300")])

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -526,7 +526,7 @@ class TestConnectionPool:
                 httplib_response.headers = httplib_response.msg = httplib.HTTPMessage()
 
                 response_conn: HTTPConnection | None = kwargs.get("response_conn")
-
+                print(httplib_response.status, httplib_response.reason)
                 response = HTTPResponse(
                     body=httplib_response,
                     headers=httplib_response.headers,  # type: ignore[arg-type]

--- a/test/with_dummyserver/asynchronous/test_connectionpool.py
+++ b/test/with_dummyserver/asynchronous/test_connectionpool.py
@@ -54,18 +54,13 @@ class TestAsyncConnectionPoolTimeouts(SocketDummyServerTestCase):
     )
     async def test_timeout_float(self) -> None:
         block_event = Event()
-        ready_event = self.start_basic_handler(block_send=block_event, num=2)
+        ready_event = self.start_basic_handler(block_send=block_event, num=1)
 
         async with AsyncHTTPConnectionPool(self.host, self.port, retries=False) as pool:
             wait_for_socket(ready_event)
             with pytest.raises(TimeoutError):
                 await pool.request("GET", "/", timeout=SHORT_TIMEOUT)
             block_event.set()  # Release block
-
-            # Shouldn't raise this time
-            wait_for_socket(ready_event)
-            block_event.set()  # Pre-release block
-            await pool.request("GET", "/", timeout=LONG_TIMEOUT)
 
     @pytest.mark.skipif(
         platform.system() == "Windows"

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -25,6 +25,7 @@ from urllib3.exceptions import (
     MaxRetryError,
     NameResolutionError,
     NewConnectionError,
+    ProtocolError,
     ReadTimeoutError,
     UnrewindableBodyError,
 )
@@ -738,7 +739,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
 
     @pytest.mark.parametrize("char", [" ", "\r", "\n", "\x00"])
     def test_invalid_method_not_allowed(self, char: str) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ProtocolError):
             with HTTPConnectionPool(self.host, self.port) as pool:
                 pool.request("GET" + char, "/")
 


### PR DESCRIPTION
2.6.904 (2024-03-17)
====================

- Overall performance improvements for both async and sync calls.
- Removed ``TrafficPolice`` internal caching for obj states of contained elements due to its inability to be up-to-date in some cases.
- Fixed SSLError wrong message displayed when using the underlying ``qh3`` library (HTTP/3 only).
- Fixed graceful shutdown for rare HTTP/2 servers configured to immediately forbid opening new streams.
