### PR TITLE
:zap: improve import performance by lazy loading qh3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.7.910 (2024-05-22)
+====================
+
+- Removed workaround for a bug that existed in qh3 < 1.0 with cryptography in a concurrent (thread) environment.
+- Avoid loading qh3 at runtime in order to improve import delay. It was used to probe HTTP/3 support. We compute it lazily from now on.
+- Added the possibility to use the ``preemptive_quic_cache`` MutableMapping to exclude endpoints.
+  If your implementation discard the recently set key/entry it will prevent the connection from upgrading itself.
+
 2.7.909 (2024-05-17)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.7.909"
+__version__ = "2.7.910"


### PR DESCRIPTION
2.7.910 (2024-05-22)
====================

- Removed workaround for a bug that existed in qh3 < 1.0 with cryptography in a concurrent (thread) environment.
- Avoid loading qh3 at runtime in order to improve import delay. It was used to probe HTTP/3 support. We compute it lazily from now on.
- Added the possibility to use the ``preemptive_quic_cache`` MutableMapping to exclude endpoints.
  If your implementation discard the recently set key/entry it will prevent the connection from upgrading itself.
