### PR TITLE
:bug: Fix an edge case with Response::read() passing positive amt then None (repeated n-times) would return cached (buffer) data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.7.901 (2024-03-27)
+====================
+
+- Fixed an edge case with Response::read() confusing situation where passing a positive amount to read then
+  passing ``None`` n-times would continuously return cached data if the stream was closed (content consumed).
+- Fixed IncompleteRead exception property ``expected`` that did not contain the "remaining" amount expected but rather
+  the total expected.
+
 2.7.900 (2024-03-25)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.7.900"
+__version__ = "2.7.901"

--- a/src/urllib3/backend/_async/_base.py
+++ b/src/urllib3/backend/_async/_base.py
@@ -94,6 +94,7 @@ class AsyncLowLevelResponse:
         else:
             if __size is None:
                 data = self.__buffer_excess
+                self.__buffer_excess = b""
             else:
                 data = self.__buffer_excess[:__size]
                 self.__buffer_excess = self.__buffer_excess[__size:]

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -630,15 +630,14 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                                 "",
                             ).strip("()")
 
-                            received, expected = tuple(msg.split(", "))
+                            received, expected = (
+                                int("".join(c for c in _ if c.isdigit()).strip())
+                                for _ in tuple(msg.split(", "))
+                            )
 
                             raise IncompleteRead(
-                                partial=int(
-                                    "".join(c for c in received if c.isdigit()).strip()
-                                ),
-                                expected=int(
-                                    "".join(c for c in expected if c.isdigit()).strip()
-                                ),
+                                partial=received,
+                                expected=expected - received,
                             )
                     except (ValueError, IndexError):
                         pass

--- a/src/urllib3/backend/_base.py
+++ b/src/urllib3/backend/_base.py
@@ -164,6 +164,7 @@ class LowLevelResponse:
         else:
             if __size is None:
                 data = self.__buffer_excess
+                self.__buffer_excess = b""
             else:
                 data = self.__buffer_excess[:__size]
                 self.__buffer_excess = self.__buffer_excess[__size:]

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -672,15 +672,14 @@ class HfaceBackend(BaseBackend):
                                 "",
                             ).strip("()")
 
-                            received, expected = tuple(msg.split(", "))
+                            received, expected = (
+                                int("".join(c for c in _ if c.isdigit()).strip())
+                                for _ in tuple(msg.split(", "))
+                            )
 
                             raise IncompleteRead(
-                                partial=int(
-                                    "".join(c for c in received if c.isdigit()).strip()
-                                ),
-                                expected=int(
-                                    "".join(c for c in expected if c.isdigit()).strip()
-                                ),
+                                partial=received,
+                                expected=expected - received,
                             )
                     except (ValueError, IndexError):
                         pass

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -267,7 +267,7 @@ class IncompleteRead(ProtocolError):
 
     def __init__(self, partial: int, expected: int) -> None:
         super().__init__(
-            f"peer closed connection without sending complete message body (received {partial} bytes, expected {expected})"
+            f"peer closed connection without sending complete message body (received {partial} bytes, expected {expected} more)"
         )
         self.partial = partial
         self.expected = expected

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -666,6 +666,9 @@ class TestConnectionPool(HTTPDummyServerTestCase):
 
             assert r.read(5) == resp_data[:5]
             assert r.read() == resp_data[5:]
+            assert (
+                r.read() == b""
+            )  # it should yield empty bytes, as we ended / closed the stream!
 
     def test_lazy_load_twice(self) -> None:
         # This test is sad and confusing. Need to figure out what's

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -2046,7 +2046,9 @@ class TestBadContentLength(SocketDummyServerTestCase):
                 "GET", url="/", preload_content=False, enforce_content_length=True
             )
             data = get_response.stream(100)
-            with pytest.raises(IncompleteRead, match="received 12 bytes, expected 22"):
+            with pytest.raises(
+                IncompleteRead, match="received 12 bytes, expected 10 more"
+            ):
                 next(data)
             done_event.set()
 


### PR DESCRIPTION
2.7.901 (2024-03-27)
====================

- Fixed an edge case with Response::read() confusing situation where passing a positive amount to read then
  passing ``None`` n-times would continuously return cached data if the stream was closed (content consumed).
- Fixed IncompleteRead exception property ``expected`` that did not contain the "remaining" amount expected but rather
  the total expected.
