### PR TITLE
:art: minor adjustments for compatibility purposes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.8.901 (2024-06-27)
+====================
+
+- Improved compatibility with httplib exception for ``IncompleteRead`` that did not behave exactly like expected (repr/str format over it).
+- The metric TLS handshake delay was wrongfully set when using HTTP/2 over cleartext.
+- Fixed compatibility with some third-party mocking library that are injecting io.BytesIO in HTTPResponse.
+  In some cases, ``IncompleteRead`` might not be raised like expected.
+
 2.8.900 (2024-06-24)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.8.900"
+__version__ = "2.8.901"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -477,7 +477,11 @@ class AsyncHfaceBackend(AsyncBaseBackend):
             # save the quic ticket for session resumption
             self.__session_ticket = self._protocol.session_ticket
 
-        if hasattr(self, "_connect_timings"):
+        if (
+            self.conn_info.certificate_der
+            and hasattr(self, "_connect_timings")
+            and not self.conn_info.tls_handshake_latency
+        ):
             self.conn_info.tls_handshake_latency = (
                 datetime.now(tz=timezone.utc) - self._connect_timings[-1]
             )

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -539,7 +539,11 @@ class HfaceBackend(BaseBackend):
             # save the quic ticket for session resumption
             self.__session_ticket = self._protocol.session_ticket
 
-        if hasattr(self, "_connect_timings"):
+        if (
+            self.conn_info.certificate_der
+            and hasattr(self, "_connect_timings")
+            and not self.conn_info.tls_handshake_latency
+        ):
             self.conn_info.tls_handshake_latency = (
                 datetime.now(tz=timezone.utc) - self._connect_timings[-1]
             )

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -265,18 +265,16 @@ class IncompleteRead(ProtocolError):
     for ``partial`` to avoid creating large objects on streamed reads.
     """
 
-    def __init__(self, partial: int, expected: int) -> None:
-        super().__init__(
-            f"peer closed connection without sending complete message body (received {partial} bytes, expected {expected} more)"
-        )
+    def __init__(self, partial: int, expected: int | None = None) -> None:
         self.partial = partial
         self.expected = expected
 
     def __repr__(self) -> str:
-        return "IncompleteRead(%i bytes read, %i more expected)" % (
-            self.partial,
-            self.expected,
-        )
+        if self.expected is not None:
+            return f"IncompleteRead({self.partial} bytes read, {self.expected} more expected)"
+        return f"IncompleteRead({self.partial} bytes read)"
+
+    __str__ = object.__str__
 
 
 class InvalidChunkLength(ProtocolError):

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -138,7 +138,7 @@ class TestResponse:
 
         r = HTTPResponse(fp, preload_content=True)
 
-        assert fp.tell() == len(b"foo")
+        assert fp.closed is True
         assert r.data == b"foo"
 
     def test_no_preload(self) -> None:
@@ -148,7 +148,7 @@ class TestResponse:
 
         assert fp.tell() == 0
         assert r.data == b"foo"
-        assert fp.tell() == len(b"foo")
+        assert fp.closed is True
 
     def test_decode_bad_data(self) -> None:
         fp = BytesIO(b"\x00" * 10)

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -2047,7 +2047,7 @@ class TestBadContentLength(SocketDummyServerTestCase):
             )
             data = get_response.stream(100)
             with pytest.raises(
-                IncompleteRead, match="received 12 bytes, expected 10 more"
+                IncompleteRead, match=r"12 bytes read\, 10 more expected"
             ):
                 next(data)
             done_event.set()


### PR DESCRIPTION
2.8.901 (2024-06-27)
====================

- Improved compatibility with httplib exception for ``IncompleteRead`` that did not behave exactly like expected (repr/str format over it).
- The metric TLS handshake delay was wrongfully set when using HTTP/2 over cleartext.
- Fixed compatibility with some third-party mocking library that are injecting io.BytesIO in HTTPResponse.
  In some cases, ``IncompleteRead`` might not be raised like expected.
