### PR TITLE
fix: Ensure str header values in connection.py

### DIFF
--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -424,6 +424,13 @@ class AsyncHTTPConnection(AsyncHfaceBackend):
                 value = str(content_length)
             if enforce_charset_transparency and header.lower() == "content-type":
                 value_lower = value.lower()
+                # even if not "officially" supported
+                # some may send values as bytes, and we have to
+                # cast "temporarily" the value
+                # this case is already covered in the parent class.
+                if isinstance(value_lower, bytes):
+                    value_lower = value_lower.decode()
+                    value = value.decode()
                 if "charset" not in value_lower:
                     value = value.strip("; ")
                     value = f"{value}; charset=utf-8"

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -427,11 +427,17 @@ class HTTPConnection(HfaceBackend):
         if "user-agent" not in header_keys:
             self.putheader("User-Agent", _get_default_user_agent())
         for header, value in headers.items():
-            value = to_str(value)
             if overrule_content_length and header.lower() == "content-length":
                 value = str(content_length)
             if enforce_charset_transparency and header.lower() == "content-type":
                 value_lower = value.lower()
+                # even if not "officially" supported
+                # some may send values as bytes, and we have to
+                # cast "temporarily" the value
+                # this case is already covered in the parent class.
+                if isinstance(value_lower, bytes):
+                    value_lower = value_lower.decode()
+                    value = value.decode()
                 if "charset" not in value_lower:
                     value = value.strip("; ")
                     value = f"{value}; charset=utf-8"

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -427,6 +427,7 @@ class HTTPConnection(HfaceBackend):
         if "user-agent" not in header_keys:
             self.putheader("User-Agent", _get_default_user_agent())
         for header, value in headers.items():
+            value = to_str(value)
             if overrule_content_length and header.lower() == "content-length":
                 value = str(content_length)
             if enforce_charset_transparency and header.lower() == "content-type":

--- a/test/with_traefik/test_send_data.py
+++ b/test/with_traefik/test_send_data.py
@@ -25,6 +25,30 @@ class TestPostBody(TraefikTestCase):
             assert "Content-Length" in resp.json()["headers"]
             assert resp.json()["headers"]["Content-Length"][0] == "4"
 
+    def test_overrule_unicode_content_length_with_bytes_content_type(
+        self,
+    ) -> None:
+        with HTTPSConnectionPool(
+            self.host,
+            self.https_port,
+            ca_certs=self.ca_authority,
+            resolver=self.test_resolver,
+        ) as p:
+            resp = p.request(
+                "POST",
+                "/post",
+                body="🚀",
+                headers={"Content-Length": "1", "Content-Type": b"plain/text"},  # type: ignore[dict-item]
+            )
+
+            assert resp.status == 200
+            assert "Content-Length" in resp.json()["headers"]
+            assert "Content-Type" in resp.json()["headers"]
+            assert (
+                resp.json()["headers"]["Content-Type"][0] == "plain/text; charset=utf-8"
+            )
+            assert resp.json()["headers"]["Content-Length"][0] == "4"
+
     @pytest.mark.parametrize(
         "method",
         [


### PR DESCRIPTION
<!---
Hello!

If this is your first PR to urllib3.future please review the Contributing Guide:
https://urllib3future.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
This PR aims to fix a bug I encountered when using a library that depends on urllib3.future in the same venv as boto3. This is I believe the same issue raised in #133.

Please let me know if there's a more robust change we could make than just converting to string in-place.