### PR TITLE
:bookmark: Release 2.8.905

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,17 @@
+2.8.905 (2024-08-04)
+====================
+
+- Fixed wrong upgrade attempt to QUIC when using a SOCKS proxy. Any usage of a proxy disable HTTP/3 over QUIC as per documented.
+  until proper support is implemented in a next minor version.
+- Backported upstream urllib3 #3434: util/ssl: make code resilient to missing hash functions.
+  In certain environments such as in a FIPS enabled system, certain algorithms such as md5 may be unavailable. Due
+  to the importing of such a module on a system where it is unavailable, urllib3(-future) will crash and is unusable.
+  https://github.com/urllib3/urllib3/pull/3434
+- Backported upstream urllib3 GHSA-34jh-p97f-mpxf: Strip Proxy-Authorization header on redirects.
+  Added the ``Proxy-Authorization`` header to the list of headers to strip from requests when redirecting to a different host.
+  As before, different headers can be set via ``Retry.remove_headers_on_redirect``.
+- Fixed state-machine desync on a rare scenario when uploading a body using HTTP/3 over QUIC.
+
 2.8.904 (2024-07-18)
 ====================
 

--- a/README.md
+++ b/README.md
@@ -141,26 +141,29 @@ We agree that this solution isn't perfect and actually put a lot of pressure on 
 
 Here are some of the reasons (not exhaustive) we choose to work this way:
 
-- A) Some major companies may not be able to touch the production code but can "change/swap" dependencies.
-- B) urllib3-future main purpose is to fuel Niquests, which is itself a drop-in replacement of Requests.
+> A) Some major companies may not be able to touch the production code but can "change/swap" dependencies.
+
+> B) urllib3-future main purpose is to fuel Niquests, which is itself a drop-in replacement of Requests.
   And there's more than 100 packages commonly used that plug into Requests, but the code (of the packages) invoke urllib3
   So... We cannot fork those 100+ projects to patch urllib3 usage, it is impossible at the moment, given our means.
   Requests trapped us, and there should be a way to escape the nonsense "migrate" to another http client that reinvent
   basic things and interactions.
-- C) We don't have to reinvent the wheel.
-- D) Some of our partners started noticing that HTTP/1 started to be disabled by some webservices in favor of HTTP/2+
+
+> C) We don't have to reinvent the wheel.
+
+> D) Some of our partners started noticing that HTTP/1 started to be disabled by some webservices in favor of HTTP/2+
   So, this fork can unblock them at (almost) zero cost.
 
-**OK... then what do I gain from this?**
+- **OK... then what do I gain from this?**
 
-- It is faster than its counterpart, we measured gain up to 2X faster in a multithreaded environment using a http2 endpoint.
-- It works well with gevent / does not conflict. We do not use the standard queue class from stdlib as it does not fit http2+ constraints.
-- Leveraging recent protocols like http2 and http3 transparently. Code and behaviors does not change one bit.
-- You do not depend on the standard library to emit http/1 requests, and that is actually a good news. http.client 
+1. It is faster than its counterpart, we measured gain up to 2X faster in a multithreaded environment using a http2 endpoint.
+2. It works well with gevent / does not conflict. We do not use the standard queue class from stdlib as it does not fit http2+ constraints.
+3. Leveraging recent protocols like http2 and http3 transparently. Code and behaviors does not change one bit.
+4. You do not depend on the standard library to emit http/1 requests, and that is actually a good news. http.client 
   has numerous known flaws but cannot be fixed as we speak. (e.g. urllib3 is based on http.client)
-- There a ton of other improvement you may leverage, but for that you will need to migrate to Niquests or update your code
+5. There a ton of other improvement you may leverage, but for that you will need to migrate to Niquests or update your code
   to enable specific capabilities, like but not limited to: "DNS over QUIC, HTTP" / "Happy Eyeballs" / "Native Asyncio" / "Advanced Multiplexing".
-- Non-blocking IO with concurrent streams/requests. And yes, transparently.
+6. Non-blocking IO with concurrent streams/requests. And yes, transparently.
 
 - **Is this funded?**
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 coverage>=7.2.7,<=7.4.1
 tornado>=6.2,<=6.4
+# 2.5 seems to break test_proxy_rejection by hanging forever
 python-socks==2.4.4
 pytest==7.4.4
 pytest-timeout==2.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ filterwarnings = [
     '''ignore:A plugin raised an exception during''',
     '''ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning''',
     '''ignore:Exception in thread:pytest.PytestUnhandledThreadExceptionWarning''',
+    '''ignore:The `hash` argument is deprecated in favor of `unsafe_hash`:DeprecationWarning''',
 ]
 
 [tool.isort]

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.8.904"
+__version__ = "2.8.905"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -825,7 +825,12 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         # We assume it is passed as-is (meaning 'keep-alive' lower-cased)
         # It may(should) break the connection.
         if not support_te_chunked:
-            if encoded_header in {b"transfer-encoding", b"connection"}:
+            if encoded_header in {
+                b"transfer-encoding",
+                b"connection",
+                b"upgrade",
+                b"keep-alive",
+            }:
                 return
 
         if self.__expected_body_length is None and encoded_header == b"content-length":
@@ -1105,6 +1110,14 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                         self._promises_per_stream[rp.stream_id] = rp
 
                         raise EarlyResponse(promise=rp)
+
+                    while True:
+                        data_out = self._protocol.bytes_to_send()
+
+                        if not data_out:
+                            break
+
+                        await self.sock.sendall(data_out)
 
                 if self.__remaining_body_length:
                     self.__remaining_body_length -= len(data)

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -1,7 +1,7 @@
 """
 This module contains provisional support for SOCKS proxies from within
 urllib3. This module supports SOCKS4, SOCKS4A (an extension of SOCKS4), and
-SOCKS5. To enable its functionality, either install PySocks or install this
+SOCKS5. To enable its functionality, either install python-socks or install this
 module with the ``socks`` extra.
 
 The SOCKS implementation supports the full range of urllib3 features. It also
@@ -40,14 +40,13 @@ with the proxy:
 
 from __future__ import annotations
 
-from python_socks import (  # type: ignore[import-untyped]
-    ProxyConnectionError,
-    ProxyError,
-    ProxyTimeoutError,
-    ProxyType,
-)
-
 try:
+    from python_socks import (  # type: ignore[import-untyped]
+        ProxyConnectionError,
+        ProxyError,
+        ProxyTimeoutError,
+        ProxyType,
+    )
     from python_socks.sync import Proxy  # type: ignore[import-untyped]
 
     from ._socks_override import AsyncioProxy
@@ -89,6 +88,7 @@ from .._async.connection import AsyncHTTPConnection, AsyncHTTPSConnection
 from .._async.connectionpool import AsyncHTTPConnectionPool, AsyncHTTPSConnectionPool
 from .._async.poolmanager import AsyncPoolManager
 from .._typing import _TYPE_SOCKS_OPTIONS
+from ..backend import HttpVersion
 
 # synchronous part
 from ..connection import HTTPConnection, HTTPSConnection
@@ -257,6 +257,11 @@ class SOCKSProxyManager(PoolManager):
         }
         connection_pool_kw["_socks_options"] = socks_options
 
+        if "disabled_svn" not in connection_pool_kw:
+            connection_pool_kw["disabled_svn"] = set()
+
+        connection_pool_kw["disabled_svn"].add(HttpVersion.h3)
+
         super().__init__(num_pools, headers, **connection_pool_kw)
 
         self.pool_classes_by_scheme = SOCKSProxyManager.pool_classes_by_scheme
@@ -414,6 +419,11 @@ class AsyncSOCKSProxyManager(AsyncPoolManager):
             "rdns": rdns,
         }
         connection_pool_kw["_socks_options"] = socks_options
+
+        if "disabled_svn" not in connection_pool_kw:
+            connection_pool_kw["disabled_svn"] = set()
+
+        connection_pool_kw["disabled_svn"].add(HttpVersion.h3)
 
         super().__init__(num_pools, headers, **connection_pool_kw)
 

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -935,6 +935,11 @@ class ProxyManager(PoolManager):
         connection_pool_kw["_proxy_headers"] = self.proxy_headers
         connection_pool_kw["_proxy_config"] = self.proxy_config
 
+        if "disabled_svn" not in connection_pool_kw:
+            connection_pool_kw["disabled_svn"] = set()
+
+        connection_pool_kw["disabled_svn"].add(HttpVersion.h3)
+
         super().__init__(num_pools, headers, **connection_pool_kw)
 
     def connection_from_host(

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -190,7 +190,9 @@ class Retry:
     RETRY_AFTER_STATUS_CODES = frozenset([413, 429, 503])
 
     #: Default headers to be used for ``remove_headers_on_redirect``
-    DEFAULT_REMOVE_HEADERS_ON_REDIRECT = frozenset(["Cookie", "Authorization"])
+    DEFAULT_REMOVE_HEADERS_ON_REDIRECT = frozenset(
+        ["Cookie", "Authorization", "Proxy-Authorization"]
+    )
 
     #: Default maximum backoff time.
     DEFAULT_BACKOFF_MAX = 120

--- a/test/contrib/asynchronous/test_resolver.py
+++ b/test/contrib/asynchronous/test_resolver.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import platform
 import socket
 from test import requires_network
 
@@ -64,9 +65,11 @@ async def test_null_resolver(hostname: str, expect_error: bool) -> None:
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
             QUICResolver,
-            marks=pytest.mark.skipif(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
+                strict=False,
             ),
         ),
         ("dns://dns.nextdns.io", None),
@@ -85,9 +88,11 @@ async def test_null_resolver(hostname: str, expect_error: bool) -> None:
         pytest.param(
             "doq://dns.nextdns.io/?implementation=qh3&timeout=1",
             QUICResolver,
-            marks=pytest.mark.skipif(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
+                strict=False,
             ),
         ),
     ],
@@ -127,9 +132,11 @@ async def test_url_resolver(
         "dot://one.one.one.one",
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.skipif(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
+                strict=False,
             ),
         ),
         "doh+google://",
@@ -165,9 +172,11 @@ async def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
         "dot://one.one.one.one",
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.skipif(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
+                strict=False,
             ),
         ),
     ],
@@ -303,9 +312,11 @@ async def test_many_resolver_host_constraint_distribution() -> None:
         "doh+cloudflare://",
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.skipif(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
+                strict=False,
             ),
         ),
         "dot://one.one.one.one",
@@ -392,9 +403,11 @@ async def test_doh_rfc8484(dns_url: str) -> None:
         "doh+cloudflare://",
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.skipif(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
+                strict=False,
             ),
         ),
         "dot://one.one.one.one",
@@ -479,9 +492,11 @@ async def test_many_resolver_task_safe() -> None:
         "doh+cloudflare://",
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.skipif(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
+                strict=False,
             ),
         ),
         "dot://one.one.one.one",
@@ -518,9 +533,11 @@ async def test_resolver_recycle(dns_url: str) -> None:
         "doh+cloudflare://",
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.skipif(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
+                strict=False,
             ),
         ),
         "dot://one.one.one.one",
@@ -545,9 +562,11 @@ async def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
         "doh+cloudflare://",
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.skipif(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
+                strict=False,
             ),
         ),
         "dot://one.one.one.one",
@@ -586,9 +605,11 @@ async def test_ipv6_always_preferred(dns_url: str) -> None:
         "doh+cloudflare://",
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.skipif(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+            marks=pytest.mark.xfail(
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
+                strict=False,
             ),
         ),
         "dot://one.one.one.one",

--- a/test/contrib/test_resolver.py
+++ b/test/contrib/test_resolver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import platform
 import socket
 from concurrent.futures import ThreadPoolExecutor
 from socket import AddressFamily, SocketKind
@@ -65,8 +66,9 @@ def test_null_resolver(hostname: str, expect_error: bool) -> None:
             "doq://dns.nextdns.io/?timeout=1",
             QUICResolver,
             marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
                 strict=False,
             ),
         ),
@@ -87,8 +89,9 @@ def test_null_resolver(hostname: str, expect_error: bool) -> None:
             "doq://dns.nextdns.io/?implementation=qh3&timeout=1",
             QUICResolver,
             marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
                 strict=False,
             ),
         ),
@@ -129,8 +132,9 @@ def test_url_resolver(
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
             marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
                 strict=False,
             ),
         ),
@@ -166,8 +170,9 @@ def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
             marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
                 strict=False,
             ),
         ),
@@ -300,8 +305,9 @@ def test_many_resolver_host_constraint_distribution() -> None:
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
             marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
                 strict=False,
             ),
         ),
@@ -388,8 +394,9 @@ def test_doh_rfc8484(dns_url: str) -> None:
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
             marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
                 strict=False,
             ),
         ),
@@ -494,8 +501,9 @@ def test_many_resolver_thread_safe() -> None:
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
             marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
                 strict=False,
             ),
         ),
@@ -533,8 +541,9 @@ def test_resolver_recycle(dns_url: str) -> None:
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
             marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
                 strict=False,
             ),
         ),
@@ -560,8 +569,9 @@ def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
             marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
                 strict=False,
             ),
         ),
@@ -601,8 +611,9 @@ def test_ipv6_always_preferred(dns_url: str) -> None:
         pytest.param(
             "doq://dns.nextdns.io/?timeout=1",
             marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None,
-                reason="Github Action CI Unpredictable",
+                os.environ.get("CI", None) is not None
+                and platform.system() != "Darwin",
+                reason="Github Action CI: Network Unreachable UDP/QUIC",
                 strict=False,
             ),
         ),

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -334,7 +334,11 @@ class TestRetry:
     def test_retry_default_remove_headers_on_redirect(self) -> None:
         retry = Retry()
 
-        assert retry.remove_headers_on_redirect == {"authorization", "cookie"}
+        assert retry.remove_headers_on_redirect == {
+            "authorization",
+            "proxy-authorization",
+            "cookie",
+        }
 
     def test_retry_set_remove_headers_on_redirect(self) -> None:
         retry = Retry(remove_headers_on_redirect=["X-API-Secret"])

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -973,6 +973,26 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         assert ctx.minimum_version == self.tls_version()
         assert ctx.maximum_version == self.tls_version()
 
+    def test_assert_missing_hashfunc(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fingerprint = "55:39:BF:70:05:12:43:FA:1F:D1:BF:4E:E8:1B:07:1D"
+        with HTTPSConnectionPool(
+            "localhost",
+            self.port,
+            cert_reqs="CERT_REQUIRED",
+            ca_certs=DEFAULT_CA,
+            assert_fingerprint=(fingerprint),
+            ssl_minimum_version=self.tls_version(),
+        ) as https_pool:
+            digest_length = len(fingerprint.replace(":", "").lower())
+            monkeypatch.setitem(urllib3.util.ssl_.HASHFUNC_MAP, digest_length, None)
+            with pytest.raises(MaxRetryError) as cm:
+                https_pool.request("GET", "/", retries=0)
+            assert type(cm.value.reason) is SSLError
+            assert (
+                f"Hash function implementation unavailable for fingerprint length: {digest_length}"
+                in str(cm.value.reason)
+            )
+
 
 @pytest.mark.usefixtures("requires_tlsv1")
 class TestHTTPS_TLSv1(TestHTTPS):

--- a/test/with_traefik/test_send_data.py
+++ b/test/with_traefik/test_send_data.py
@@ -55,28 +55,44 @@ class TestPostBody(TraefikTestCase):
             ca_certs=self.ca_authority,
             resolver=self.test_resolver,
         ) as p:
+            # first will be done in HTTP/2
+            # two others using HTTP/3
             for i in range(3):
                 if isinstance(body, BytesIO):
                     body.seek(0, 0)
-                    # traefik bug with http3, should not happen!
-                    if i > 0:
-                        headers = {"content-length": "-1"}
-                    else:
-                        headers = {}
-                else:
-                    headers = {}
 
-                resp = p.request(
-                    method, f"/{method.lower()}", body=body, headers=headers
+                # in some cases, urllib3 cannot infer in advance the body full length
+                # it will trigger a stream upload
+                # http1.1 => (Transfer-Encoding: chunked) legacy algorithm
+                # http2+  => send data frames, server aware of the end with the FIN bit.
+                expect_no_content_length = isinstance(body, BytesIO) or hasattr(
+                    body, "__next__"
                 )
+
+                # traefik bug with http3, should not happen!
+                # see https://github.com/traefik/traefik/issues/10185
+                if i > 0 and expect_no_content_length:
+                    pytest.skip(
+                        "traefik bug with http3 forbid stream upload without content-length"
+                    )
+
+                resp = p.request(method, f"/{method.lower()}", body=body)
 
                 assert resp.status == 200
                 assert resp.version == (20 if i == 0 else 30)
 
+                echo_data_from_httpbin = resp.json()["data"]
+                need_b64_decode = echo_data_from_httpbin.startswith(
+                    "data:application/octet-stream;base64,"
+                )
+
+                if need_b64_decode:
+                    echo_data_from_httpbin = b64decode(echo_data_from_httpbin[37:])
+
                 payload_seen_by_server: bytes = (
-                    b64decode(resp.json()["data"][37:])
-                    if not isinstance(body, str)
-                    else resp.json()["data"].encode()
+                    echo_data_from_httpbin
+                    if isinstance(echo_data_from_httpbin, bytes)
+                    else echo_data_from_httpbin.encode()
                 )
 
                 if isinstance(body, str):


### PR DESCRIPTION
- Fixed wrong upgrade attempt to QUIC when using a SOCKS proxy. Any usage of a proxy disable HTTP/3 over QUIC as per documented. until proper support is implemented in a next minor version.
- Backported upstream urllib3 #3434: util/ssl: make code resilient to missing hash functions. In certain environments such as in a FIPS enabled system, certain algorithms such as md5 may be unavailable. Due to the importing of such a module on a system where it is unavailable, urllib3(-future) will crash and is unusable. https://github.com/urllib3/urllib3/pull/3434
- Backported upstream urllib3 GHSA-34jh-p97f-mpxf: Strip Proxy-Authorization header on redirects. Added the ``Proxy-Authorization`` header to the list of headers to strip from requests when redirecting to a different host. As before, different headers can be set via ``Retry.remove_headers_on_redirect``.
- Fixed state-machine desync on a rare scenario when uploading a body using HTTP/3 over QUIC.
