### PR TITLE
:sparkle: HTTP/2 with prior knowledge, and HTTP/3 with prior knowledge through svn toggles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+2.8.900 (2024-06-24)
+====================
+
+- Support for HTTP/2 with prior knowledge over non-encrypted connection to leverage multiplexing in internal networks.
+  To leverage this feature, you have to disable HTTP/1.1 so that `urllib3-future` can infer your intent.
+  Disabling HTTP/1.1 is to be made as follow: ``PoolManager(disabled_svn={HttpVersion.h11})``.
+- Added raw data bytes counter in ``LowLevelResponse`` to help end-users track download speed accordingly if they use
+  brotli, gzip or zstd transfer-encoding during downloads.
+
 2.7.914 (2024-06-15)
 ====================
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - HTTP/1.1, HTTP/2 and HTTP/3 support.
 - Proxy support for HTTP and SOCKS.
 - Detailed connection inspection.
+- HTTP/2 with prior knowledge.
 - Multiplexed connection.
 - Mirrored Sync & Async.
 - Amazingly Fast.
@@ -84,7 +85,18 @@ Or...
 import urllib3_future
 ```
 
-Doing `import urllib3_future` is the safest option for you as there is a significant number of projects that
+Or... upgrade any of your containers with...
+
+```dockerfile
+FROM python:3.12
+
+# ... your installation ...
+RUN pip install .
+# then! (after every other pip call)
+RUN pip install urllib3-future
+```
+
+Doing `import urllib3_future` is the safest option if you start a project from scratch for you as there is a significant number of projects that
 require `urllib3`.
 
 ## Notes

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -1473,3 +1473,23 @@ This will enable up to 10 concurrent connections. To be clear, with that setting
 if your DNS resolver yield 6 addresses, you will spawn 6 tasks.
 
 .. warning:: Setting more than 20 is impracticable, DNS servers have a set limit of how many records can be returned. Most of the time, regular user are advised to leave the default value.
+
+HTTP/2 with prior knowledge
+---------------------------
+
+.. note:: Available since version 2.8+
+
+In some cases, mostly internal networks, you may desire to leverage multiplexing within a single HTTP connection without
+bothering with TLS (ALPN extensions) to discover and use HTTP/2 capabilities.
+
+You're in luck! urllib3-future now support talking with HTTP/2 server over an unencrypted connection.
+The only things you have to do is to disable HTTP/1.1 so that we can infer that you want to negotiate HTTP/2
+without any prior clear indicative that the remote can.
+
+Here is a simple example::
+
+    import urllib3
+
+    with urllib3.PoolManager(disabled_svn={urllib3.HttpVersion.h11}) as pm:
+        r = pm.urlopen("GET", "http://my-internal.svc.local/")
+

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -737,7 +737,7 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
                 tls_in_tls=tls_in_tls,
                 assert_hostname=self.assert_hostname,
                 assert_fingerprint=self.assert_fingerprint,
-                alpn_protocols=alpn_protocols,
+                alpn_protocols=alpn_protocols or None,
                 cert_data=self.cert_data,
                 key_data=self.key_data,
             )

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.7.914"
+__version__ = "2.8.900"

--- a/src/urllib3/backend/_async/_base.py
+++ b/src/urllib3/backend/_async/_base.py
@@ -63,6 +63,9 @@ class AsyncLowLevelResponse:
             content_length = self.msg.get("content-length")
             self.length = int(content_length) if content_length else None
 
+        #: not part of http.client but useful to track (raw) download speeds!
+        self.data_in_count = 0
+
         self._stream_id = stream_id
 
         self.__buffer_excess: bytes = b""
@@ -131,12 +134,16 @@ class AsyncLowLevelResponse:
         if self._eot and len(self.__buffer_excess) == 0:
             self.closed = True
 
+        size_in = len(data)
+
         if self.chunked:
             self.chunk_left = (
                 len(self.__buffer_excess) if self.__buffer_excess else None
             )
         elif self.length is not None:
-            self.length -= len(data)
+            self.length -= size_in
+
+        self.data_in_count += size_in
 
         return data
 

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -735,7 +735,7 @@ class HTTPSConnection(HTTPConnection):
                 tls_in_tls=tls_in_tls,
                 assert_hostname=self.assert_hostname,
                 assert_fingerprint=self.assert_fingerprint,
-                alpn_protocols=alpn_protocols,
+                alpn_protocols=alpn_protocols or None,
                 cert_data=self.cert_data,
                 key_data=self.key_data,
             )

--- a/test/with_traefik/test_protolevel.py
+++ b/test/with_traefik/test_protolevel.py
@@ -4,7 +4,13 @@ import socket
 
 import pytest
 
-from urllib3 import HTTPHeaderDict, HTTPSConnectionPool, ResolverDescription
+from urllib3 import (
+    HTTPConnectionPool,
+    HTTPHeaderDict,
+    HTTPSConnectionPool,
+    HttpVersion,
+    ResolverDescription,
+)
 from urllib3.exceptions import InsecureRequestWarning, ProtocolError
 from urllib3.util import parse_url
 from urllib3.util.request import SKIP_HEADER
@@ -104,3 +110,18 @@ class TestProtocolLevel(TraefikTestCase):
 
                 assert resp.status == 200
                 assert resp.version == 30
+
+    def test_http2_with_prior_knowledge(self) -> None:
+        with HTTPConnectionPool(
+            self.host,
+            self.http_port,
+            disabled_svn={HttpVersion.h11},
+        ) as p:
+            resp = p.request(
+                "GET",
+                f"{self.http_url}/get",
+                retries=False,
+            )
+
+            assert resp.status == 200
+            assert resp.version == 20


### PR DESCRIPTION
It was already possible to force HTTP/3 using a fake entry in the quic preemptive cache, but now you can leverage the main protocol toggles to do it.


