### PR TITLE
:sparkle: Improve http.client deep compatibility offered by us

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.7.914 (2024-06-15)
+====================
+
+- Further improved compatibility with some third party programs that accessed hazardous materials within http.client standard library.
+- Add "ARM64" architecture for qh3 automatic installation on Windows.
+
 2.7.913 (2024-05-31)
 ====================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 requires-python = ">=3.7"
 dynamic = ["version"]
 dependencies = [
-  "qh3>=1.0.3,<2.0.0; (platform_system == 'Darwin' or platform_system == 'Windows' or platform_system == 'Linux') and (platform_machine == 'x86_64' or platform_machine == 's390x' or platform_machine == 'aarch64' or platform_machine == 'armv7l' or platform_machine == 'ppc64le' or platform_machine == 'ppc64' or platform_machine == 'AMD64' or platform_machine == 'arm64') and (platform_python_implementation == 'CPython' or (platform_python_implementation == 'PyPy' and python_version < '3.11'))",
+  "qh3>=1.0.3,<2.0.0; (platform_system == 'Darwin' or platform_system == 'Windows' or platform_system == 'Linux') and (platform_machine == 'x86_64' or platform_machine == 's390x' or platform_machine == 'aarch64' or platform_machine == 'armv7l' or platform_machine == 'ppc64le' or platform_machine == 'ppc64' or platform_machine == 'AMD64' or platform_machine == 'arm64' or platform_machine == 'ARM64') and (platform_python_implementation == 'CPython' or (platform_python_implementation == 'PyPy' and python_version < '3.11'))",
   "h11>=0.11.0,<1.0.0",
   "jh2>=5.0.3,<6.0.0",
 ]

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.7.913"
+__version__ = "2.7.914"

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -1047,6 +1047,7 @@ class HfaceBackend(BaseBackend):
             authority=self.host,
             port=self.port,
             stream_id=promise.stream_id,
+            sock=self.sock,  # kept for BC purposes[...] one should not try to read from it.
         )
 
         promise.response = self._response

--- a/test/contrib/asynchronous/test_resolver.py
+++ b/test/contrib/asynchronous/test_resolver.py
@@ -148,7 +148,7 @@ async def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
         quic_upgrade_via_dns_rr=False,
     )
 
-    assert any([_[-1][0] == "1.1.1.1" for _ in res])
+    assert any([_[-1][0] in ["1.1.1.1", "1.0.0.1"] for _ in res])
     await resolver.close()
 
 

--- a/test/contrib/test_resolver.py
+++ b/test/contrib/test_resolver.py
@@ -148,8 +148,7 @@ def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
         socket.SOCK_STREAM,
         quic_upgrade_via_dns_rr=False,
     )
-
-    assert any([_[-1][0] == "1.1.1.1" for _ in res])
+    assert any([_[-1][0] in ["1.1.1.1", "1.0.0.1"] for _ in res])
     resolver.close()
 
 


### PR DESCRIPTION
2.7.914 (2024-06-15)
====================

- Further improved compatibility with some third party programs that accessed hazardous materials within http.client standard library.
- Add "ARM64" architecture for qh3 automatic installation on Windows.

