### PR TITLE
:bookmark: Release 2.8.906

### DIFF
--- a/.github/workflows/ci-dead-things.yml
+++ b/.github/workflows/ci-dead-things.yml
@@ -1,0 +1,60 @@
+name: CI for EOL 3rd parties
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: "read-all"
+
+concurrency:
+  group: ci-dead-things-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+
+  dead-libressl:
+    name: Ensure LibreSSL <2.8
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    continue-on-error: true
+
+    steps:
+      - name: "Checkout repository"
+        uses: "actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608"
+
+      - name: "Run against Python 3.7 built with LibreSSL 2.7.4"
+        run: ./ci/run_legacy_libressl.sh
+
+  dead-openssl:
+    name: Ensure OpenSSL <1.1.1
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: "Checkout repository"
+        uses: "actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608"
+
+      - name: "Run against Python 3.7 built with OpenSSL 1.0.2q"
+        run: ./ci/run_legacy_openssl.sh
+
+  dead-pip:
+    name: Ensure pip <21.2.4
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: "Checkout repository"
+        uses: "actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608"
+
+      - name: "Setup Python"
+        uses: "actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1"
+        with:
+          python-version: "3.7"
+
+      - name: "Enforce pip 20.x"
+        run: python -m pip install "pip<21"
+
+      - name: "Ensure that urllib3-future can be installed"
+        run: python -m pip install .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,12 @@ jobs:
         uses: "actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608"
 
       - name: "Traefik: Prerequisites - Colima (MacOS)"
+        uses: nick-fields/retry@v3
         if: ${{ matrix.traefik-server && contains(matrix.os, 'mac') }}
-        run: ./traefik/macos.sh
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: ./traefik/macos.sh
 
       - name: "Setup Python ${{ matrix.python-version }}"
         uses: "actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,26 @@
+2.8.906 (2024-08-15)
+====================
+
+- Removed opinionated OpenSSL version constraint that forbid any version lower than 1.1.1.
+  The reasoning behind this is that some companies expressed (to us) the need to upgrade urllib3 to urllib3-future
+  in (very) old Python 3.7 built against patched OpenSSL 1.0.2 or 1.0.8 and collaborative testing showed us
+  that this constraint is overly protective. Those build often lack TLS 1.3 support and may contain
+  major vulnerabilities, but we have to be optimistic on their awareness.
+  TLS 1.3 / QUIC is also an option for them as it works out of the box on those old distributions.
+  Effective immediately, we added a dedicated pipeline in our CI to verify that urllib3-future works
+  with the oldest Python 3.7 build we found out there.
+  Blindly removing support for those libraries when supporting Python 3.7 ... 3.9 is as we "partially"
+  support this range and end-users have no to little clues for why it's rejected when it clearly works.
+  The only issue that can appear is for users that have Python built against a SSL library that does not
+  support either TLS 1.2 or 1.3, they will encounter errors for sure.
+- Changed to submodule http2 to subpackage http2. Purely upstream sync. Still no use for us.
+- Changed minimum (C)Python interpreter version for qh3 automatic pickup to 3.7.11 as it bundle pip 21.2.4 and
+  is the minimum version to pick an appropriate (abi3) pre-built wheel. You may still install ``qh3`` manually
+  by first upgrading your pip installation by running ``python -m pip install -U pip``.
+- Fixed an issue where a server is yielding an invalid/malformed ``Alt-Svc`` header and urllib3-future may crash upon it.
+- Fixed an issue where sending a ``str`` body using a ``bytes`` value for Content-Type would induce a crash.
+  This was due to our unicode transparency policy. See https://github.com/jawah/urllib3.future/pull/142
+
 2.8.905 (2024-08-04)
 ====================
 

--- a/LibreSSL.Dockerfile
+++ b/LibreSSL.Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.7.1-alpine3.8
+
+RUN apk add build-base libffi-dev
+
+WORKDIR /app
+
+RUN pip install --upgrade pip setuptools
+RUN pip install nox
+
+ENV TRAEFIK_HTTPBIN_ENABLE=false
+ENV CI=true
+
+COPY ./src/urllib3 src/urllib3/
+COPY ./test test/
+COPY ./dummyserver dummyserver/
+COPY ./ci ci/
+
+COPY noxfile.py LICENSE.txt pyproject.toml README.md setup.cfg hatch_build.py dev-requirements.txt mypy-requirements.txt ./
+
+CMD nox -s test-3.7

--- a/OpenSSL.Dockerfile
+++ b/OpenSSL.Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.7.2-alpine3.7
+
+RUN apk add build-base libffi-dev
+
+WORKDIR /app
+
+RUN pip install --upgrade pip setuptools
+RUN pip install nox
+
+ENV TRAEFIK_HTTPBIN_ENABLE=false
+ENV CI=true
+
+COPY ./src/urllib3 src/urllib3/
+COPY ./test test/
+COPY ./dummyserver dummyserver/
+COPY ./ci ci/
+
+COPY noxfile.py LICENSE.txt pyproject.toml README.md setup.cfg hatch_build.py dev-requirements.txt mypy-requirements.txt ./
+
+CMD nox -s test-3.7

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - Thread safety.
 - Happy Eyeballs.
 - Connection pooling.
+- Unopinionated about OpenSSL.
 - Client-side SSL/TLS verification.
 - Highly customizable DNS resolution.
 - File uploads with multipart encoding.
@@ -164,6 +165,7 @@ Here are some of the reasons (not exhaustive) we choose to work this way:
 5. There a ton of other improvement you may leverage, but for that you will need to migrate to Niquests or update your code
   to enable specific capabilities, like but not limited to: "DNS over QUIC, HTTP" / "Happy Eyeballs" / "Native Asyncio" / "Advanced Multiplexing".
 6. Non-blocking IO with concurrent streams/requests. And yes, transparently.
+7. It relaxes some constraints established by upstream in their version 2, thus making it easier to upgrade from version 1.
 
 - **Is this funded?**
 

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -exo pipefail
-
-python3 -m pip install --upgrade twine wheel build
-python3 -m build
-python3 -m twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD --skip-existing

--- a/ci/run_legacy_libressl.sh
+++ b/ci/run_legacy_libressl.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+docker build -f LibreSSL.Dockerfile -t urllib3:legacy-libressl .
+docker run urllib3:legacy-libressl

--- a/ci/run_legacy_openssl.sh
+++ b/ci/run_legacy_openssl.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+docker build -f OpenSSL.Dockerfile -t urllib3:legacy-openssl .
+docker run urllib3:legacy-openssl

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,9 +7,10 @@ pytest-timeout==2.3.1
 trustme==0.9.0
 # We have to install at most cryptography 39.0.2 for PyPy<7.3.10
 # versions of Python 3.7, 3.8, and 3.9.
-cryptography==39.0.2;implementation_name=="pypy" and implementation_version<"7.3.10"
-cryptography==42.0.5;implementation_name!="pypy" or implementation_version>="7.3.10"
-backports.zoneinfo==0.2.1;python_version<"3.9"
+cryptography==39.0.2; implementation_name=="pypy" and implementation_version<"7.3.10"
+cryptography==42.0.5; implementation_name!="pypy" or implementation_version>="7.3.10"
+backports.zoneinfo==0.2.1; python_version<"3.9"
+tzdata==2024.1; python_version<"3.8"
 towncrier==21.9.0
 pytest-asyncio>=0.21.1,<=0.23.5.post1
 # unblock cffi for Python 3.13

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,4 +157,5 @@ nitpick_ignore = [
     ("py:class", "AsyncTrafficPolice"),
     ("py:attr", "HTTPResponse.data"),
     ("py:class", "_TYPE_PEER_CERT_RET_DICT"),
+    ("py:class", "_TYPE_ASYNC_BODY"),
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,18 +21,23 @@ urllib3.future
 - Async.
 - Task safety.
 - Thread safety.
+- Happy Eyeballs.
 - Connection pooling.
+- Unopinionated about OpenSSL.
 - Client-side SSL/TLS verification.
 - Highly customizable DNS resolution.
 - File uploads with multipart encoding.
 - DNS over UDP, TLS, QUIC, or HTTPS. DNSSEC protected.
 - Helpers for retrying requests and dealing with HTTP redirects.
 - Support for gzip, deflate, brotli, and zstd encoding.
+- Support for Python/PyPy 3.7+, no compromise.
 - HTTP/1.1, HTTP/2 and HTTP/3 support.
 - Proxy support for HTTP and SOCKS.
 - Detailed connection inspection.
+- HTTP/2 with prior knowledge.
 - Multiplexed connection.
 - Mirrored Sync & Async.
+- Amazingly Fast.
 
 urllib3 is powerful and easy to use:
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -16,7 +16,7 @@ urllib3 can be installed with `pip <https://pip.pypa.io>`_
 HTTP/2 and HTTP/3 support
 -------------------------
 
-HTTP/2 support is enabled by default via the ``h2`` dependency, HTTP/3 may or not be
+HTTP/2 support is enabled by default via the ``jh2`` dependency, HTTP/3 may or not be
 automatically available depending on the availability of the wheel on your platform.
 
 .. code-block:: bash
@@ -28,6 +28,8 @@ This may require some external toolchain to be available (compilation).
 .. note:: HTTP/3 is automatically installed and ready-to-use if you fulfill theses requirements: Linux, Windows or MacOS using Python (or PyPy) 3.7 onward with one of the supported architecture (arm64/aarch64/s390x/x86_64/amd64/ppc64/ppc64le).
 
 .. caution:: If the requirements aren't fulfilled for HTTP/3, your package manager won't pick qh3 for installation when installing urllib3-future and it will be silently disabled. We choose not to impose compilation and keep a safe pure Python fallback.
+
+.. note:: Very old ``pip`` versions may not be able to pick the pre-built wheel accordingly. Make sure to have the latest ``pip`` version installed first.
 
 Making Requests
 ---------------

--- a/docs/v2-migration-guide.rst
+++ b/docs/v2-migration-guide.rst
@@ -23,11 +23,10 @@ What are the important changes?
 Here's a short summary of which changes in urllib3 v2.0 are most important:
 
 - Python version must be **3.7 or later** (previously supported Python 2.7, 3.5, and 3.6).
-- Removed support for OpenSSL versions older than 1.1.1.
 - Removed support for Python implementations that aren't CPython or PyPy3 (previously supported Google App Engine, Jython).
 - Removed the ``urllib3.contrib.ntlmpool`` module.
 - Deprecated the ``urllib3.contrib.pyopenssl`` module, made inoperant in v2.1.0.
-- Deprecated the ``urllib3.contrib.securetransport`` module, will be removed in v2.1.0.
+- Deprecated the ``urllib3.contrib.securetransport`` module, is removed in v2.1.0.
 - Deprecated the ``urllib3[secure]`` extra, made inoperant in v2.1.0.
 - Deprecated the ``HTTPResponse.getheaders()`` method in favor of ``HTTPResponse.headers``, will be removed in v2.1.0.
 - Deprecated the ``HTTPResponse.getheader(name, default)`` method in favor of ``HTTPResponse.headers.get(name, default)``, will be removed in v2.1.0.
@@ -149,34 +148,10 @@ immediately you will `receive security fixes on the 1.26.x release stream <#secu
 **🤔 Common upgrading issues**
 -------------------------------
 
-ssl module is compiled with OpenSSL 1.0.2.k-fips
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: text
-
-  ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'.
-  See: https://github.com/urllib3/urllib3/issues/2168
-
-Remediation depends on your system:
-
-- **AWS Lambda**: Upgrade to the Python3.10 runtime as it uses OpenSSL 1.1.1. Alternatively, you can
-  use a `custom Docker image
-  <https://aws.amazon.com/blogs/aws/new-for-aws-lambda-container-image-support/>`_ and ensure you
-  use a Python build that uses OpenSSL 1.1.1 or later.
-- **Amazon Linux 2**: Upgrade to `Amazon Linux 2023
-  <https://aws.amazon.com/linux/amazon-linux-2023/>`_. Alternatively, you can install OpenSSL 1.1.1
-  on Amazon Linux 2 using ``yum install openssl11 openssl11-devel`` and then install Python with a
-  tool like pyenv.
-- **Red Hat Enterpritse Linux 7 (RHEL 7)**: Upgrade to RHEL 8 or RHEL 9.
-- **Read the Docs**: Upgrade your `configuration file to use Ubuntu 22.04
-  <https://docs.readthedocs.io/en/stable/config-file/v2.html>`_ by using ``os: ubuntu-22.04`` in the
-  ``build`` section. Feel free to use the `urllib3 configuration
-  <https://github.com/urllib3/urllib3/blob/2.0.0/.readthedocs.yml>`_ as an inspiration.
-
 docker.errors.dockerexception: error while fetching server api version: request() got an unexpected keyword argument 'chunked'
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Upgrade to ``docker==6.1.0`` that is compatible with urllib3 2.0.
+Upgrade to ``docker==6.1.0`` that is compatible with urllib3(-future) 2+
 
 ImportError: cannot import name 'gaecontrib' from 'requests_toolbelt._compat'
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -186,19 +161,6 @@ Engine Standard Python 2.7 support. Most users that reported this issue were usi
 <https://github.com/thisbejim/Pyrebase>`_ library that provides an API for the Firebase API. This
 library is unmaintained, but `replacements exist
 <https://github.com/thisbejim/Pyrebase/issues/435>`_.
-
-``ImportError: cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_'``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This likely happens because you're using botocore which `does not support urllib3 2.0 yet
-<https://github.com/boto/botocore/issues/2921>`_. The good news is that botocore explicitly declares
-in its dependencies that it only supports ``urllib3<2``. Make sure to use a recent pip. That way, pip
-will install urllib3 1.26.x until botocore starts supporting urllib3 2.0.
-
-If you're deploying to an AWS environment such as Lambda or a host using Amazon Linux 2,
-you'll need to explicitly pin to ``urllib3<2`` in your project to ensure urllib3 2.0 isn't
-brought into your environment. Otherwise, this may result in unintended side effects with
-the default boto3 installation.
 
 AttributeError: module 'urllib3.connectionpool' has no attribute 'VerifiedHTTPSConnection'
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -279,7 +279,7 @@ def run_loop_in_thread() -> Generator[tornado.ioloop.IOLoop, None, None]:
         # run asyncio.run in a thread and collect exceptions from *either*
         # the loop failing to start, or failing to close
         ran = tpe.submit(_run_and_close_tornado, run)
-        for f in concurrent.futures.as_completed((loop_started, ran)):  # type: ignore[misc]
+        for f in concurrent.futures.as_completed((loop_started, ran)):
             if f is loop_started:
                 io_loop, stop_event = loop_started.result()
                 try:

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,4 @@
-mypy==1.8.0; python_version >= '3.8'
+mypy==1.11.1; python_version >= '3.8'
 mypy==1.4.1; python_version < '3.8'
 idna>=2.0.0
 cryptography==42.0.5

--- a/noxfile.py
+++ b/noxfile.py
@@ -196,11 +196,12 @@ def traefik_boot(session: nox.Session) -> typing.Generator[None, None, None]:
 
 def tests_impl(
     session: nox.Session,
-    extras: str = "socks,brotli",
+    extras: str = "socks,brotli,zstd",
     byte_string_comparisons: bool = False,
 ) -> None:
     with traefik_boot(session):
         # Install deps and the package itself.
+        session.install("-U", "pip", "setuptools", silent=False)
         session.install("-r", "dev-requirements.txt", silent=False)
         session.install(f".[{extras}]", silent=False)
 
@@ -209,6 +210,7 @@ def tests_impl(
         # Print the Python version and bytesize.
         session.run("python", "--version")
         session.run("python", "-c", "import struct; print(struct.calcsize('P') * 8)")
+        session.run("python", "-c", "import ssl; print(ssl.OPENSSL_VERSION)")
 
         # Inspired from https://hynek.me/articles/ditch-codecov-python/
         # We use parallel mode and then combine in a later CI step

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 requires-python = ">=3.7"
 dynamic = ["version"]
 dependencies = [
-  "qh3>=1.0.3,<2.0.0; (platform_system == 'Darwin' or platform_system == 'Windows' or platform_system == 'Linux') and (platform_machine == 'x86_64' or platform_machine == 's390x' or platform_machine == 'aarch64' or platform_machine == 'armv7l' or platform_machine == 'ppc64le' or platform_machine == 'ppc64' or platform_machine == 'AMD64' or platform_machine == 'arm64' or platform_machine == 'ARM64') and (platform_python_implementation == 'CPython' or (platform_python_implementation == 'PyPy' and python_version < '3.11'))",
+  "qh3>=1.0.3,<2.0.0; (platform_python_implementation != 'CPython' or python_full_version > '3.7.10') and (platform_system == 'Darwin' or platform_system == 'Windows' or platform_system == 'Linux') and (platform_machine == 'x86_64' or platform_machine == 's390x' or platform_machine == 'aarch64' or platform_machine == 'armv7l' or platform_machine == 'ppc64le' or platform_machine == 'ppc64' or platform_machine == 'AMD64' or platform_machine == 'arm64' or platform_machine == 'ARM64') and (platform_python_implementation == 'CPython' or (platform_python_implementation == 'PyPy' and python_version < '3.11'))",
   "h11>=0.11.0,<1.0.0",
   "jh2>=5.0.3,<6.0.0",
 ]
@@ -103,8 +103,6 @@ markers = ["limit_memory"]
 log_level = "DEBUG"
 filterwarnings = [
     "error",
-    '''default:urllib3 v2.0 only supports OpenSSL 1.1.1+.*''',
-    '''default:'urllib3\[secure\]' extra is deprecated and will be removed in urllib3 v2\.1\.0.*:DeprecationWarning''',
     '''default:No IPv6 support. Falling back to IPv4:urllib3.exceptions.HTTPWarning''',
     '''default:No IPv6 support. skipping:urllib3.exceptions.HTTPWarning''',
     '''default:ssl\.TLSVersion\.TLSv1 is deprecated:DeprecationWarning''',
@@ -126,6 +124,7 @@ filterwarnings = [
     '''ignore:A plugin raised an exception during''',
     '''ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning''',
     '''ignore:Exception in thread:pytest.PytestUnhandledThreadExceptionWarning''',
+    '''ignore:function _SSLProtocolTransport\.__del__:pytest.PytestUnraisableExceptionWarning''',
     '''ignore:The `hash` argument is deprecated in favor of `unsafe_hash`:DeprecationWarning''',
 ]
 

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -31,26 +31,6 @@ from .util.request import make_headers
 from .util.retry import Retry
 from .util.timeout import Timeout
 
-# Ensure that Python is compiled with OpenSSL 1.1.1+
-# If the 'ssl' module isn't available at all that's
-# fine, we only care if the module is available.
-try:
-    import ssl
-except ImportError:
-    pass
-else:
-    if ssl.OPENSSL_VERSION.startswith("OpenSSL ") and ssl.OPENSSL_VERSION_INFO < (
-        1,
-        1,
-        1,
-    ):  # Defensive:
-        raise ImportError(
-            "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
-            f"the 'ssl' module is compiled with {ssl.OPENSSL_VERSION!r}. "
-            "See: https://github.com/urllib3/urllib3/issues/2168"
-        )
-
-
 __author__ = "Andrey Petrov (andrey.petrov@shazow.net)"
 __license__ = "MIT"
 __version__ = __version__

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.8.905"
+__version__ = "2.8.906"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -281,7 +281,10 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                 if server and server != self.host:
                     continue
 
-                return server, int(port)
+                try:
+                    return server, int(port)
+                except ValueError:
+                    pass
 
         return None
 

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -305,7 +305,10 @@ class HfaceBackend(BaseBackend):
                 if server and server != self.host:
                     continue
 
-                return server, int(port)
+                try:
+                    return server, int(port)
+                except ValueError:
+                    pass
 
         return None
 

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import warnings
 
 warnings.warn(
-    """'urllib3.contrib.pyopenssl' module has been removed in urllib3.future due to incompatibilities with our QUIC integration.
-While the import proceed without error for your convenience, it is rendered completely ineffective. Were you looking for in-memory client certificate?
-See https://urllib3future.readthedocs.io/en/latest/advanced-usage.html#in-memory-client-mtls-certificate""",
+    (
+        "'urllib3.contrib.pyopenssl' module has been removed in urllib3.future due to incompatibilities "
+        "with our QUIC integration. While the import proceed without error for your convenience, it is rendered "
+        "completely ineffective. Were you looking for in-memory client certificate? "
+        "See https://urllib3future.readthedocs.io/en/latest/advanced-usage.html#in-memory-client-mtls-certificate"
+    ),
     category=DeprecationWarning,
     stacklevel=2,
 )

--- a/src/urllib3/contrib/resolver/_async/doh/_urllib3.py
+++ b/src/urllib3/contrib/resolver/_async/doh/_urllib3.py
@@ -558,7 +558,9 @@ class HTTPSResolver(AsyncBaseResolver):
         return sorted(quic_results + results, key=lambda _: _[0] + _[1], reverse=True)
 
 
-class GoogleResolver(HTTPSResolver):
+class GoogleResolver(
+    HTTPSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "google"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -575,7 +577,9 @@ class GoogleResolver(HTTPSResolver):
         super().__init__("dns.google", port, *patterns, **kwargs)
 
 
-class CloudflareResolver(HTTPSResolver):
+class CloudflareResolver(
+    HTTPSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "cloudflare"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -591,7 +595,9 @@ class CloudflareResolver(HTTPSResolver):
         super().__init__("cloudflare-dns.com", port, *patterns, **kwargs)
 
 
-class AdGuardResolver(HTTPSResolver):
+class AdGuardResolver(
+    HTTPSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "adguard"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -607,7 +613,9 @@ class AdGuardResolver(HTTPSResolver):
         super().__init__("unfiltered.adguard-dns.com", port, *patterns, **kwargs)
 
 
-class OpenDNSResolver(HTTPSResolver):
+class OpenDNSResolver(
+    HTTPSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "opendns"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -623,7 +631,9 @@ class OpenDNSResolver(HTTPSResolver):
         super().__init__("dns.opendns.com", port, *patterns, **kwargs)
 
 
-class Quad9Resolver(HTTPSResolver):
+class Quad9Resolver(
+    HTTPSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "quad9"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -639,7 +649,9 @@ class Quad9Resolver(HTTPSResolver):
         super().__init__("dns11.quad9.net", port, *patterns, **kwargs)
 
 
-class NextDNSResolver(HTTPSResolver):
+class NextDNSResolver(
+    HTTPSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "nextdns"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:

--- a/src/urllib3/contrib/resolver/_async/doq/_qh3.py
+++ b/src/urllib3/contrib/resolver/_async/doq/_qh3.py
@@ -436,7 +436,9 @@ class QUICResolver(PlainResolver):
             return events
 
 
-class AdGuardResolver(QUICResolver):
+class AdGuardResolver(
+    QUICResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "adguard"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any):
@@ -450,7 +452,9 @@ class AdGuardResolver(QUICResolver):
         super().__init__("unfiltered.adguard-dns.com", port, *patterns, **kwargs)
 
 
-class NextDNSResolver(QUICResolver):
+class NextDNSResolver(
+    QUICResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "nextdns"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any):

--- a/src/urllib3/contrib/resolver/_async/dot/_ssl.py
+++ b/src/urllib3/contrib/resolver/_async/dot/_ssl.py
@@ -115,7 +115,9 @@ class TLSResolver(PlainResolver):
         )
 
 
-class GoogleResolver(TLSResolver):
+class GoogleResolver(
+    TLSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "google"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -130,7 +132,9 @@ class GoogleResolver(TLSResolver):
         super().__init__("dns.google", port, *patterns, **kwargs)
 
 
-class CloudflareResolver(TLSResolver):
+class CloudflareResolver(
+    TLSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "cloudflare"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -145,7 +149,9 @@ class CloudflareResolver(TLSResolver):
         super().__init__("1.1.1.1", port, *patterns, **kwargs)
 
 
-class AdGuardResolver(TLSResolver):
+class AdGuardResolver(
+    TLSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "adguard"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -160,7 +166,9 @@ class AdGuardResolver(TLSResolver):
         super().__init__("unfiltered.adguard-dns.com", port, *patterns, **kwargs)
 
 
-class OpenDNSResolver(TLSResolver):
+class OpenDNSResolver(
+    TLSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "opendns"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -175,7 +183,9 @@ class OpenDNSResolver(TLSResolver):
         super().__init__("dns.opendns.com", port, *patterns, **kwargs)
 
 
-class Quad9Resolver(TLSResolver):
+class Quad9Resolver(
+    TLSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "quad9"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:

--- a/src/urllib3/contrib/resolver/_async/dou/_socket.py
+++ b/src/urllib3/contrib/resolver/_async/dou/_socket.py
@@ -300,7 +300,9 @@ class PlainResolver(AsyncBaseResolver):
         return sorted(quic_results + results, key=lambda _: _[0] + _[1], reverse=True)
 
 
-class CloudflareResolver(PlainResolver):
+class CloudflareResolver(
+    PlainResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "cloudflare"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -315,7 +317,9 @@ class CloudflareResolver(PlainResolver):
         super().__init__("1.1.1.1", port, *patterns, **kwargs)
 
 
-class GoogleResolver(PlainResolver):
+class GoogleResolver(
+    PlainResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "google"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -330,7 +334,9 @@ class GoogleResolver(PlainResolver):
         super().__init__("8.8.8.8", port, *patterns, **kwargs)
 
 
-class Quad9Resolver(PlainResolver):
+class Quad9Resolver(
+    PlainResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "quad9"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -345,7 +351,9 @@ class Quad9Resolver(PlainResolver):
         super().__init__("9.9.9.9", port, *patterns, **kwargs)
 
 
-class AdGuardResolver(PlainResolver):
+class AdGuardResolver(
+    PlainResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "adguard"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:

--- a/src/urllib3/contrib/resolver/doh/_urllib3.py
+++ b/src/urllib3/contrib/resolver/doh/_urllib3.py
@@ -558,7 +558,9 @@ class HTTPSResolver(BaseResolver):
         return sorted(quic_results + results, key=lambda _: _[0] + _[1], reverse=True)
 
 
-class GoogleResolver(HTTPSResolver):
+class GoogleResolver(
+    HTTPSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "google"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -575,7 +577,9 @@ class GoogleResolver(HTTPSResolver):
         super().__init__("dns.google", port, *patterns, **kwargs)
 
 
-class CloudflareResolver(HTTPSResolver):
+class CloudflareResolver(
+    HTTPSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "cloudflare"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -591,7 +595,9 @@ class CloudflareResolver(HTTPSResolver):
         super().__init__("cloudflare-dns.com", port, *patterns, **kwargs)
 
 
-class AdGuardResolver(HTTPSResolver):
+class AdGuardResolver(
+    HTTPSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "adguard"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -607,7 +613,9 @@ class AdGuardResolver(HTTPSResolver):
         super().__init__("unfiltered.adguard-dns.com", port, *patterns, **kwargs)
 
 
-class OpenDNSResolver(HTTPSResolver):
+class OpenDNSResolver(
+    HTTPSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "opendns"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -623,7 +631,9 @@ class OpenDNSResolver(HTTPSResolver):
         super().__init__("dns.opendns.com", port, *patterns, **kwargs)
 
 
-class Quad9Resolver(HTTPSResolver):
+class Quad9Resolver(
+    HTTPSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "quad9"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -639,7 +649,9 @@ class Quad9Resolver(HTTPSResolver):
         super().__init__("dns11.quad9.net", port, *patterns, **kwargs)
 
 
-class NextDNSResolver(HTTPSResolver):
+class NextDNSResolver(
+    HTTPSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "nextdns"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:

--- a/src/urllib3/contrib/resolver/doq/_qh3.py
+++ b/src/urllib3/contrib/resolver/doq/_qh3.py
@@ -420,7 +420,9 @@ class QUICResolver(PlainResolver):
             return events
 
 
-class AdGuardResolver(QUICResolver):
+class AdGuardResolver(
+    QUICResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "adguard"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any):
@@ -434,7 +436,9 @@ class AdGuardResolver(QUICResolver):
         super().__init__("unfiltered.adguard-dns.com", port, *patterns, **kwargs)
 
 
-class NextDNSResolver(QUICResolver):
+class NextDNSResolver(
+    QUICResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "nextdns"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any):

--- a/src/urllib3/contrib/resolver/dot/_ssl.py
+++ b/src/urllib3/contrib/resolver/dot/_ssl.py
@@ -65,7 +65,9 @@ class TLSResolver(PlainResolver):
         self._hook_out = lambda p: struct.pack("!H", len(p)) + p
 
 
-class GoogleResolver(TLSResolver):
+class GoogleResolver(
+    TLSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "google"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -80,7 +82,9 @@ class GoogleResolver(TLSResolver):
         super().__init__("dns.google", port, *patterns, **kwargs)
 
 
-class CloudflareResolver(TLSResolver):
+class CloudflareResolver(
+    TLSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "cloudflare"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -95,7 +99,9 @@ class CloudflareResolver(TLSResolver):
         super().__init__("1.1.1.1", port, *patterns, **kwargs)
 
 
-class AdGuardResolver(TLSResolver):
+class AdGuardResolver(
+    TLSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "adguard"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -110,7 +116,9 @@ class AdGuardResolver(TLSResolver):
         super().__init__("unfiltered.adguard-dns.com", port, *patterns, **kwargs)
 
 
-class OpenDNSResolver(TLSResolver):
+class OpenDNSResolver(
+    TLSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "opendns"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -125,7 +133,9 @@ class OpenDNSResolver(TLSResolver):
         super().__init__("dns.opendns.com", port, *patterns, **kwargs)
 
 
-class Quad9Resolver(TLSResolver):
+class Quad9Resolver(
+    TLSResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "quad9"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:

--- a/src/urllib3/contrib/resolver/dou/_socket.py
+++ b/src/urllib3/contrib/resolver/dou/_socket.py
@@ -290,7 +290,9 @@ class PlainResolver(BaseResolver):
         return sorted(quic_results + results, key=lambda _: _[0] + _[1], reverse=True)
 
 
-class CloudflareResolver(PlainResolver):
+class CloudflareResolver(
+    PlainResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "cloudflare"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -305,7 +307,9 @@ class CloudflareResolver(PlainResolver):
         super().__init__("1.1.1.1", port, *patterns, **kwargs)
 
 
-class GoogleResolver(PlainResolver):
+class GoogleResolver(
+    PlainResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "google"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -320,7 +324,9 @@ class GoogleResolver(PlainResolver):
         super().__init__("8.8.8.8", port, *patterns, **kwargs)
 
 
-class Quad9Resolver(PlainResolver):
+class Quad9Resolver(
+    PlainResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "quad9"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:
@@ -335,7 +341,9 @@ class Quad9Resolver(PlainResolver):
         super().__init__("9.9.9.9", port, *patterns, **kwargs)
 
 
-class AdGuardResolver(PlainResolver):
+class AdGuardResolver(
+    PlainResolver
+):  # Defensive: we do not cover specific vendors/DNS shortcut
     specifier = "adguard"
 
     def __init__(self, *patterns: str, **kwargs: typing.Any) -> None:

--- a/src/urllib3/contrib/ssa/__init__.py
+++ b/src/urllib3/contrib/ssa/__init__.py
@@ -10,12 +10,12 @@ StandardTimeoutError = socket.timeout
 try:
     from concurrent.futures import TimeoutError as FutureTimeoutError
 except ImportError:
-    FutureTimeoutError = TimeoutError  # type: ignore[misc,assignment]
+    FutureTimeoutError = TimeoutError  # type: ignore[misc]
 
 try:
     AsyncioTimeoutError = asyncio.exceptions.TimeoutError
 except AttributeError:
-    AsyncioTimeoutError = TimeoutError  # type: ignore[misc,assignment]
+    AsyncioTimeoutError = TimeoutError  # type: ignore[misc]
 
 if typing.TYPE_CHECKING:
     import ssl

--- a/src/urllib3/http2/__init__.py
+++ b/src/urllib3/http2/__init__.py
@@ -13,7 +13,8 @@ import warnings
 def inject_into_urllib3() -> None:
     warnings.warn(
         "urllib3-future do not propose the http2 module as it is useless to us. "
-        "enjoy all three protocols. urllib3-future just works out of the box with all protocols.",
+        "enjoy HTTP/1.1, HTTP/2, and HTTP/3 without hacks. urllib3-future just works out "
+        "of the box with all protocols. No hassles.",
         UserWarning,
     )
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1068,6 +1068,7 @@ class TestUtilSSL:
             ("LibreSSL 2.8.3", 0x101010CF, "cpython", (3, 10, 0), False),
             # old OpenSSL and old Python, unreliable
             ("OpenSSL 1.1.0", 0x10101000, "cpython", (3, 9, 2), False),
+            ("OpenSSL 1.0.2", 0x1000211F, "cpython", (3, 7, 2), False),
         ],
     )
     def test_is_has_never_check_common_name_reliable(

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -960,6 +960,10 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             assert r.status == 200
             assert r.data.decode("utf-8") == util.ALPN_PROTOCOLS[0]
 
+    @pytest.mark.skipif(
+        urllib3.util.ssl_.SUPPORT_MIN_MAX_TLS_VERSION is False,
+        reason="Python built against restricted ssl library with one protocol supported",
+    )
     def test_default_ssl_context_ssl_min_max_versions(self) -> None:
         ctx = urllib3.util.ssl_.create_urllib3_context()
         assert ctx.minimum_version == ssl.TLSVersion.TLSv1_2
@@ -968,6 +972,10 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         ).maximum_version
         assert ctx.maximum_version == expected_maximum_version
 
+    @pytest.mark.skipif(
+        urllib3.util.ssl_.SUPPORT_MIN_MAX_TLS_VERSION is False,
+        reason="Python built against restricted ssl library with one protocol supported",
+    )
     def test_ssl_context_ssl_version_uses_ssl_min_max_versions(self) -> None:
         ctx = urllib3.util.ssl_.create_urllib3_context(ssl_version=self.ssl_version())
         assert ctx.minimum_version == self.tls_version()

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -714,7 +714,7 @@ class TestHTTPSProxyVerification:
                 https.request("GET", destination_url)
 
             proxy_host = self._get_certificate_formatted_proxy_host(proxy.host)
-            msg = f"hostname \\'{proxy_hostname}\\' doesn\\'t match \\'{proxy_host}\\'"
+            msg = f"hostname \\'{proxy_hostname}\\' doesn\\'t match \\'{proxy_host}"
             assert msg in str(e)
 
     def test_https_proxy_hostname_verification(
@@ -756,6 +756,7 @@ class TestHTTPSProxyVerification:
             r = https.request("GET", destination_url)
             assert r.status == 200
 
+    @pytest.mark.skipif(HAS_IPV6 is False, reason="Only runs on IPv6 systems")
     def test_https_proxy_ipv6_san(
         self, ipv6_san_proxy_with_server: tuple[ServerConfig, ServerConfig]
     ) -> None:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -384,6 +384,7 @@ class TestClientCerts(SocketDummyServerTestCase):
 
             assert len(client_certs) == 1
 
+    @pytest.mark.xfail(raises=BlockingIOError, reason="CPython 3.7.x bug", strict=False)
     def test_load_keyfile_with_invalid_password(self) -> None:
         assert ssl_.SSLContext is not None
         context = ssl_.SSLContext(ssl_.PROTOCOL_SSLv23)
@@ -393,12 +394,6 @@ class TestClientCerts(SocketDummyServerTestCase):
                 keyfile=self.password_key_path,
                 password=b"letmei",
             )
-
-    def test_load_invalid_cert_file(self) -> None:
-        assert ssl_.SSLContext is not None
-        context = ssl_.SSLContext(ssl_.PROTOCOL_SSLv23)
-        with pytest.raises(ssl.SSLError):
-            context.load_cert_chain(certfile=self.password_key_path)
 
 
 class TestSocketClosing(SocketDummyServerTestCase):

--- a/test/with_traefik/asynchronous/test_svn.py
+++ b/test/with_traefik/asynchronous/test_svn.py
@@ -193,6 +193,28 @@ class TestSvnCapability(TraefikTestCase):
                     == f'h3-25=":443"; ma=3600, h3=":{self.https_port}"; ma=3600'
                 )
 
+    async def test_invalid_alt_svc_h3_upgrade(self) -> None:
+        async with AsyncHTTPSConnectionPool(
+            self.host,
+            self.https_alt_port,
+            timeout=1,
+            retries=False,
+            ca_certs=self.ca_authority,
+            resolver=self.test_async_resolver,
+        ) as p:
+            for i in range(2):
+                resp = await p.request(
+                    "GET",
+                    "/response-headers?Alt-Svc=h3-25%3D%22%3A443%22%3B%20ma%3D3600%2C%20h3%3D%22%3Aabc%22%3B%20ma%3D3600",
+                )
+
+                assert resp.version == 20
+                assert "Alt-Svc" in resp.headers
+                assert (
+                    resp.headers.get("Alt-Svc")
+                    == 'h3-25=":443"; ma=3600, h3=":abc"; ma=3600'
+                )
+
     async def test_drop_h3_upgrade(self) -> None:
         conn = AsyncHTTPSConnection(
             self.host,


### PR DESCRIPTION
- Removed opinionated OpenSSL version constraint that forbid any version lower than 1.1.1. The reasoning behind this is that some companies expressed (to us) the need to upgrade urllib3 to urllib3-future in (very) old Python 3.7 built against patched OpenSSL 1.0.2 or 1.0.8 and collaborative testing showed us that this constraint is overly protective. Those build often lack TLS 1.3 support and may contain major vulnerabilities, but we have to be optimistic on their awareness. TLS 1.3 / QUIC is also an option for them as it works out of the box on those old distributions. Effective immediately, we added a dedicated pipeline in our CI to verify that urllib3-future works with the oldest Python 3.7 build we found out there. Blindly removing support for those libraries when supporting Python 3.7 ... 3.9 is as we "partially" support this range and end-users have no to little clues for why it's rejected when it clearly works. The only issue that can appear is for users that have Python built against a SSL library that does not support either TLS 1.2 or 1.3, they will encounter errors for sure.
- Changed to submodule http2 to subpackage http2. Purely upstream sync. Still no use for us.
- Changed minimum (C)Python interpreter version for qh3 automatic pickup to 3.7.11 as it bundle pip 21.2.4 and is the minimum version to pick an appropriate (abi3) pre-built wheel. You may still install ``qh3`` manually by first upgrading your pip installation by running ``python -m pip install -U pip``.
- Fixed an issue where a server is yielding an invalid/malformed ``Alt-Svc`` header and urllib3-future may crash upon it.
- Fixed an issue where sending a ``str`` body using a ``bytes`` value for Content-Type would induce a crash. This was due to our unicode transparency policy. See https://github.com/jawah/urllib3.future/pull/142
