### PR TITLE
:bug: Fix SSL context cache construction that did not take key_password into account

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.6.906 (2024-03-18)
+====================
+
+- Fixed SSL context cache construction that did not take key_password into account.
+- Prefer return ``NotImplemented`` instead of raising ``NotImplementedError`` to avoid polluting the stack trace when trying to
+  initialize the external tls layer when not concerned (e.g. not http3 over QUIC).
+
 2.6.905 (2024-03-17)
 ====================
 

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -667,8 +667,8 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
         sock: AsyncSocket | SSLAsyncSocket
         self.sock = sock = await self._new_conn()
 
-        try:
-            # the protocol/state-machine may also ship with an external TLS Engine.
+        # the protocol/state-machine may also ship with an external TLS Engine.
+        if (
             self._custom_tls(
                 self.ssl_context,
                 self.ca_certs,
@@ -683,7 +683,8 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
                 self.assert_hostname,
                 self.cert_reqs,
             )
-        except NotImplementedError:
+            is NotImplemented
+        ):
             server_hostname: str = self.host
             tls_in_tls = False
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.6.905"
+__version__ = "2.6.906"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -199,10 +199,10 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         cert_fingerprint: str | None = None,
         assert_hostname: None | str | typing.Literal[False] = None,
         cert_reqs: int | str | None = None,
-    ) -> None:
+    ) -> bool:
         """Meant to support TLS over QUIC meanwhile cpython does not ship with its native implementation."""
         if self._svn != HttpVersion.h3:
-            raise NotImplementedError
+            return NotImplemented
 
         cert_use_common_name = False
 
@@ -241,6 +241,8 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         )
 
         self.is_verified = not self.__custom_tls_settings.insecure
+
+        return True
 
     def __h3_probe(self) -> tuple[str, int] | None:
         """Determine if remote is capable of operating through the http/3 protocol over QUIC."""

--- a/src/urllib3/backend/_base.py
+++ b/src/urllib3/backend/_base.py
@@ -383,7 +383,7 @@ class BaseBackend:
         cert_file: str | None = None,
         key_file: str | None = None,
         key_password: str | None = None,
-    ) -> None:
+    ) -> bool:
         """This method serve as bypassing any default tls setup.
         It is most useful when the encryption does not lie on the TCP layer. This method
         WILL raise NotImplementedError if the connection is not concerned."""

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -204,10 +204,10 @@ class HfaceBackend(BaseBackend):
         cert_fingerprint: str | None = None,
         assert_hostname: None | str | typing.Literal[False] = None,
         cert_reqs: int | str | None = None,
-    ) -> None:
+    ) -> bool:
         """Meant to support TLS over QUIC meanwhile cpython does not ship with its native implementation."""
         if self._svn != HttpVersion.h3:
-            raise NotImplementedError
+            return NotImplemented
 
         cert_use_common_name = False
 
@@ -246,6 +246,8 @@ class HfaceBackend(BaseBackend):
         )
 
         self.is_verified = not self.__custom_tls_settings.insecure
+
+        return True
 
     def __h3_probe(self) -> tuple[str, int] | None:
         """Determine if remote is capable of operating through the http/3 protocol over QUIC."""

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -665,8 +665,8 @@ class HTTPSConnection(HTTPConnection):
         sock: socket.socket | ssl.SSLSocket
         self.sock = sock = self._new_conn()
 
-        try:
-            # the protocol/state-machine may also ship with an external TLS Engine.
+        # the protocol/state-machine may also ship with an external TLS Engine.
+        if (
             self._custom_tls(
                 self.ssl_context,
                 self.ca_certs,
@@ -681,7 +681,8 @@ class HTTPSConnection(HTTPConnection):
                 self.assert_hostname,
                 self.cert_reqs,
             )
-        except NotImplementedError:
+            is NotImplemented
+        ):
             server_hostname: str = self.host
             tls_in_tls = False
 

--- a/src/urllib3/util/_async/ssl_.py
+++ b/src/urllib3/util/_async/ssl_.py
@@ -98,6 +98,7 @@ async def ssl_wrap_socket(
             alpn_protocols,
             certdata,
             keydata,
+            key_password,
         )
         if sharable_ssl_context
         else None

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -541,6 +541,7 @@ def ssl_wrap_socket(
             alpn_protocols,
             certdata,
             keydata,
+            key_password,
         )
         if sharable_ssl_context
         else None


### PR DESCRIPTION
2.6.906 (2024-03-18)
====================

- Fixed SSL context cache construction that did not take key_password into account.
- Prefer return ``NotImplemented`` instead of raising ``NotImplementedError`` to avoid polluting the stack trace when trying to
  initialize the external tls layer when not concerned (e.g. not http3 over QUIC).
