### PR TITLE
:bug: fix http2 maximum frame size error when the remote explicitly set a lower value than the default blocksize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os:
           - macos-12
-          - windows-2019
+          - windows-2022
           - ubuntu-20.04  # OpenSSL 1.1.1
           - ubuntu-latest  # OpenSSL 3.0
         nox-session: ['']
@@ -89,7 +89,7 @@ jobs:
             os: ubuntu-22.04
 
     runs-on: ${{ matrix.os }}
-    name: ${{ fromJson('{"macos-12":"macOS","windows-2019":"Windows","ubuntu-latest":"Ubuntu","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)","ubuntu-latest":"Ubuntu Latest (OpenSSL 3+)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session }}
+    name: ${{ fromJson('{"macos-12":"macOS","windows-2022":"Windows","ubuntu-latest":"Ubuntu","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)","ubuntu-latest":"Ubuntu Latest (OpenSSL 3+)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session }}
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 40
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.8.907 (2024-08-20)
+====================
+
+- Fixed http2 maximum frame size error when the remote explicitly set a lower value than the default blocksize.
+  This can happen when facing old server like Apache < 2.5 see https://github.com/apache/httpd/commit/ff6b8026acb8610e4faf10ee345141a3da85946e
+  Now we monitor the max_frame setting value to ensure we don't exceed it.
+
 2.8.906 (2024-08-15)
 ====================
 

--- a/docker-compose.win.yaml
+++ b/docker-compose.win.yaml
@@ -1,6 +1,6 @@
 services:
   proxy:
-    image: traefik:v2.10.4-windowsservercore-1809
+    image: traefik:v3.1-windowsservercore-ltsc2022
     restart: unless-stopped
     healthcheck:
       test: [ "CMD", "traefik" ,"healthcheck", "--ping" ]
@@ -51,7 +51,6 @@ services:
       - --entrypoints.alt-http.address=:9999
       - --entrypoints.alt-https.address=:8754
       # QUIC Related Configuration
-      - --experimental.http3=true
       - --entrypoints.https.http3=true
       - --entrypoints.alt-https.http3=false
       # Enable the access log, with HTTP requests

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   proxy:
-    image: traefik:v2.10.4
+    image: traefik:v3.1
     restart: unless-stopped
     healthcheck:
       test: [ "CMD", "traefik" ,"healthcheck", "--ping" ]
@@ -48,7 +48,6 @@ services:
       - --entrypoints.alt-http.address=:9999
       - --entrypoints.alt-https.address=:8754
       # QUIC Related Configuration
-      - --experimental.http3=true
       - --entrypoints.https.http3=true
       - --entrypoints.alt-https.http3=false
       # Enable the access log, with HTTP requests

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -372,7 +372,7 @@ class AsyncHTTPConnection(AsyncHfaceBackend):
         chunks_and_cl = body_to_chunks(
             body,
             method=method,
-            blocksize=self.blocksize,
+            blocksize=self.max_frame_size,
             force=self._svn != HttpVersion.h11,
         )
         is_sending_string = chunks_and_cl.is_string

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -1087,6 +1087,10 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
                 )
             conn.timeout = read_timeout
 
+        http_vsn_str = (
+            conn._http_vsn_str
+        )  # keep vsn here, as conn may be upgraded afterward.
+
         # Receive the response from the server
         try:
             response = await conn.getresponse(police_officer=self.pool)
@@ -1106,7 +1110,7 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
             method,
             url,
             # HTTP version
-            conn._http_vsn_str,
+            http_vsn_str,
             response.status,
             response.length_remaining,
         )

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.8.906"
+__version__ = "2.8.907"

--- a/src/urllib3/backend/_base.py
+++ b/src/urllib3/backend/_base.py
@@ -429,6 +429,10 @@ class BaseBackend:
     def is_multiplexed(self) -> bool:
         raise NotImplementedError
 
+    @property
+    def max_frame_size(self) -> int:
+        raise NotImplementedError
+
     def _upgrade(self) -> None:
         """Upgrade conn from svn ver to max supported."""
         raise NotImplementedError

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -136,6 +136,18 @@ class HfaceBackend(BaseBackend):
     def is_multiplexed(self) -> bool:
         return self._protocol is not None and self._protocol.multiplexed
 
+    @property
+    def max_frame_size(self) -> int:
+        if self._protocol is None:
+            return self.blocksize
+
+        try:
+            remote_max_size = self._protocol.max_frame_size()
+        except NotImplementedError:
+            return self.blocksize
+
+        return remote_max_size if self.blocksize > remote_max_size else self.blocksize
+
     def _new_conn(self) -> socket.socket | None:
         # handle if set up, quic cache capability. thus avoiding first TCP request prior to upgrade.
         if (

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -379,7 +379,7 @@ class HTTPConnection(HfaceBackend):
         chunks_and_cl = body_to_chunks(
             body,
             method=method,
-            blocksize=self.blocksize,
+            blocksize=self.max_frame_size,
             force=self._svn != HttpVersion.h11,
         )
         is_sending_string = chunks_and_cl.is_string

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1065,6 +1065,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             conn.timeout = read_timeout
 
         # Receive the response from the server
+        http_vsn_str = (
+            conn._http_vsn_str
+        )  # keep vsn here, as conn may be upgraded afterward.
+
         try:
             response = conn.getresponse(police_officer=self.pool)
         except (BaseSSLError, OSError) as e:
@@ -1083,7 +1087,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             method,
             url,
             # HTTP version
-            conn._http_vsn_str,
+            http_vsn_str,
             response.status,
             response.length_remaining,
         )

--- a/src/urllib3/contrib/hface/protocols/_protocols.py
+++ b/src/urllib3/contrib/hface/protocols/_protocols.py
@@ -63,6 +63,12 @@ class BaseProtocol(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    def max_frame_size(self) -> int:
+        """
+        Determine if the remote set a limited size for each data frame.
+        """
+        raise NotImplementedError
+
 
 class OverTCPProtocol(BaseProtocol, metaclass=ABCMeta):
     """

--- a/traefik/patched.Dockerfile
+++ b/traefik/patched.Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN mkdir dist
 RUN go build -ldflags="-s" -o dist/go-httpbin.exe ./cmd/go-httpbin
 
-FROM mcr.microsoft.com/windows/nanoserver:ltsc2019
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 
 COPY --from=build /go/src/github.com/mccutchen/go-httpbin/dist /app
 


### PR DESCRIPTION
…
Originally found at https://github.com/internetstandards/Internet.nl/issues/1485
