### PR TITLE
:sparkle: Add support for Happy Eyeballs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+2.7.900 (2024-03-25)
+====================
+
+- Added Happy-Eyeballs support.
+  This feature is disabled by default, you can enable it by passing ``happy_eyeballs=True``
+  into ``AsyncPoolManager``, ``AsyncHTTPConnectionPool`` or its synchronous counterparts.
+  See the documentation to learn more.
+- Fixed an issue where passing a IPv6 address to the in-memory resolver provider would be improperly registered.
+- Fixed unclosed socket when the user attempt to set a impossible port to bind on (i.e. not in range 0-65535) leading to a ResourceWarning.
+- Fixed a rare issue with DNS-over-HTTPS where a HTTPS record would also be interpreted as a normal record.
+
 2.6.906 (2024-03-18)
 ====================
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - Async.
 - Task safety.
 - Thread safety.
+- Happy Eyeballs.
 - Connection pooling.
 - Client-side SSL/TLS verification.
 - Highly customizable DNS resolution.
@@ -24,6 +25,7 @@
 - DNS over UDP, TLS, QUIC, or HTTPS. DNSSEC protected.
 - Helpers for retrying requests and dealing with HTTP redirects.
 - Support for gzip, deflate, brotli, and zstd encoding.
+- Support for Python/PyPy 3.7+, no compromise.
 - HTTP/1.1, HTTP/2 and HTTP/3 support.
 - Proxy support for HTTP and SOCKS.
 - Detailed connection inspection.

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.6.906"
+__version__ = "2.7.900"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -161,16 +161,15 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         assert self.sock is not None
         assert self._svn is not None
 
-        if not _HAS_HTTP3_SUPPORT:
+        if not _HAS_HTTP3_SUPPORT or not _HAS_DGRAM_SUPPORT:
             return
 
         # do not upgrade if not coming from TLS already.
-        # we exclude SSLTransport, HTTP/3 is not supported in that condition anyway.
-        if type(self.sock) is AsyncSocket:
-            return
-        if self._svn == HttpVersion.h3:
-            return
-        if HttpVersion.h3 in self._disabled_svn:
+        if (
+            type(self.sock) is AsyncSocket
+            or self._svn == HttpVersion.h3
+            or HttpVersion.h3 in self._disabled_svn
+        ):
             return
 
         self.__alt_authority = self.__h3_probe()

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import errno
 import logging
 import queue
+import socket
 import sys
+import threading
 import typing
 import warnings
-from datetime import timedelta
+from concurrent.futures import Future, ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+from itertools import zip_longest
 from socket import timeout as SocketTimeout
 from types import TracebackType
 
@@ -194,6 +198,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         | list[str]
         | BaseResolver
         | None = None,
+        happy_eyeballs: bool | int = False,
         **conn_kw: typing.Any,
     ):
         ConnectionPool.__init__(self, host, port)
@@ -207,6 +212,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         self.timeout = timeout
         self.retries = retries
+        self.happy_eyeballs = happy_eyeballs
 
         self._maxsize = maxsize
 
@@ -301,7 +307,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
     def is_idle(self) -> bool:
         return self.pool is None or self.pool.bag_only_idle
 
-    def _new_conn(self) -> HTTPConnection:
+    def _new_conn(self, *, heb_timeout: Timeout | None = None) -> HTTPConnection:
         """
         Return a fresh :class:`HTTPConnection`.
         """
@@ -316,16 +322,171 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             self.port or "80",
         )
 
-        conn = self.ConnectionCls(
-            host=self.host,
-            port=self.port,
-            timeout=self.timeout.connect_timeout,
-            **self.conn_kw,
-        )
+        conn = None
+
+        if self.happy_eyeballs:
+            log.debug(
+                "Attempting Happy-Eyeball %s:%s",
+                self.host,
+                self.port or "443",
+            )
+
+            dt_pre_resolve = datetime.now(tz=timezone.utc)
+            ip_addresses = self._resolver.getaddrinfo(
+                self.host,
+                self.port,
+                socket.AF_UNSPEC
+                if "socket_family" not in self.conn_kw
+                else self.conn_kw["socket_family"],
+                socket.SOCK_STREAM,
+                quic_upgrade_via_dns_rr=False,
+            )
+            delta_post_resolve = datetime.now(tz=timezone.utc) - dt_pre_resolve
+
+            if len(ip_addresses) > 1:
+                ipv6_addresses = []
+                ipv4_addresses = []
+
+                for ip_address in ip_addresses:
+                    if ip_address[0] == socket.AF_INET6:
+                        ipv6_addresses.append(ip_address)
+                    else:
+                        ipv4_addresses.append(ip_address)
+
+                if ipv4_addresses and ipv6_addresses:
+                    log.debug(
+                        "Happy-Eyeball Dual-Stack %s:%s",
+                        self.host,
+                        self.port or "443",
+                    )
+
+                    intermediary_addresses = []
+                    for ipv6_entry, ipv4_entry in zip_longest(
+                        ipv6_addresses, ipv4_addresses
+                    ):
+                        if ipv6_entry:
+                            intermediary_addresses.append(ipv6_entry)
+                        if ipv4_entry:
+                            intermediary_addresses.append(ipv4_entry)
+                    ip_addresses = intermediary_addresses
+                else:
+                    log.debug(
+                        "Happy-Eyeball Single-Stack %s:%s",
+                        self.host,
+                        self.port or "443",
+                    )
+
+                challengers = []
+                max_task = (
+                    4 if isinstance(self.happy_eyeballs, bool) else self.happy_eyeballs
+                )
+
+                if heb_timeout is None:
+                    heb_timeout = self.timeout
+
+                override_timeout = (
+                    heb_timeout.connect_timeout
+                    if heb_timeout.connect_timeout is not None
+                    and isinstance(heb_timeout.connect_timeout, (float, int))
+                    else 0.4
+                )
+
+                for ip_address in ip_addresses[:max_task]:
+                    conn_kw = self.conn_kw.copy()
+                    target_solo_addr = (
+                        f"[{ip_address[-1][0]}]"
+                        if ip_address[0] == socket.AF_INET6
+                        else ip_address[-1][0]
+                    )
+                    conn_kw["resolver"] = ResolverDescription.from_url(
+                        f"in-memory://default?hosts={self.host}:{target_solo_addr}"
+                    ).new()
+                    conn_kw["socket_family"] = ip_address[0]
+
+                    challengers.append(
+                        self.ConnectionCls(
+                            host=self.host,
+                            port=self.port,
+                            timeout=override_timeout,
+                            **conn_kw,
+                        )
+                    )
+
+                event = threading.Event()
+                winning_task: Future[None] | None = None
+                completed_count: int = 0
+
+                def _happy_eyeballs_completed(t: Future[None]) -> None:
+                    nonlocal winning_task, event, completed_count
+
+                    if winning_task is None and t.exception() is None:
+                        winning_task = t
+                        event.set()
+
+                        return
+
+                    completed_count += 1
+
+                    if completed_count >= len(challengers):
+                        event.set()
+
+                tpe = ThreadPoolExecutor(max_workers=max_task)
+
+                tasks: list[Future[None]] = []
+
+                for challenger in challengers:
+                    task = tpe.submit(challenger.connect)
+                    task.add_done_callback(_happy_eyeballs_completed)
+
+                    tasks.append(task)
+
+                event.wait()
+
+                for task in tasks:
+                    if task == winning_task:
+                        continue
+
+                    if task.running():
+                        task.cancel()
+                    else:
+                        challengers[tasks.index(task)].close()
+
+                if winning_task is None:
+                    within_delay_msg: str = (
+                        f" within {override_timeout}s" if override_timeout else ""
+                    )
+                    raise NewConnectionError(
+                        challengers[0],
+                        f"Failed to establish a new connection: No suitable address to connect to using Happy Eyeballs for {self.host}:{self.port}{within_delay_msg}",
+                    ) from tasks[0].exception()
+
+                conn = challengers[tasks.index(winning_task)]
+
+                # we have to replace the resolution latency metric
+                if conn.conn_info:
+                    conn.conn_info.resolution_latency = delta_post_resolve
+
+                tpe.shutdown(wait=False)
+            else:
+                log.debug(
+                    "Happy-Eyeball Ineligible %s:%s",
+                    self.host,
+                    self.port or "443",
+                )
+
+        if conn is None:
+            conn = self.ConnectionCls(
+                host=self.host,
+                port=self.port,
+                timeout=self.timeout.connect_timeout,
+                **self.conn_kw,
+            )
         self.pool.put(conn, immediately_unavailable=True)
         return conn
 
-    def _get_conn(self, timeout: float | None = None) -> HTTPConnection:
+    def _get_conn(
+        self, timeout: float | None = None, *, heb_timeout: Timeout | None = None
+    ) -> HTTPConnection:
         """
         Get a connection. Will return a pooled connection if one is available.
 
@@ -362,7 +523,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             log.debug("Resetting dropped connection: %s", self.host)
             conn.close()
 
-        return conn or self._new_conn()
+        return conn or self._new_conn(heb_timeout=heb_timeout)
 
     def _put_conn(self, conn: HTTPConnection) -> None:
         """
@@ -1198,7 +1359,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         try:
             # Request a connection from the queue.
             timeout_obj = self._get_timeout(timeout)
-            conn = self._get_conn(timeout=pool_timeout)
+            conn = self._get_conn(timeout=pool_timeout, heb_timeout=timeout_obj)
 
             conn.timeout = timeout_obj.connect_timeout  # type: ignore[assignment]
 
@@ -1526,7 +1687,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         )
         conn.connect()
 
-    def _new_conn(self) -> HTTPSConnection:
+    def _new_conn(self, *, heb_timeout: Timeout | None = None) -> HTTPSConnection:
         """
         Return a fresh :class:`urllib3.connection.HTTPConnection`.
         """
@@ -1551,26 +1712,206 @@ class HTTPSConnectionPool(HTTPConnectionPool):
             actual_host = self.proxy.host
             actual_port = self.proxy.port
 
-        conn = self.ConnectionCls(
-            host=actual_host,
-            port=actual_port,
-            timeout=self.timeout.connect_timeout,
-            cert_file=self.cert_file,
-            key_file=self.key_file,
-            key_password=self.key_password,
-            cert_reqs=self.cert_reqs,
-            ca_certs=self.ca_certs,
-            ca_cert_dir=self.ca_cert_dir,
-            ca_cert_data=self.ca_cert_data,
-            assert_hostname=self.assert_hostname,
-            assert_fingerprint=self.assert_fingerprint,
-            ssl_version=self.ssl_version,
-            ssl_minimum_version=self.ssl_minimum_version,
-            ssl_maximum_version=self.ssl_maximum_version,
-            cert_data=self.cert_data,
-            key_data=self.key_data,
-            **self.conn_kw,
-        )
+        conn = None
+
+        if self.happy_eyeballs:
+            log.debug(
+                "Attempting Happy-Eyeball %s:%s",
+                self.host,
+                self.port or "443",
+            )
+
+            dt_pre_resolve = datetime.now(tz=timezone.utc)
+            ip_addresses = self._resolver.getaddrinfo(
+                actual_host,
+                actual_port,
+                socket.AF_UNSPEC
+                if "socket_family" not in self.conn_kw
+                else self.conn_kw["socket_family"],
+                socket.SOCK_STREAM,
+                quic_upgrade_via_dns_rr=True,
+            )
+            delta_post_resolve = datetime.now(tz=timezone.utc) - dt_pre_resolve
+
+            target_pqc = {}
+
+            if (
+                "preemptive_quic_cache" in self.conn_kw
+                and self.conn_kw["preemptive_quic_cache"] is not None
+            ):
+                target_pqc = self.conn_kw["preemptive_quic_cache"]
+
+            if any(_[1] == socket.SOCK_DGRAM for _ in ip_addresses):
+                if (self.host, self.port) not in target_pqc:
+                    target_pqc[(self.host, self.port)] = (self.host, self.port)
+
+            if len(ip_addresses) > 1:
+                ipv6_addresses = []
+                ipv4_addresses = []
+
+                for ip_address in ip_addresses:
+                    if ip_address[0] == socket.AF_INET6:
+                        ipv6_addresses.append(ip_address)
+                    else:
+                        ipv4_addresses.append(ip_address)
+
+                if ipv4_addresses and ipv6_addresses:
+                    log.debug(
+                        "Happy-Eyeball Dual-Stack %s:%s",
+                        self.host,
+                        self.port or "443",
+                    )
+
+                    intermediary_addresses = []
+                    for ipv6_entry, ipv4_entry in zip_longest(
+                        ipv6_addresses, ipv4_addresses
+                    ):
+                        if ipv6_entry:
+                            intermediary_addresses.append(ipv6_entry)
+                        if ipv4_entry:
+                            intermediary_addresses.append(ipv4_entry)
+                    ip_addresses = intermediary_addresses
+                else:
+                    log.debug(
+                        "Happy-Eyeball Single-Stack %s:%s",
+                        self.host,
+                        self.port or "443",
+                    )
+
+                challengers = []
+                max_task = (
+                    4 if isinstance(self.happy_eyeballs, bool) else self.happy_eyeballs
+                )
+
+                if heb_timeout is None:
+                    heb_timeout = self.timeout
+
+                override_timeout = (
+                    heb_timeout.connect_timeout
+                    if heb_timeout.connect_timeout is not None
+                    and isinstance(heb_timeout.connect_timeout, (float, int))
+                    else 0.4
+                )
+
+                for ip_address in ip_addresses[:max_task]:
+                    conn_kw = self.conn_kw.copy()
+                    target_solo_addr = (
+                        f"[{ip_address[-1][0]}]"
+                        if ip_address[0] == socket.AF_INET6
+                        else ip_address[-1][0]
+                    )
+                    conn_kw["resolver"] = ResolverDescription.from_url(
+                        f"in-memory://default?hosts={self.host}:{target_solo_addr}"
+                    ).new()
+                    conn_kw["socket_family"] = ip_address[0]
+                    conn_kw["preemptive_quic_cache"] = target_pqc
+
+                    challengers.append(
+                        self.ConnectionCls(
+                            host=actual_host,
+                            port=actual_port,
+                            timeout=override_timeout,
+                            cert_file=self.cert_file,
+                            key_file=self.key_file,
+                            key_password=self.key_password,
+                            cert_reqs=self.cert_reqs,
+                            ca_certs=self.ca_certs,
+                            ca_cert_dir=self.ca_cert_dir,
+                            ca_cert_data=self.ca_cert_data,
+                            assert_hostname=self.assert_hostname,
+                            assert_fingerprint=self.assert_fingerprint,
+                            ssl_version=self.ssl_version,
+                            ssl_minimum_version=self.ssl_minimum_version,
+                            ssl_maximum_version=self.ssl_maximum_version,
+                            cert_data=self.cert_data,
+                            key_data=self.key_data,
+                            **conn_kw,
+                        )
+                    )
+
+                event = threading.Event()
+                winning_task: Future[None] | None = None
+                completed_count: int = 0
+
+                def _happy_eyeballs_completed(t: Future[None]) -> None:
+                    nonlocal winning_task, event, completed_count
+
+                    if winning_task is None and t.exception() is None:
+                        winning_task = t
+                        event.set()
+                        return
+
+                    completed_count += 1
+
+                    if completed_count >= len(challengers):
+                        event.set()
+
+                tpe = ThreadPoolExecutor(max_workers=max_task)
+
+                tasks: list[Future[None]] = []
+
+                for challenger in challengers:
+                    task = tpe.submit(challenger.connect)
+                    task.add_done_callback(_happy_eyeballs_completed)
+
+                    tasks.append(task)
+
+                event.wait()
+
+                for task in tasks:
+                    if task == winning_task:
+                        continue
+
+                    if task.running():
+                        task.cancel()
+                    else:
+                        challengers[tasks.index(task)].close()
+
+                if winning_task is None:
+                    within_delay_msg: str = (
+                        f" within {override_timeout}s" if override_timeout else ""
+                    )
+                    raise NewConnectionError(
+                        challengers[0],
+                        f"Failed to establish a new connection: No suitable address to connect to using Happy Eyeballs algorithm for {actual_host}:{actual_port}{within_delay_msg}",
+                    ) from tasks[0].exception()
+
+                conn = challengers[tasks.index(winning_task)]
+
+                # we have to replace the resolution latency metric
+                if conn.conn_info:
+                    conn.conn_info.resolution_latency = delta_post_resolve
+
+                tpe.shutdown(wait=False)
+            else:
+                log.debug(
+                    "Happy-Eyeball Ineligible %s:%s",
+                    self.host,
+                    self.port or "443",
+                )
+
+        if conn is None:
+            conn = self.ConnectionCls(
+                host=actual_host,
+                port=actual_port,
+                timeout=self.timeout.connect_timeout,
+                cert_file=self.cert_file,
+                key_file=self.key_file,
+                key_password=self.key_password,
+                cert_reqs=self.cert_reqs,
+                ca_certs=self.ca_certs,
+                ca_cert_dir=self.ca_cert_dir,
+                ca_cert_data=self.ca_cert_data,
+                assert_hostname=self.assert_hostname,
+                assert_fingerprint=self.assert_fingerprint,
+                ssl_version=self.ssl_version,
+                ssl_minimum_version=self.ssl_minimum_version,
+                ssl_maximum_version=self.ssl_maximum_version,
+                cert_data=self.cert_data,
+                key_data=self.key_data,
+                **self.conn_kw,
+            )
+
         self.pool.put(conn, immediately_unavailable=True)
         return conn
 

--- a/src/urllib3/contrib/resolver/_async/doh/_urllib3.py
+++ b/src/urllib3/contrib/resolver/_async/doh/_urllib3.py
@@ -463,7 +463,7 @@ class HTTPSResolver(AsyncBaseResolver):
                                         )
                                     )
 
-                            continue
+                        continue
 
                     inet_type = (
                         socket.AF_INET if answer["type"] == 1 else socket.AF_INET6

--- a/src/urllib3/contrib/resolver/_async/in_memory/_dict.py
+++ b/src/urllib3/contrib/resolver/_async/in_memory/_dict.py
@@ -56,14 +56,15 @@ class InMemoryResolver(AsyncBaseResolver):
         else:
             for e in self._hosts[hostname]:
                 t, addr = e
-                if ipaddr == addr:
+                if addr in ipaddr:
                     return
 
         if _IPV6_ADDRZ_RE.match(ipaddr):
+            self._hosts[hostname].append((socket.AF_INET6, ipaddr[1:-1]))
+        elif is_ipv6(ipaddr):
             self._hosts[hostname].append((socket.AF_INET6, ipaddr))
-            return
-
-        self._hosts[hostname].append((socket.AF_INET, ipaddr))
+        else:
+            self._hosts[hostname].append((socket.AF_INET, ipaddr))
 
         if len(self._hosts) > self._maxsize:
             k = None

--- a/src/urllib3/contrib/resolver/_async/protocols.py
+++ b/src/urllib3/contrib/resolver/_async/protocols.py
@@ -136,10 +136,12 @@ class AsyncBaseResolver(BaseResolver, metaclass=ABCMeta):
                     )
 
                 return sock
-            except OSError as _:
+            except (OSError, OverflowError) as _:
                 err = _
                 if sock is not None:
                     sock.close()
+                if isinstance(_, OverflowError):
+                    break
 
         if err is not None:
             try:

--- a/src/urllib3/contrib/resolver/doh/_urllib3.py
+++ b/src/urllib3/contrib/resolver/doh/_urllib3.py
@@ -463,7 +463,7 @@ class HTTPSResolver(BaseResolver):
                                         )
                                     )
 
-                            continue
+                        continue
 
                     inet_type = (
                         socket.AF_INET if answer["type"] == 1 else socket.AF_INET6

--- a/src/urllib3/contrib/resolver/in_memory/_dict.py
+++ b/src/urllib3/contrib/resolver/in_memory/_dict.py
@@ -56,14 +56,15 @@ class InMemoryResolver(BaseResolver):
             else:
                 for e in self._hosts[hostname]:
                     t, addr = e
-                    if ipaddr == addr:
+                    if addr in ipaddr:
                         return
 
             if _IPV6_ADDRZ_RE.match(ipaddr):
+                self._hosts[hostname].append((socket.AF_INET6, ipaddr[1:-1]))
+            elif is_ipv6(ipaddr):
                 self._hosts[hostname].append((socket.AF_INET6, ipaddr))
-                return
-
-            self._hosts[hostname].append((socket.AF_INET, ipaddr))
+            else:
+                self._hosts[hostname].append((socket.AF_INET, ipaddr))
 
             if len(self._hosts) > self._maxsize:
                 k = None

--- a/src/urllib3/contrib/resolver/protocols.py
+++ b/src/urllib3/contrib/resolver/protocols.py
@@ -239,10 +239,12 @@ class BaseResolver(metaclass=ABCMeta):
                     )
 
                 return sock
-            except OSError as _:
+            except (OSError, OverflowError) as _:
                 err = _
                 if sock is not None:
                     sock.close()
+                if isinstance(_, OverflowError):
+                    break
 
         if err is not None:
             try:

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -111,6 +111,7 @@ class PoolKey(typing.NamedTuple):
     key_disabled_svn: set[HttpVersion] | None
     key_cert_data: str | bytes | None
     key_key_data: str | bytes | None
+    key_happy_eyeballs: bool | int | None
 
 
 @functools.lru_cache(maxsize=8)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -224,7 +224,9 @@ class LogRecorder:
     def __init__(self, target: logging.Logger = logging.root) -> None:
         super().__init__()
         self._target = target
+        self._target.setLevel(logging.DEBUG)
         self._handler = _ListHandler()
+        self._handler.setLevel(logging.DEBUG)
 
     @property
     def records(self) -> list[logging.LogRecord]:

--- a/test/contrib/asynchronous/test_resolver.py
+++ b/test/contrib/asynchronous/test_resolver.py
@@ -668,6 +668,11 @@ async def test_dgram_upgrade(dns_url: str) -> None:
             "abc.tld",
             "::1",
         ),
+        (
+            "in-memory://default/?hosts=abc.tld:[::1],def.tld:8.8.8.8",
+            "abc.tld",
+            "::1",
+        ),
     ],
 )
 @pytest.mark.asyncio

--- a/test/contrib/test_resolver.py
+++ b/test/contrib/test_resolver.py
@@ -683,6 +683,11 @@ def test_dgram_upgrade(dns_url: str) -> None:
             "abc.tld",
             "::1",
         ),
+        (
+            "in-memory://default/?hosts=abc.tld:[::1],def.tld:8.8.8.8",
+            "abc.tld",
+            "::1",
+        ),
     ],
 )
 def test_in_memory_resolver(

--- a/test/with_dummyserver/asynchronous/test_happy_eyeballs.py
+++ b/test/with_dummyserver/asynchronous/test_happy_eyeballs.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import pytest
+
+from urllib3 import AsyncPoolManager
+from urllib3._async.connectionpool import log as cp_logger
+from urllib3.exceptions import InsecureRequestWarning, NewConnectionError
+
+from ... import LogRecorder
+from ...conftest import ServerConfig
+
+
+@pytest.mark.asyncio
+class TestHappyEyeballs:
+    async def test_dual_stack(self, ipv6_san_server: ServerConfig) -> None:
+        async with AsyncPoolManager(
+            happy_eyeballs=True,
+            resolver="in-memory://default?hosts=dummy.io:127.0.0.1,dummy.io:[::1]",
+            cert_reqs=0,
+        ) as pm:
+            with LogRecorder(target=cp_logger) as logs:
+                with pytest.warns(InsecureRequestWarning):
+                    r = await pm.urlopen(
+                        "GET", f"https://dummy.io:{ipv6_san_server.port}/"
+                    )
+
+            attempt_happy_eyeballs: bool = False
+            choose_dual_stack: bool = False
+            ineligible_records: bool = False
+
+            for log in logs:
+                if (
+                    not attempt_happy_eyeballs
+                    and "Attempting Happy-Eyeball" in log.message
+                ):
+                    attempt_happy_eyeballs = True
+                    continue
+                if not choose_dual_stack and "Happy-Eyeball Dual-Stack" in log.message:
+                    choose_dual_stack = True
+                if not ineligible_records and "Happy-Eyeball Ineligible" in log.message:
+                    ineligible_records = True
+
+            assert attempt_happy_eyeballs
+            assert choose_dual_stack
+            assert not ineligible_records
+            assert r.status == 200
+
+    async def test_single_stack(self, ipv6_san_server: ServerConfig) -> None:
+        async with AsyncPoolManager(
+            happy_eyeballs=True,
+            resolver="in-memory://default?hosts=dummy.io:[::2],dummy.io:[::1]",
+            cert_reqs=0,
+        ) as pm:
+            with LogRecorder(target=cp_logger) as logs:
+                with pytest.warns(InsecureRequestWarning):
+                    r = await pm.urlopen(
+                        "GET", f"https://dummy.io:{ipv6_san_server.port}/"
+                    )
+
+            attempt_happy_eyeballs: bool = False
+            choose_single_stack: bool = False
+            ineligible_records: bool = False
+
+            for log in logs:
+                if (
+                    not attempt_happy_eyeballs
+                    and "Attempting Happy-Eyeball" in log.message
+                ):
+                    attempt_happy_eyeballs = True
+                    continue
+                if (
+                    not choose_single_stack
+                    and "Happy-Eyeball Single-Stack" in log.message
+                ):
+                    choose_single_stack = True
+                    continue
+                if not ineligible_records and "Happy-Eyeball Ineligible" in log.message:
+                    ineligible_records = True
+
+            assert attempt_happy_eyeballs
+            assert choose_single_stack
+            assert not ineligible_records
+            assert r.status == 200
+
+    async def test_with_one_tarpit(self, ipv6_san_server: ServerConfig) -> None:
+        async with AsyncPoolManager(
+            happy_eyeballs=True,
+            resolver="in-memory://default?hosts=dummy.io:240.0.0.0,dummy.io:[::1]",
+            cert_reqs=0,
+        ) as pm:
+            with LogRecorder(target=cp_logger) as logs:
+                with pytest.warns(InsecureRequestWarning):
+                    r = await pm.urlopen(
+                        "GET", f"https://dummy.io:{ipv6_san_server.port}/"
+                    )
+
+            attempt_happy_eyeballs: bool = False
+            choose_dual_stack: bool = False
+            ineligible_records: bool = False
+
+            for log in logs:
+                if (
+                    not attempt_happy_eyeballs
+                    and "Attempting Happy-Eyeball" in log.message
+                ):
+                    attempt_happy_eyeballs = True
+                    continue
+                if not choose_dual_stack and "Happy-Eyeball Dual-Stack" in log.message:
+                    choose_dual_stack = True
+                    continue
+                if not ineligible_records and "Happy-Eyeball Ineligible" in log.message:
+                    ineligible_records = True
+
+            assert attempt_happy_eyeballs
+            assert choose_dual_stack
+            assert not ineligible_records
+            assert r.status == 200
+
+    async def test_with_all_tarpit_global_timeout(self) -> None:
+        async with AsyncPoolManager(
+            happy_eyeballs=True,
+            resolver="in-memory://default?hosts=dummy.io:240.0.0.0,dummy.io:240.0.0.1",
+            cert_reqs=0,
+            retries=False,
+            timeout=0.5,
+        ) as pm:
+            with pytest.raises(NewConnectionError) as exc:
+                await pm.urlopen("GET", "https://dummy.io/")
+
+            assert (
+                "No suitable address to connect to using Happy Eyeballs"
+                in exc.value.args[0]
+            )
+            assert "within 0.5s" in exc.value.args[0]
+
+    async def test_with_all_tarpit_local_timeout(self) -> None:
+        async with AsyncPoolManager(
+            happy_eyeballs=True,
+            resolver="in-memory://default?hosts=dummy.io:240.0.0.0,dummy.io:240.0.0.1",
+            cert_reqs=0,
+            retries=False,
+        ) as pm:
+            with pytest.raises(NewConnectionError) as exc:
+                await pm.urlopen("GET", "https://dummy.io/", timeout=0.5)
+
+            assert (
+                "No suitable address to connect to using Happy Eyeballs"
+                in exc.value.args[0]
+            )
+            assert "within 0.5s" in exc.value.args[0]
+            # we must ensure we can tie the NewConnectionError to a TimeoutError
+            # some people relies on it.
+            assert exc.value.__cause__ is not None
+
+    async def test_ineligible_target(self, ipv6_san_server: ServerConfig) -> None:
+        async with AsyncPoolManager(
+            happy_eyeballs=True,
+            resolver="in-memory://default?hosts=dummy.io:[::1]",
+            cert_reqs=0,
+        ) as pm:
+            with LogRecorder(target=cp_logger) as logs:
+                with pytest.warns(InsecureRequestWarning):
+                    r = await pm.urlopen(
+                        "GET", f"https://dummy.io:{ipv6_san_server.port}/"
+                    )
+
+            attempt_happy_eyeballs: bool = False
+            choose_dual_stack: bool = False
+            ineligible_records: bool = False
+
+            for log in logs:
+                if (
+                    not attempt_happy_eyeballs
+                    and "Attempting Happy-Eyeball" in log.message
+                ):
+                    attempt_happy_eyeballs = True
+                    continue
+                if not choose_dual_stack and "Happy-Eyeball Dual-Stack" in log.message:
+                    choose_dual_stack = True
+                    continue
+                if not ineligible_records and "Happy-Eyeball Ineligible" in log.message:
+                    ineligible_records = True
+
+            assert attempt_happy_eyeballs
+            assert not choose_dual_stack
+            assert ineligible_records
+            assert r.status == 200

--- a/test/with_dummyserver/test_happy_eyeballs.py
+++ b/test/with_dummyserver/test_happy_eyeballs.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import pytest
+
+from urllib3 import PoolManager
+from urllib3.connectionpool import log as cp_logger
+from urllib3.exceptions import InsecureRequestWarning, NewConnectionError
+
+from .. import LogRecorder
+from ..conftest import ServerConfig
+
+
+class TestHappyEyeballs:
+    def test_dual_stack(self, ipv6_san_server: ServerConfig) -> None:
+        with PoolManager(
+            happy_eyeballs=True,
+            resolver="in-memory://default?hosts=dummy.io:127.0.0.1,dummy.io:[::1]",
+            cert_reqs=0,
+        ) as pm:
+            with LogRecorder(target=cp_logger) as logs:
+                with pytest.warns(InsecureRequestWarning):
+                    r = pm.urlopen("GET", f"https://dummy.io:{ipv6_san_server.port}/")
+
+            attempt_happy_eyeballs: bool = False
+            choose_dual_stack: bool = False
+            ineligible_records: bool = False
+
+            for log in logs:
+                if (
+                    not attempt_happy_eyeballs
+                    and "Attempting Happy-Eyeball" in log.message
+                ):
+                    attempt_happy_eyeballs = True
+                    continue
+                if not choose_dual_stack and "Happy-Eyeball Dual-Stack" in log.message:
+                    choose_dual_stack = True
+                if not ineligible_records and "Happy-Eyeball Ineligible" in log.message:
+                    ineligible_records = True
+
+            assert attempt_happy_eyeballs
+            assert choose_dual_stack
+            assert not ineligible_records
+            assert r.status == 200
+
+    def test_single_stack(self, ipv6_san_server: ServerConfig) -> None:
+        with PoolManager(
+            happy_eyeballs=True,
+            resolver="in-memory://default?hosts=dummy.io:[::2],dummy.io:[::1]",
+            cert_reqs=0,
+        ) as pm:
+            with LogRecorder(target=cp_logger) as logs:
+                with pytest.warns(InsecureRequestWarning):
+                    r = pm.urlopen("GET", f"https://dummy.io:{ipv6_san_server.port}/")
+
+            attempt_happy_eyeballs: bool = False
+            choose_single_stack: bool = False
+            ineligible_records: bool = False
+
+            for log in logs:
+                if (
+                    not attempt_happy_eyeballs
+                    and "Attempting Happy-Eyeball" in log.message
+                ):
+                    attempt_happy_eyeballs = True
+                    continue
+                if (
+                    not choose_single_stack
+                    and "Happy-Eyeball Single-Stack" in log.message
+                ):
+                    choose_single_stack = True
+                    continue
+                if not ineligible_records and "Happy-Eyeball Ineligible" in log.message:
+                    ineligible_records = True
+
+            assert attempt_happy_eyeballs
+            assert choose_single_stack
+            assert not ineligible_records
+            assert r.status == 200
+
+    def test_with_one_tarpit(self, ipv6_san_server: ServerConfig) -> None:
+        with PoolManager(
+            happy_eyeballs=True,
+            resolver="in-memory://default?hosts=dummy.io:240.0.0.0,dummy.io:[::1]",
+            cert_reqs=0,
+        ) as pm:
+            with LogRecorder(target=cp_logger) as logs:
+                with pytest.warns(InsecureRequestWarning):
+                    r = pm.urlopen("GET", f"https://dummy.io:{ipv6_san_server.port}/")
+
+            attempt_happy_eyeballs: bool = False
+            choose_dual_stack: bool = False
+            ineligible_records: bool = False
+
+            for log in logs:
+                if (
+                    not attempt_happy_eyeballs
+                    and "Attempting Happy-Eyeball" in log.message
+                ):
+                    attempt_happy_eyeballs = True
+                    continue
+                if not choose_dual_stack and "Happy-Eyeball Dual-Stack" in log.message:
+                    choose_dual_stack = True
+                    continue
+                if not ineligible_records and "Happy-Eyeball Ineligible" in log.message:
+                    ineligible_records = True
+
+            assert attempt_happy_eyeballs
+            assert choose_dual_stack
+            assert not ineligible_records
+            assert r.status == 200
+
+    def test_with_all_tarpit_implicit_timeout(self) -> None:
+        """In the synchronous context, using HEB algorithm, we cannot set the infinite wait.
+        We have to make sure it fails after a short period of time (by default 400ms)"""
+        with PoolManager(
+            happy_eyeballs=True,
+            resolver="in-memory://default?hosts=dummy.io:240.0.0.0,dummy.io:240.0.0.1",
+            cert_reqs=0,
+            retries=False,
+        ) as pm:
+            with pytest.raises(NewConnectionError) as exc:
+                pm.urlopen("GET", "https://dummy.io/")
+
+            assert (
+                "No suitable address to connect to using Happy Eyeballs"
+                in exc.value.args[0]
+            )
+            assert "within 0.4s" in exc.value.args[0]
+
+    def test_with_all_tarpit_explicit_timeout_global(self) -> None:
+        with PoolManager(
+            happy_eyeballs=True,
+            resolver="in-memory://default?hosts=dummy.io:240.0.0.0,dummy.io:240.0.0.1",
+            cert_reqs=0,
+            retries=False,
+            timeout=1,
+        ) as pm:
+            with pytest.raises(NewConnectionError) as exc:
+                pm.urlopen("GET", "https://dummy.io/")
+
+            assert (
+                "No suitable address to connect to using Happy Eyeballs"
+                in exc.value.args[0]
+            )
+            assert "within 1s" in exc.value.args[0]
+
+    def test_with_all_tarpit_explicit_timeout_local(self) -> None:
+        with PoolManager(
+            happy_eyeballs=True,
+            resolver="in-memory://default?hosts=dummy.io:240.0.0.0,dummy.io:240.0.0.1",
+            cert_reqs=0,
+            retries=False,
+        ) as pm:
+            with pytest.raises(NewConnectionError) as exc:
+                pm.urlopen("GET", "https://dummy.io/", timeout=1)
+
+            assert (
+                "No suitable address to connect to using Happy Eyeballs"
+                in exc.value.args[0]
+            )
+            assert "within 1s" in exc.value.args[0]
+            # we must ensure we can tie the NewConnectionError to a TimeoutError
+            # some people relies on it.
+            assert exc.value.__cause__ is not None
+
+    def test_ineligible_target(self, ipv6_san_server: ServerConfig) -> None:
+        with PoolManager(
+            happy_eyeballs=True,
+            resolver="in-memory://default?hosts=dummy.io:[::1]",
+            cert_reqs=0,
+        ) as pm:
+            with LogRecorder(target=cp_logger) as logs:
+                with pytest.warns(InsecureRequestWarning):
+                    r = pm.urlopen("GET", f"https://dummy.io:{ipv6_san_server.port}/")
+
+            attempt_happy_eyeballs: bool = False
+            choose_dual_stack: bool = False
+            ineligible_records: bool = False
+
+            for log in logs:
+                if (
+                    not attempt_happy_eyeballs
+                    and "Attempting Happy-Eyeball" in log.message
+                ):
+                    attempt_happy_eyeballs = True
+                    continue
+                if not choose_dual_stack and "Happy-Eyeball Dual-Stack" in log.message:
+                    choose_dual_stack = True
+                    continue
+                if not ineligible_records and "Happy-Eyeball Ineligible" in log.message:
+                    ineligible_records = True
+
+            assert attempt_happy_eyeballs
+            assert not choose_dual_stack
+            assert ineligible_records
+            assert r.status == 200


### PR DESCRIPTION
2.7.900 (2024-03-25)
====================

- Added Happy-Eyeballs support.
  This feature is disabled by default, you can enable it by passing ``happy_eyeballs=True``
  into ``AsyncPoolManager``, ``AsyncHTTPConnectionPool`` or its synchronous counterparts.
  See the documentation to learn more.
- Fixed an issue where passing a IPv6 address to the in-memory resolver provider would be improperly registered.
- Fixed unclosed socket when the user attempt to set a impossible port to bind on (i.e. not in range 0-65535) leading to a ResourceWarning.
- Fixed a rare issue with DNS-over-HTTPS where a HTTPS record would also be interpreted as a normal record.
