### PR TITLE
:bug: Fix traffic police shutdown procedure to avoid killing needlessly a new connection or pool

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.6.905 (2024-03-17)
+====================
+
+- Fixed traffic police shutdown procedure to avoid killing needlessly a new connection or pool.
+
 2.6.904 (2024-03-17)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.6.904"
+__version__ = "2.6.905"

--- a/src/urllib3/util/_async/traffic_police.py
+++ b/src/urllib3/util/_async/traffic_police.py
@@ -575,14 +575,16 @@ class AsyncTrafficPolice(typing.Generic[T]):
         """Shutdown traffic pool."""
         planned_removal = []
 
-        self._shutdown = True
-
         for obj_id in self._container:
             if traffic_state_of(self._container[obj_id]) == TrafficState.IDLE:  # type: ignore[arg-type]
                 planned_removal.append(obj_id)
 
         for obj_id in planned_removal:
             self._container.pop(obj_id)
+
+        # if we can't shut down them all, we need to toggle the shutdown bit to collect and close remaining connections.
+        if len(self._registry) > len(planned_removal):
+            self._shutdown = True
 
         for obj_id in planned_removal:
             conn_or_pool = self._registry.pop(obj_id)

--- a/src/urllib3/util/traffic_police.py
+++ b/src/urllib3/util/traffic_police.py
@@ -579,6 +579,11 @@ class TrafficPolice(typing.Generic[T]):
                 if cursor_obj_id in planned_removal:
                     self._local.cursor = None
 
+            # we've closed all conn/pool successfully, we can unset the shutdown toggle to
+            # prevent killing incoming new conn or pool.
+            if not self._registry:
+                self._shutdown = False
+
     def qsize(self) -> int:
         with self._lock:
             return len(self._container)


### PR DESCRIPTION
Not really problematic per say, but rather a efficiency matter.
