### PR TITLE
:bug: Fix usage of custom ssl context in conjunction of HTTP/3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.7.907 (2024-05-05)
+====================
+
+- Passing a ssl context containing manually loaded root certificates no longer is ignored with HTTP/3 over QUIC.
+
 2.7.906 (2024-05-02)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.7.906"
+__version__ = "2.7.907"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -919,7 +919,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                 if raw_header == b":status":
                     status = int(raw_value)
             else:
-                headers.add(raw_header.decode("ascii"), raw_value.decode("latin-1"))
+                headers.add(raw_header.decode("ascii"), raw_value.decode("iso-8859-1"))
 
         if promise is None:
             try:

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -215,6 +215,14 @@ class AsyncHfaceBackend(AsyncBaseBackend):
             if ssl_context.verify_mode == ssl.CERT_NONE:
                 allow_insecure = True
 
+            if ca_certs is None and ca_cert_dir is None and ca_cert_data is None:
+                ctx_root_certificates = ssl_context.get_ca_certs(True)
+
+                if ctx_root_certificates:
+                    ca_cert_data = "\n".join(
+                        ssl.DER_cert_to_PEM_cert(cert) for cert in ctx_root_certificates
+                    )
+
         if not allow_insecure and resolve_cert_reqs(cert_reqs) == ssl.CERT_NONE:
             allow_insecure = True
 
@@ -911,7 +919,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                 if raw_header == b":status":
                     status = int(raw_value)
             else:
-                headers.add(raw_header.decode("ascii"), raw_value.decode("iso-8859-1"))
+                headers.add(raw_header.decode("ascii"), raw_value.decode("latin-1"))
 
         if promise is None:
             try:

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -221,6 +221,14 @@ class HfaceBackend(BaseBackend):
             if ssl_context.verify_mode == ssl.CERT_NONE:
                 allow_insecure = True
 
+            if ca_certs is None and ca_cert_dir is None and ca_cert_data is None:
+                ctx_root_certificates = ssl_context.get_ca_certs(True)
+
+                if ctx_root_certificates:
+                    ca_cert_data = "\n".join(
+                        ssl.DER_cert_to_PEM_cert(cert) for cert in ctx_root_certificates
+                    )
+
         if not allow_insecure and resolve_cert_reqs(cert_reqs) == ssl.CERT_NONE:
             allow_insecure = True
 
@@ -947,7 +955,7 @@ class HfaceBackend(BaseBackend):
             event_type_collectable=(HeadersReceived,),
             respect_end_stream_signal=False,
             stream_id=promise.stream_id if promise else None,
-        ).pop()
+        )[0]
 
         headers = HTTPHeaderDict()
         status: int | None = None

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -955,7 +955,7 @@ class HfaceBackend(BaseBackend):
             event_type_collectable=(HeadersReceived,),
             respect_end_stream_signal=False,
             stream_id=promise.stream_id if promise else None,
-        )[0]
+        ).pop()
 
         headers = HTTPHeaderDict()
         status: int | None = None

--- a/test/with_traefik/asynchronous/test_connection.py
+++ b/test/with_traefik/asynchronous/test_connection.py
@@ -5,6 +5,7 @@ import pytest
 from urllib3 import HttpVersion
 from urllib3._async.connection import AsyncHTTPSConnection
 from urllib3.exceptions import ResponseNotReady
+from urllib3.util import create_urllib3_context
 
 from .. import TraefikTestCase
 
@@ -145,3 +146,34 @@ class TestConnection(TraefikTestCase):
 
         assert len(quic_cache_resumption.keys()) == 1
         assert (self.host, self.https_port) in quic_cache_resumption
+
+    async def test_quic_extract_ssl_ctx_ca_root(self) -> None:
+        quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = {
+            (self.host, self.https_port): ("", self.https_port)
+        }
+
+        ctx = create_urllib3_context()
+        ctx.load_verify_locations(cafile=self.ca_authority)
+
+        conn = AsyncHTTPSConnection(
+            self.host,
+            self.https_port,
+            ssl_context=ctx,
+            preemptive_quic_cache=quic_cache_resumption,
+        )
+
+        await conn.request("GET", "/get")
+        resp = await conn.getresponse()
+
+        assert conn._AsyncHfaceBackend__custom_tls_settings is not None  # type: ignore
+        detect_ctx_fallback = conn._AsyncHfaceBackend__custom_tls_settings.cadata  # type: ignore
+
+        assert detect_ctx_fallback is not None
+        assert isinstance(detect_ctx_fallback, bytes)
+        assert self.ca_authority is not None
+
+        with open(self.ca_authority, "rb") as fp:
+            assert fp.read() in detect_ctx_fallback
+
+        assert resp.status == 200
+        assert resp.version == 30


### PR DESCRIPTION
Passing a ssl context containing manually loaded root certificates no longer is ignored with HTTP/3 over QUIC.
Close #113 