### PR TITLE
:bookmark: Release 2.7.912

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.7.912 (2024-05-27)
+====================
+
+- Fixed unset ``tls_version`` within ``ConnectionInfo`` when using the legacy TLSv1 protocol.
+- Fixed license metadata SPDX in package.
+- Fixed custom ssl context with ``OP_NO_TLSv1_3`` option that did not disable HTTP/3.
+- Fixed custom ssl context with ``assert_hostname=False`` parameter not forwarded to QUIC configuration.
+
 2.7.911 (2024-05-24)
 ====================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ build-backend = "hatchling.build"
 name = "urllib3-future"
 description = "urllib3.future is a powerful HTTP 1.1, 2, and 3 client with both sync and async interfaces"
 readme = "README.md"
+license-files = { paths = ["LICENSE.txt"] }
+license = "MIT"
 keywords = ["urllib", "httplib", "threadsafe", "filepost", "http", "https", "ssl", "pooling", "multiplexed", "concurrent", "dns", "dot", "doq", "doh", "dou", "dns-over-quic", "dns-over-https", "dns-over-tls", "async", "tasksafe"]
 authors = [
   {name = "Andrey Petrov", email = "andrey.petrov@shazow.net"}
@@ -28,6 +30,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.7.911"
+__version__ = "2.7.912"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -374,7 +374,9 @@ class AsyncHfaceBackend(AsyncBaseBackend):
 
             if cipher_tuple:
                 self.conn_info.cipher = cipher_tuple[0]
-                if cipher_tuple[1] == "TLSv1.1":
+                if cipher_tuple[1] == "TLSv1.0":
+                    self.conn_info.tls_version = ssl.TLSVersion.TLSv1
+                elif cipher_tuple[1] == "TLSv1.1":
                     self.conn_info.tls_version = ssl.TLSVersion.TLSv1_1
                 elif cipher_tuple[1] == "TLSv1.2":
                     self.conn_info.tls_version = ssl.TLSVersion.TLSv1_2

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -243,6 +243,13 @@ class HfaceBackend(BaseBackend):
                         ssl.DER_cert_to_PEM_cert(cert) for cert in ctx_root_certificates
                     )
 
+            if (
+                assert_hostname is None
+                and hasattr(ssl_context, "check_hostname")
+                and ssl_context.check_hostname is False
+            ):
+                assert_hostname = False
+
         if not allow_insecure and resolve_cert_reqs(cert_reqs) == ssl.CERT_NONE:
             allow_insecure = True
 
@@ -425,7 +432,9 @@ class HfaceBackend(BaseBackend):
 
             if cipher_tuple:
                 self.conn_info.cipher = cipher_tuple[0]
-                if cipher_tuple[1] == "TLSv1.1":
+                if cipher_tuple[1] == "TLSv1.0":
+                    self.conn_info.tls_version = ssl.TLSVersion.TLSv1
+                elif cipher_tuple[1] == "TLSv1.1":
                     self.conn_info.tls_version = ssl.TLSVersion.TLSv1_1
                 elif cipher_tuple[1] == "TLSv1.2":
                     self.conn_info.tls_version = ssl.TLSVersion.TLSv1_2

--- a/src/urllib3/contrib/hface/__init__.py
+++ b/src/urllib3/contrib/hface/__init__.py
@@ -1,4 +1,6 @@
 # Copyright 2022 Akamai Technologies, Inc
+# Largely rewritten in 2023 for urllib3-future
+# Copyright 2024 Ahmed Tahri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/urllib3/contrib/hface/_configuration.py
+++ b/src/urllib3/contrib/hface/_configuration.py
@@ -1,4 +1,6 @@
 # Copyright 2022 Akamai Technologies, Inc
+# Largely rewritten in 2023 for urllib3-future
+# Copyright 2024 Ahmed Tahri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/urllib3/contrib/hface/_error_codes.py
+++ b/src/urllib3/contrib/hface/_error_codes.py
@@ -1,4 +1,6 @@
 # Copyright 2022 Akamai Technologies, Inc
+# Largely rewritten in 2023 for urllib3-future
+# Copyright 2024 Ahmed Tahri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/urllib3/contrib/hface/_typing.py
+++ b/src/urllib3/contrib/hface/_typing.py
@@ -1,4 +1,6 @@
 # Copyright 2022 Akamai Technologies, Inc
+# Largely rewritten in 2023 for urllib3-future
+# Copyright 2024 Ahmed Tahri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/urllib3/contrib/hface/events/__init__.py
+++ b/src/urllib3/contrib/hface/events/__init__.py
@@ -1,4 +1,6 @@
 # Copyright 2022 Akamai Technologies, Inc
+# Largely rewritten in 2023 for urllib3-future
+# Copyright 2024 Ahmed Tahri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/urllib3/contrib/hface/events/_events.py
+++ b/src/urllib3/contrib/hface/events/_events.py
@@ -1,4 +1,6 @@
 # Copyright 2022 Akamai Technologies, Inc
+# Largely rewritten in 2023 for urllib3-future
+# Copyright 2024 Ahmed Tahri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/urllib3/contrib/hface/protocols/__init__.py
+++ b/src/urllib3/contrib/hface/protocols/__init__.py
@@ -1,4 +1,6 @@
 # Copyright 2022 Akamai Technologies, Inc
+# Largely rewritten in 2023 for urllib3-future
+# Copyright 2024 Ahmed Tahri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/urllib3/contrib/hface/protocols/_factories.py
+++ b/src/urllib3/contrib/hface/protocols/_factories.py
@@ -1,4 +1,6 @@
 # Copyright 2022 Akamai Technologies, Inc
+# Largely rewritten in 2023 for urllib3-future
+# Copyright 2024 Ahmed Tahri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/urllib3/contrib/hface/protocols/_protocols.py
+++ b/src/urllib3/contrib/hface/protocols/_protocols.py
@@ -1,4 +1,6 @@
 # Copyright 2022 Akamai Technologies, Inc
+# Largely rewritten in 2023 for urllib3-future
+# Copyright 2024 Ahmed Tahri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/urllib3/contrib/hface/protocols/http1/__init__.py
+++ b/src/urllib3/contrib/hface/protocols/http1/__init__.py
@@ -1,4 +1,6 @@
 # Copyright 2022 Akamai Technologies, Inc
+# Largely rewritten in 2023 for urllib3-future
+# Copyright 2024 Ahmed Tahri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/urllib3/contrib/hface/protocols/http1/_h11.py
+++ b/src/urllib3/contrib/hface/protocols/http1/_h11.py
@@ -1,4 +1,6 @@
 # Copyright 2022 Akamai Technologies, Inc
+# Largely rewritten in 2023 for urllib3-future
+# Copyright 2024 Ahmed Tahri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/urllib3/contrib/hface/protocols/http2/__init__.py
+++ b/src/urllib3/contrib/hface/protocols/http2/__init__.py
@@ -1,4 +1,6 @@
 # Copyright 2022 Akamai Technologies, Inc
+# Largely rewritten in 2023 for urllib3-future
+# Copyright 2024 Ahmed Tahri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/urllib3/contrib/hface/protocols/http2/_h2.py
+++ b/src/urllib3/contrib/hface/protocols/http2/_h2.py
@@ -1,4 +1,6 @@
 # Copyright 2022 Akamai Technologies, Inc
+# Largely rewritten in 2023 for urllib3-future
+# Copyright 2024 Ahmed Tahri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/urllib3/contrib/hface/protocols/http3/__init__.py
+++ b/src/urllib3/contrib/hface/protocols/http3/__init__.py
@@ -1,4 +1,6 @@
 # Copyright 2022 Akamai Technologies, Inc
+# Largely rewritten in 2023 for urllib3-future
+# Copyright 2024 Ahmed Tahri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/urllib3/contrib/hface/protocols/http3/_qh3.py
+++ b/src/urllib3/contrib/hface/protocols/http3/_qh3.py
@@ -1,4 +1,6 @@
 # Copyright 2022 Akamai Technologies, Inc
+# Largely rewritten in 2023 for urllib3-future
+# Copyright 2024 Ahmed Tahri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -668,7 +668,9 @@ def is_capable_for_quic(
     quic_disable: bool = False
 
     if ctx is not None:
-        if isinstance(ctx.maximum_version, ssl.TLSVersion):
+        if ssl.OP_NO_TLSv1_3 in ctx.options:
+            quic_disable = True
+        elif isinstance(ctx.maximum_version, ssl.TLSVersion):
             if (
                 ctx.maximum_version != ssl.TLSVersion.MAXIMUM_SUPPORTED
                 and ctx.maximum_version <= ssl.TLSVersion.TLSv1_2


### PR DESCRIPTION
- Fixed unset ``tls_version`` within ``ConnectionInfo`` when using the legacy TLSv1 protocol.
- Fixed license metadata SPDX in package.
- Fixed custom ssl context with ``OP_NO_TLSv1_3`` option that did not disable HTTP/3.
- Fixed custom ssl context with ``assert_hostname=False`` parameter not forwarded to QUIC configuration.
