### PR TITLE
:bookmark: Release 2.8.904

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        downstream: [botocore, niquests, requests, boto3, sphinx]
+        downstream: [botocore, niquests, requests, boto3, sphinx, docker]
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -24,10 +24,16 @@ jobs:
       - name: "Setup Python"
         uses: "actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1"
         with:
-          python-version: "3.x"
+          python-version: "3.11"
 
       - name: "Install dependencies"
         run: python -m pip install --upgrade nox
+
+      - name: "Undo Docker Config: docker-py"
+        if: matrix.downstream == 'docker'
+        run: | 
+          docker logout
+          rm -rf ~/.docker
 
       - name: "Run downstream tests"
         run: nox -s downstream_${{ matrix.downstream }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.8.904 (2024-07-18)
+====================
+
+- Relaxed h11 constraint around "pending proposal" and coming server event about upgrade.
+  This is made to ensure near perfect compatibility against the legacy urllib3 which is based on http.client.
+- Fixed h11 yielding bytearray instead of bytes in rare circumstances.
+- Added ``docker-py`` in our CI/integration pipeline.
+
 2.8.903 (2024-07-17)
 ====================
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ less forgiven in case of bugs than the original urllib3. For good~ish reasons, w
 
 The matter is taken with utmost seriousness and everyone can inspect this package at will.
 
-We regularly test this fork against the most used packages (that depend on urllib3).
+We regularly test this fork against the most used packages (that depend on urllib3, especially those who plunged deep into urllib3 internals).
 
 Finally, rare is someone "fully aware" of their transitive dependencies. And "urllib3" is forced
 into your environments regardless of your preferences.
@@ -150,6 +150,17 @@ Here are some of the reasons (not exhaustive) we choose to work this way:
 - C) We don't have to reinvent the wheel.
 - D) Some of our partners started noticing that HTTP/1 started to be disabled by some webservices in favor of HTTP/2+
   So, this fork can unblock them at (almost) zero cost.
+
+**OK... then what do I gain from this?**
+
+- It is faster than its counterpart, we measured gain up to 2X faster in a multithreaded environment using a http2 endpoint.
+- It works well with gevent / does not conflict. We do not use the standard queue class from stdlib as it does not fit http2+ constraints.
+- Leveraging recent protocols like http2 and http3 transparently. Code and behaviors does not change one bit.
+- You do not depend on the standard library to emit http/1 requests, and that is actually a good news. http.client 
+  has numerous known flaws but cannot be fixed as we speak. (e.g. urllib3 is based on http.client)
+- There a ton of other improvement you may leverage, but for that you will need to migrate to Niquests or update your code
+  to enable specific capabilities, like but not limited to: "DNS over QUIC, HTTP" / "Happy Eyeballs" / "Native Asyncio" / "Advanced Multiplexing".
+- Non-blocking IO with concurrent streams/requests. And yes, transparently.
 
 - **Is this funded?**
 

--- a/ci/0005-DockerPy-FixBadChunk.patch
+++ b/ci/0005-DockerPy-FixBadChunk.patch
@@ -1,0 +1,35 @@
+diff --git a/tests/unit/api_test.py b/tests/unit/api_test.py
+index 3ce127b3..cea350ee 100644
+--- a/tests/unit/api_test.py
++++ b/tests/unit/api_test.py
+@@ -330,6 +330,7 @@ class DockerApiTest(BaseAPIClientTest):
+         content_str = json.dumps(content)
+         content_str = content_str.encode('utf-8')
+         body = io.BytesIO(content_str)
++        body.close = lambda: None  # necessary because get closed after initial preloading.
+ 
+         # mock a stream interface
+         raw_resp = urllib3.HTTPResponse(body=body)
+@@ -445,7 +446,7 @@ class UnixSocketStreamTest(unittest.TestCase):
+             b'HTTP/1.1 200 OK\r\n'
+             b'Transfer-Encoding: chunked\r\n'
+             b'\r\n'
+-        ) + b'\r\n'.join(lines)
++        ) + b'\r\n'.join(lines) + b'\r\n'  # fix invalid chunked: missing extraneous RC+LF
+ 
+         with APIClient(
+                 base_url=f"http+unix://{self.socket_file}",
+@@ -460,9 +461,11 @@ class UnixSocketStreamTest(unittest.TestCase):
+                     if i == 4:
+                         raise e
+ 
+-            assert list(stream) == [
++            # assert assume that sock will yield on each chunk
++            # but not necessarily true.
++            assert b"".join(list(stream)) == b"".join([
+                 str(i).encode() for i in range(50)
+-            ]
++            ])
+ 
+ 
+ class TCPSocketStreamTest(unittest.TestCase):

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import typing
-import warnings
 from collections import OrderedDict
 from enum import Enum, auto
 from functools import lru_cache
@@ -72,7 +71,9 @@ class RecentlyUsedContainer(typing.Generic[_KT, _VT], typing.MutableMapping[_KT,
     """
     Provides a thread-safe dict-like container which maintains up to
     ``maxsize`` keys while throwing away the least-recently-used keys beyond
-    ``maxsize``.
+    ``maxsize``. Caution: RecentlyUsedContainer is deprecated and scheduled for
+    removal in a next major of urllib3.future. It has been replaced by a more
+    suitable implementation in ``urllib3.util.traffic_police``.
 
     :param maxsize:
         Maximum number of recent elements to retain.
@@ -97,13 +98,6 @@ class RecentlyUsedContainer(typing.Generic[_KT, _VT], typing.MutableMapping[_KT,
         self.dispose_func = dispose_func
         self._container = OrderedDict()
         self.lock = RLock()
-
-        warnings.warn(
-            "RecentlyUsedContainer is deprecated and scheduled for removal in urllib3.future v3. "
-            "It has been replaced by a more suitable implementation in urllib3.util.traffic_police.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
     def __getitem__(self, key: _KT) -> _VT:
         # Re-insert the item, moving it to the end of the eviction line.

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.8.903"
+__version__ = "2.8.904"


### PR DESCRIPTION
- Relaxed h11 constraint around "pending proposal" and coming server event about upgrade. This is made to ensure near perfect compatibility against the legacy urllib3 which is based on http.client.
- Fixed h11 yielding bytearray instead of bytes in rare circumstances.
- Added ``docker-py`` in our CI/integration pipeline.

<!---
Hello!

If this is your first PR to urllib3.future please review the Contributing Guide:
https://urllib3future.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
