### PR TITLE
:bookmark: Release 2.8.903

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.8.903 (2024-07-17)
+====================
+
+- Added ``IS_PYOPENSSL`` constant that is exposed by upstream in ``urllib3.util.ssl_`` submodule.
+- Fixed missing exception (``ImportError``) when importing ``urllib3.contrib.pyopenssl`` when PyOpenSSL isn't present in environment.
+- Lowered and simplified testing requirements for HTTP/2, and HTTP/3.
+- Added ``boto3``, ``sphinx``, and ``requests`` to our downstream test cases (nox).
+
 2.8.902 (2024-07-07)
 ====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.8.902"
+__version__ = "2.8.903"

--- a/traefik/macos.sh
+++ b/traefik/macos.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 # MacOS in GitHub Actions does not ship with Docker due to legal reasons
 # we have to circumvent that limitation by using Colima as a viable alternative.
+set -e
 sudo security authorizationdb write com.apple.trust-settings.admin allow
 brew install docker
 brew install docker-compose


### PR DESCRIPTION
- Added ``IS_PYOPENSSL`` constant that is exposed by upstream in ``urllib3.util.ssl_`` submodule.
- Fixed missing exception (``ImportError``) when importing ``urllib3.contrib.pyopenssl`` when PyOpenSSL isn't present in environment.
- Lowered and simplified testing requirements for HTTP/2, and HTTP/3.
- Added ``boto3``, ``sphinx``, and ``requests`` to our downstream test cases (nox).
