### PR TITLE
:sparkle: Add support for jh2 instead of h2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os:
-          - macos-latest
+          - macos-12
           - windows-latest
           - ubuntu-20.04  # OpenSSL 1.1.1
           - ubuntu-latest  # OpenSSL 3.0
@@ -89,7 +89,7 @@ jobs:
             os: ubuntu-22.04
 
     runs-on: ${{ matrix.os }}
-    name: ${{ fromJson('{"macos-latest":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)","ubuntu-latest":"Ubuntu Latest (OpenSSL 3+)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session }}
+    name: ${{ fromJson('{"macos-12":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)","ubuntu-latest":"Ubuntu Latest (OpenSSL 3+)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session }}
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 40
     steps:
@@ -253,7 +253,7 @@ jobs:
           NOX_SESSION: ${{ matrix.nox-session }}
 
       - name: "Upload artifact"
-        uses: "actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba"
+        uses: "actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce"
         with:
           name: coverage-data
           path: ".coverage.*"
@@ -277,7 +277,7 @@ jobs:
         run: "python -m pip install --upgrade coverage"
 
       - name: "Download artifact"
-        uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: coverage-data
 
@@ -289,7 +289,7 @@ jobs:
 
       - if: ${{ failure() }}
         name: "Upload report if check failed"
-        uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: coverage-report
           path: htmlcov

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
           cd dist && echo "::set-output name=hashes::$(sha256sum * | base64 -w0)"
 
       - name: "Upload dists"
-        uses: "actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba"
+        uses: "actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce"
         with:
           name: "dist"
           path: "dist/"
@@ -71,7 +71,7 @@ jobs:
 
     steps:
     - name: "Download dists"
-      uses: "actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d"
+      uses: "actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a"
       with:
         name: "dist"
         path: "dist/"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.7.905 (2024-04-28)
+====================
+
+- Added support for ``jh2>=5,<6`` instead of ``h2~=4.0`` as a drop-in replacement.
+  Expect a significant performance improvement with HTTP/2. We successfully reduced our dependency footprint to the minimum.
+
 2.7.904 (2024-04-20)
 ====================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dynamic = ["version"]
 dependencies = [
   "qh3>=1.0.3,<2.0.0; (platform_system == 'Darwin' or platform_system == 'Windows' or platform_system == 'Linux') and (platform_machine == 'x86_64' or platform_machine == 's390x' or platform_machine == 'aarch64' or platform_machine == 'armv7l' or platform_machine == 'ppc64le' or platform_machine == 'ppc64' or platform_machine == 'AMD64' or platform_machine == 'arm64') and (platform_python_implementation == 'CPython' or (platform_python_implementation == 'PyPy' and python_version < '3.11'))",
   "h11>=0.11.0,<1.0.0",
-  "h2>=4.0.0,<5.0.0",
+  "jh2>=5.0.0,<6.0.0",
 ]
 
 [project.optional-dependencies]
@@ -55,7 +55,7 @@ socks = [
   "python-socks>=2.0,<3.0",
 ]
 qh3 = [
-  "qh3>=0.14.0,<1.0.0",
+  "qh3>=1.0.3,<2.0.0",
 ]
 
 [project.urls]

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.7.904"
+__version__ = "2.7.905"


### PR DESCRIPTION
2.7.905 (2024-04-28)
====================

- Added support for ``jh2>=5,<6`` instead of ``h2~=4.0`` as a drop-in replacement.
  Expect a significant performance improvement with HTTP/2. We successfully reduced our dependency footprint to the minimum.
