### PR TITLE
Release 2.9.900

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-2.9.900 (2024-09-23)
+2.9.900 (2024-09-24)
 ====================
 
 - Fixed a rare issue where HTTPS record is misinterpreted, thus leading to a missed preemptive HTTP/3 negotiation.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,9 @@
 - Restored support for older-and-deprecated ``PySocks`` if installed and ``python-socks`` is absent for synchronous support of SOCKS proxies.
 - Added support for HTTP Trailers across HTTP/1, HTTP/2 and HTTP/3 responses. We added the property ``trailers`` in ``HTTPResponse`` to reflect that.
 - Fixed unclosed resource warning for socket created in asynchronous mode.
-- Added support for Upgrading to HTTP/2 via Alt-Svc. Whether it's h2c (http/2 over cleartext) or h2.
+- Added support for Upgrading to HTTP/2 (If coming from HTTP/1) via Alt-Svc. Whether it's h2c (http/2 over cleartext) or h2.
 - Largely improve download speed on the QUIC layer by increasing automatically the blocksize to the largest value allowed on UDP (value taken from sysconf).
+- Fixed the test suite outcome if no support for HTTP/3 exist in current environment.
 
 2.8.907 (2024-08-20)
 ====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+2.9.900 (2024-09-23)
+====================
+
+- Fixed a rare issue where HTTPS record is misinterpreted, thus leading to a missed preemptive HTTP/3 negotiation.
+- Restored support for older-and-deprecated ``PySocks`` if installed and ``python-socks`` is absent for synchronous support of SOCKS proxies.
+- Added support for HTTP Trailers across HTTP/1, HTTP/2 and HTTP/3 responses. We added the property ``trailers`` in ``HTTPResponse`` to reflect that.
+- Fixed unclosed resource warning for socket created in asynchronous mode.
+- Added support for Upgrading to HTTP/2 via Alt-Svc. Whether it's h2c (http/2 over cleartext) or h2.
+- Largely improve download speed on the QUIC layer by increasing automatically the blocksize to the largest value allowed on UDP (value taken from sysconf).
+
 2.8.907 (2024-08-20)
 ====================
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@
 - Support for Python/PyPy 3.7+, no compromise.
 - HTTP/1.1, HTTP/2 and HTTP/3 support.
 - Proxy support for HTTP and SOCKS.
+- Post-Quantum Security with QUIC.
 - Detailed connection inspection.
 - HTTP/2 with prior knowledge.
 - Multiplexed connection.
 - Mirrored Sync & Async.
+- Trailer Headers.
 - Amazingly Fast.
 
 urllib3.future is powerful and easy to use:
@@ -209,6 +211,9 @@ This being said, rest assured, we kept all the tests from urllib3 to ensure that
 guaranteed by upstream is also carefully watched down there. See the CI/pipeline for yourself.
 
 In addition to that, we enforced key integration tests to watch how urllib3-future act with some critical projects.
+
+Top-priorities issues are those impacting users with the "shadowing" part. Meaning, if a user is suffering
+an error or something that ends up causing an undesirable outcome from a third-party library that leverage urllib3.
 
 - **OS Package Managers**
 

--- a/docker-compose.win.yaml
+++ b/docker-compose.win.yaml
@@ -1,6 +1,6 @@
 services:
   proxy:
-    image: traefik:v3.1-windowsservercore-ltsc2022
+    image: traefik:v3.1.4-windowsservercore-ltsc2022
     restart: unless-stopped
     healthcheck:
       test: [ "CMD", "traefik" ,"healthcheck", "--ping" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   proxy:
-    image: traefik:v3.1
+    image: traefik:v3.1.4
     restart: unless-stopped
     healthcheck:
       test: [ "CMD", "traefik" ,"healthcheck", "--ping" ]
@@ -61,7 +61,7 @@ services:
       - --log.level=INFO
 
   httpbin:
-    image: mccutchen/go-httpbin:v2.14.0
+    image: mccutchen/go-httpbin:v2.15.0
     restart: unless-stopped
     depends_on:
       proxy:

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -1493,3 +1493,27 @@ Here is a simple example::
     with urllib3.PoolManager(disabled_svn={urllib3.HttpVersion.h11}) as pm:
         r = pm.urlopen("GET", "http://my-internal.svc.local/")
 
+
+HTTP Trailers
+-------------
+
+.. note:: Available since version 2.9+
+
+HTTP response may contain one or several trailer headers. Those special headers are received
+after the reception of the body. Before this, those headers were unreachable and dropped silently.
+
+Quoted from Mozilla MDN: "The Trailer response header allows the sender to include additional fields
+at the end of chunked messages in order to supply metadata that might be dynamically generated while the
+message body is sent, such as a message integrity check, digital signature, or post-processing status."
+
+Here is a simple example::
+
+    import urllib3
+
+    with urllib3.PoolManager() as pm:
+        r = pm.urlopen("GET", "https://example.test")
+        print(r.trailers)
+
+.. note:: The property ``trailers`` return either ``None`` or a fully constructed ``HTTPHeaderDict``.
+
+.. warning:: ``None`` means we did not receive trailer headers (yet). If ``preload_content`` is set to False, you will need to consume the entire body before reaching the ``trailers`` property.

--- a/noxfile.py
+++ b/noxfile.py
@@ -171,7 +171,7 @@ def traefik_boot(session: nox.Session) -> typing.Generator[None, None, None]:
                     ),
                     timeout=1.0,
                 )
-            except (HTTPError, URLError, RemoteDisconnected) as e:
+            except (HTTPError, URLError, RemoteDisconnected, TimeoutError) as e:
                 i += 1
                 time.sleep(1)
                 session.log(f"Waiting for the Traefik server: {e}...")

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,5 @@
 ignore = E501, E203, W503, W504, E721
 exclude=./docs/conf.py
 max-line-length=99
+per-file-ignores =
+    src/urllib3/contrib/socks.py:F811

--- a/src/urllib3/_async/response.py
+++ b/src/urllib3/_async/response.py
@@ -196,6 +196,20 @@ class AsyncHTTPResponse(HTTPResponse):
         except (HTTPError, OSError, BaseSSLError):
             pass
 
+    @property
+    def trailers(self) -> HTTPHeaderDict | None:
+        """
+        Retrieve post-response (trailing headers) if any.
+        This WILL return None if no HTTP Trailer Headers have been received.
+        """
+        if self._fp is None:
+            return None
+
+        if hasattr(self._fp, "trailers"):
+            return self._fp.trailers
+
+        return None
+
     async def json(self) -> typing.Any:
         """
         Parses the body of the HTTP response as JSON.

--- a/src/urllib3/_constant.py
+++ b/src/urllib3/_constant.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import typing
 import socket
+import typing
 from enum import IntEnum
 
 

--- a/src/urllib3/_constant.py
+++ b/src/urllib3/_constant.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+import socket
 from enum import IntEnum
 
 
@@ -219,9 +220,25 @@ responses: typing.Mapping[int, str] = {
 
 # Default value for `blocksize` - a new parameter introduced to
 # http.client.HTTPConnection & http.client.HTTPSConnection in Python 3.7
-# The maximum TCP packet size is 65535 octets. But Python seems to buffer packets, so
-# passing a "very-high" value does improve responsiveness.
-DEFAULT_BLOCKSIZE: int = 65535 * 2
+# The maximum TCP packet size is 65535 octets. But OSes can have a recv buffer greater than 65k, so
+# passing the highest value does improve responsiveness.
+# udp usually is set to 212992
+# and tcp usually is set to 131072 (16384 * 8) or (65535 * 2)
+try:
+    # dynamically retrieve the kernel rcvbuf size.
+    stream = socket.socket(type=socket.SOCK_STREAM)
+    dgram = socket.socket(type=socket.SOCK_DGRAM)
+
+    DEFAULT_BLOCKSIZE: int = stream.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)
+    UDP_DEFAULT_BLOCKSIZE: int = dgram.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)
+
+    stream.close()
+    dgram.close()
+except OSError:
+    DEFAULT_BLOCKSIZE = 131072
+    UDP_DEFAULT_BLOCKSIZE = 212992
+
+TCP_DEFAULT_BLOCKSIZE: int = DEFAULT_BLOCKSIZE
 
 # Mozilla TLS recommendations for ciphers
 # General-purpose servers with a variety of clients, recommended for almost all systems.

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.8.907"
+__version__ = "2.9.900"

--- a/src/urllib3/backend/_async/_base.py
+++ b/src/urllib3/backend/_async/_base.py
@@ -23,7 +23,7 @@ class AsyncLowLevelResponse:
         reason: str,
         headers: HTTPHeaderDict,
         body: typing.Callable[
-            [int | None, int | None], typing.Awaitable[tuple[bytes, bool]]
+            [int | None, int | None], typing.Awaitable[tuple[bytes, bool, HTTPHeaderDict | None]]
         ]
         | None,
         *,
@@ -71,6 +71,8 @@ class AsyncLowLevelResponse:
         self.__buffer_excess: bytes = b""
         self.__promise: ResponsePromise | None = None
 
+        self.trailers: HTTPHeaderDict | None = None
+
     @property
     def fp(self) -> typing.NoReturn:
         raise RuntimeError(
@@ -110,7 +112,7 @@ class AsyncLowLevelResponse:
             return b""  # Defensive: This is unreachable, this case is already covered higher in the stack.
 
         if self._eot is False:
-            data, self._eot = await self.__internal_read_st(__size, self._stream_id)
+            data, self._eot, self.trailers = await self.__internal_read_st(__size, self._stream_id)
 
             # that's awkward, but rather no choice. the state machine
             # consume and render event regardless of your amt !

--- a/src/urllib3/backend/_async/_base.py
+++ b/src/urllib3/backend/_async/_base.py
@@ -12,7 +12,8 @@ class AsyncLowLevelResponse:
     basic response object. So that we don't have to change urllib3 tested behaviors."""
 
     __internal_read_st: typing.Callable[
-        [int | None, int | None], typing.Awaitable[tuple[bytes, bool]]
+        [int | None, int | None],
+        typing.Awaitable[tuple[bytes, bool, HTTPHeaderDict | None]],
     ] | None
 
     def __init__(
@@ -23,7 +24,8 @@ class AsyncLowLevelResponse:
         reason: str,
         headers: HTTPHeaderDict,
         body: typing.Callable[
-            [int | None, int | None], typing.Awaitable[tuple[bytes, bool, HTTPHeaderDict | None]]
+            [int | None, int | None],
+            typing.Awaitable[tuple[bytes, bool, HTTPHeaderDict | None]],
         ]
         | None,
         *,
@@ -112,7 +114,9 @@ class AsyncLowLevelResponse:
             return b""  # Defensive: This is unreachable, this case is already covered higher in the stack.
 
         if self._eot is False:
-            data, self._eot, self.trailers = await self.__internal_read_st(__size, self._stream_id)
+            data, self._eot, self.trailers = await self.__internal_read_st(
+                __size, self._stream_id
+            )
 
             # that's awkward, but rather no choice. the state machine
             # consume and render event regardless of your amt !

--- a/src/urllib3/backend/_base.py
+++ b/src/urllib3/backend/_base.py
@@ -96,7 +96,10 @@ class LowLevelResponse:
         version: int,
         reason: str,
         headers: HTTPHeaderDict,
-        body: typing.Callable[[int | None, int | None], tuple[bytes, bool, HTTPHeaderDict | None]] | None,
+        body: typing.Callable[
+            [int | None, int | None], tuple[bytes, bool, HTTPHeaderDict | None]
+        ]
+        | None,
         *,
         authority: str | None = None,
         port: int | None = None,
@@ -211,7 +214,9 @@ class LowLevelResponse:
             return b""  # Defensive: This is unreachable, this case is already covered higher in the stack.
 
         if self._eot is False:
-            data, self._eot, self.trailers = self.__internal_read_st(__size, self._stream_id)
+            data, self._eot, self.trailers = self.__internal_read_st(
+                __size, self._stream_id
+            )
 
             # that's awkward, but rather no choice. the state machine
             # consume and render event regardless of your amt !

--- a/src/urllib3/backend/_base.py
+++ b/src/urllib3/backend/_base.py
@@ -96,7 +96,7 @@ class LowLevelResponse:
         version: int,
         reason: str,
         headers: HTTPHeaderDict,
-        body: typing.Callable[[int | None, int | None], tuple[bytes, bool]] | None,
+        body: typing.Callable[[int | None, int | None], tuple[bytes, bool, HTTPHeaderDict | None]] | None,
         *,
         authority: str | None = None,
         port: int | None = None,
@@ -151,6 +151,8 @@ class LowLevelResponse:
 
         self.__buffer_excess: bytes = b""
         self.__promise: ResponsePromise | None = None
+
+        self.trailers: HTTPHeaderDict | None = None
 
     @property
     def fp(self) -> socket.SocketIO | None:
@@ -209,7 +211,7 @@ class LowLevelResponse:
             return b""  # Defensive: This is unreachable, this case is already covered higher in the stack.
 
         if self._eot is False:
-            data, self._eot = self.__internal_read_st(__size, self._stream_id)
+            data, self._eot, self.trailers = self.__internal_read_st(__size, self._stream_id)
 
             # that's awkward, but rather no choice. the state machine
             # consume and render event regardless of your amt !

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -198,6 +198,10 @@ class HfaceBackend(BaseBackend):
         assert self.sock is not None
         assert self._svn is not None
 
+        #: Don't search for alt-svc again if already done once.
+        if self.__alt_authority is not None:
+            return
+
         #: determine if http/3 support is present in environment
         has_h3_support = _HAS_HTTP3_SUPPORT()
 
@@ -207,6 +211,8 @@ class HfaceBackend(BaseBackend):
         #: did the user purposely killed h3/h2 support?
         is_h3_disabled = HttpVersion.h3 in self._disabled_svn
         is_h2_disabled = HttpVersion.h2 in self._disabled_svn
+
+        upgradable_svn: HttpVersion | None = None
 
         if is_plain_socket:
             if is_h2_disabled or self._svn == HttpVersion.h2:
@@ -218,15 +224,19 @@ class HfaceBackend(BaseBackend):
             )  # h2c = http2 over cleartext
         else:
             # do not upgrade if not coming from TLS already.
-            if (
-                is_plain_socket
-                or not has_h3_support
-                or is_h3_disabled
-                or self._svn == HttpVersion.h3
-            ):
+
+            # already maxed out!
+            if self._svn == HttpVersion.h3:
                 return
-            upgradable_svn = HttpVersion.h3
-            self.__alt_authority = self.__altsvc_probe(svc="h3")
+
+            if is_h3_disabled is False and has_h3_support is True:
+                upgradable_svn = HttpVersion.h3
+                self.__alt_authority = self.__altsvc_probe(svc="h3")
+
+            # no h3 target found[...] try to locate h2 support if appropriated!
+            if not self.__alt_authority and self._svn != HttpVersion.h2:
+                upgradable_svn = HttpVersion.h2
+                self.__alt_authority = self.__altsvc_probe(svc="h2")
 
         if self.__alt_authority:
             if upgradable_svn == HttpVersion.h3:
@@ -553,9 +563,12 @@ class HfaceBackend(BaseBackend):
                 receive_first=False,
             )
         except ProtocolError as e:
-            if isinstance(self._protocol, HTTPOverQUICProtocol):
+            if (
+                isinstance(self._protocol, HTTPOverQUICProtocol)
+                and self.__alt_authority is not None
+            ):
                 raise ProtocolError(
-                    "It is likely that the server yielded its support for HTTP/3 through the Alt-Svc header while unable to do so. "
+                    "The server yielded its support for HTTP/3 through the Alt-Svc header while unable to do so. "
                     "To remediate that issue, either disable http3 or reach out to the server admin."
                 ) from e
             raise

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -22,7 +22,7 @@ except (ImportError, AttributeError):
     Certificate = None
 
 from .._collections import HTTPHeaderDict
-from .._constant import DEFAULT_BLOCKSIZE, responses
+from .._constant import DEFAULT_BLOCKSIZE, responses, UDP_DEFAULT_BLOCKSIZE
 from ..contrib.hface import (
     HTTP1Protocol,
     HTTP2Protocol,
@@ -175,6 +175,8 @@ class HfaceBackend(BaseBackend):
                 self.port = self.__alt_authority[1]
 
         if self._svn == HttpVersion.h3:
+            if self.blocksize == DEFAULT_BLOCKSIZE:
+                self.blocksize = UDP_DEFAULT_BLOCKSIZE
             self.socket_kind = SOCK_DGRAM
 
             # undo local memory on whether conn supposedly support quic/h3
@@ -183,6 +185,8 @@ class HfaceBackend(BaseBackend):
                 self._svn = None
                 self._new_conn()  # restore socket defaults
         else:
+            if self.blocksize == UDP_DEFAULT_BLOCKSIZE:
+                self.blocksize = DEFAULT_BLOCKSIZE
             self.socket_kind = SOCK_STREAM
 
         return None
@@ -194,31 +198,40 @@ class HfaceBackend(BaseBackend):
         assert self.sock is not None
         assert self._svn is not None
 
-        if not _HAS_HTTP3_SUPPORT():
-            return
+        #: determine if http/3 support is present in environment
+        has_h3_support = _HAS_HTTP3_SUPPORT()
 
-        # do not upgrade if not coming from TLS already.
-        # we exclude SSLTransport, HTTP/3 is not supported in that condition anyway.
-        if type(self.sock) is socket.socket:
-            return
+        #: are we on a plain conn? unencrypted?
+        is_plain_socket = type(self.sock) is socket.socket
 
-        if self._svn == HttpVersion.h3:
-            return
-        if HttpVersion.h3 in self._disabled_svn:
-            return
+        #: did the user purposely killed h3/h2 support?
+        is_h3_disabled = HttpVersion.h3 in self._disabled_svn
+        is_h2_disabled = HttpVersion.h2 in self._disabled_svn
 
-        self.__alt_authority = self.__h3_probe()
+        if is_plain_socket:
+            if is_h2_disabled or self._svn == HttpVersion.h2:
+                return
+            upgradable_svn = HttpVersion.h2
+
+            self.__alt_authority = self.__altsvc_probe(svc="h2c")  # h2c = http2 over cleartext
+        else:
+            # do not upgrade if not coming from TLS already.
+            if is_plain_socket or not has_h3_support or is_h3_disabled or self._svn == HttpVersion.h3:
+                return
+            upgradable_svn = HttpVersion.h3
+            self.__alt_authority = self.__altsvc_probe(svc="h3")
 
         if self.__alt_authority:
-            if self._preemptive_quic_cache is not None:
-                self._preemptive_quic_cache[
-                    (self.host, self.port or 443)
-                ] = self.__alt_authority
+            if upgradable_svn == HttpVersion.h3:
+                if self._preemptive_quic_cache is not None:
+                    self._preemptive_quic_cache[
+                        (self.host, self.port or 443)
+                    ] = self.__alt_authority
 
-                if (self.host, self.port or 443) not in self._preemptive_quic_cache:
-                    return
+                    if (self.host, self.port or 443) not in self._preemptive_quic_cache:
+                        return
 
-            self._svn = HttpVersion.h3
+            self._svn = upgradable_svn
             # We purposely ignore setting the Hostname. Avoid MITM attack from local cache attack.
             self.port = self.__alt_authority[1]
             self.close()
@@ -299,15 +312,14 @@ class HfaceBackend(BaseBackend):
 
         return True
 
-    def __h3_probe(self) -> tuple[str, int] | None:
-        """Determine if remote is capable of operating through the http/3 protocol over QUIC."""
+    def __altsvc_probe(self, svc: str = "h3") -> tuple[str, int] | None:
+        """Determine if remote yield support for an alternative service protocol."""
         # need at least first request being made
         assert self._response is not None
 
         for alt_svc in self._response.msg.getlist("alt-svc"):
             for protocol, alt_authority in parse_alt_svc(alt_svc):
-                # Looking for final specification of HTTP/3 over QUIC.
-                if protocol != "h3":
+                if protocol != svc:
                     continue
 
                 server, port = alt_authority.split(":")

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -22,7 +22,7 @@ except (ImportError, AttributeError):
     Certificate = None
 
 from .._collections import HTTPHeaderDict
-from .._constant import DEFAULT_BLOCKSIZE, responses, UDP_DEFAULT_BLOCKSIZE
+from .._constant import DEFAULT_BLOCKSIZE, UDP_DEFAULT_BLOCKSIZE, responses
 from ..contrib.hface import (
     HTTP1Protocol,
     HTTP2Protocol,
@@ -213,10 +213,17 @@ class HfaceBackend(BaseBackend):
                 return
             upgradable_svn = HttpVersion.h2
 
-            self.__alt_authority = self.__altsvc_probe(svc="h2c")  # h2c = http2 over cleartext
+            self.__alt_authority = self.__altsvc_probe(
+                svc="h2c"
+            )  # h2c = http2 over cleartext
         else:
             # do not upgrade if not coming from TLS already.
-            if is_plain_socket or not has_h3_support or is_h3_disabled or self._svn == HttpVersion.h3:
+            if (
+                is_plain_socket
+                or not has_h3_support
+                or is_h3_disabled
+                or self._svn == HttpVersion.h3
+            ):
                 return
             upgradable_svn = HttpVersion.h3
             self.__alt_authority = self.__altsvc_probe(svc="h3")
@@ -854,7 +861,11 @@ class HfaceBackend(BaseBackend):
                     if reshelve_events:
                         self._protocol.reshelve(*reshelve_events)
                     return events
-                elif stream_related_event and event.end_stream is True and respect_end_stream_signal is True:
+                elif (
+                    stream_related_event
+                    and event.end_stream is True  # type: ignore[attr-defined]
+                    and respect_end_stream_signal is True
+                ):
                     if reshelve_events:
                         self._protocol.reshelve(*reshelve_events)
                     return events
@@ -1083,7 +1094,9 @@ class HfaceBackend(BaseBackend):
                     if raw_header[0] == 0x3A:
                         continue
                     else:
-                        trailers.add(raw_header.decode("ascii"), raw_value.decode("iso-8859-1"))
+                        trailers.add(
+                            raw_header.decode("ascii"), raw_value.decode("iso-8859-1")
+                        )
 
                 events.pop()
 
@@ -1091,7 +1104,7 @@ class HfaceBackend(BaseBackend):
                     return b"", True, trailers
 
         return (
-            b"".join(e.data for e in events) if len(events) > 1 else events[0].data,
+            b"".join(e.data for e in events) if len(events) > 1 else events[0].data,  # type: ignore[union-attr]
             eot,
             trailers,
         )

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -813,7 +813,10 @@ class HfaceBackend(BaseBackend):
                         events.append(event)
 
                         if data_in_len_from is not None:
-                            data_in_len += data_in_len_from(event)
+                            try:
+                                data_in_len += data_in_len_from(event)
+                            except AttributeError:
+                                pass
                     else:
                         reshelve_events.append(event)
 
@@ -836,6 +839,10 @@ class HfaceBackend(BaseBackend):
                             return events
                         continue
 
+                    if reshelve_events:
+                        self._protocol.reshelve(*reshelve_events)
+                    return events
+                elif stream_related_event and event.end_stream is True and respect_end_stream_signal is True:
                     if reshelve_events:
                         self._protocol.reshelve(*reshelve_events)
                     return events
@@ -1024,15 +1031,14 @@ class HfaceBackend(BaseBackend):
 
     def __read_st(
         self, __amt: int | None, __stream_id: int | None
-    ) -> tuple[bytes, bool]:
+    ) -> tuple[bytes, bool, HTTPHeaderDict | None]:
         """Allows us to defer the body loading after constructing the response object."""
         eot = False
 
-        events: list[DataReceived] = self.__exchange_until(  # type: ignore[assignment]
+        events: list[DataReceived | HeadersReceived] = self.__exchange_until(  # type: ignore[assignment]
             DataReceived,
             receive_first=True,
-            # we ignore Trailers even if provided in response.
-            event_type_collectable=(DataReceived,),
+            event_type_collectable=(DataReceived, HeadersReceived),
             maximal_data_in_read=__amt,
             data_in_len_from=lambda x: len(x.data),  # type: ignore[attr-defined]
             stream_id=__stream_id,
@@ -1053,9 +1059,29 @@ class HfaceBackend(BaseBackend):
                 # probe for h3/quic if available, and remember it.
                 self._upgrade()
 
+        trailers = None
+
+        if eot:
+            # http-trailers SHOULD be received LAST!
+            if isinstance(events[-1], HeadersReceived):
+                trailers = HTTPHeaderDict()
+
+                for raw_header, raw_value in events[-1].headers:
+                    # ignore...them? special headers. aka. starting with semicolon
+                    if raw_header[0] == 0x3A:
+                        continue
+                    else:
+                        trailers.add(raw_header.decode("ascii"), raw_value.decode("iso-8859-1"))
+
+                events.pop()
+
+                if not events:
+                    return b"", True, trailers
+
         return (
             b"".join(e.data for e in events) if len(events) > 1 else events[0].data,
             eot,
+            trailers,
         )
 
     def getresponse(

--- a/src/urllib3/contrib/_socks_legacy.py
+++ b/src/urllib3/contrib/_socks_legacy.py
@@ -1,0 +1,237 @@
+"""
+This module contains provisional support for SOCKS proxies from within
+urllib3. This module supports SOCKS4, SOCKS4A (an extension of SOCKS4), and
+SOCKS5. To enable its functionality, either install PySocks or install this
+module with the ``socks`` extra.
+
+The SOCKS implementation supports the full range of urllib3 features. It also
+supports the following SOCKS features:
+
+- SOCKS4A (``proxy_url='socks4a://...``)
+- SOCKS4 (``proxy_url='socks4://...``)
+- SOCKS5 with remote DNS (``proxy_url='socks5h://...``)
+- SOCKS5 with local DNS (``proxy_url='socks5://...``)
+- Usernames and passwords for the SOCKS proxy
+
+.. note::
+   It is recommended to use ``socks5h://`` or ``socks4a://`` schemes in
+   your ``proxy_url`` to ensure that DNS resolution is done from the remote
+   server instead of client-side when connecting to a domain name.
+
+SOCKS4 supports IPv4 and domain names with the SOCKS4A extension. SOCKS5
+supports IPv4, IPv6, and domain names.
+
+When connecting to a SOCKS4 proxy the ``username`` portion of the ``proxy_url``
+will be sent as the ``userid`` section of the SOCKS request:
+
+.. code-block:: python
+
+    proxy_url="socks4a://<userid>@proxy-host"
+
+When connecting to a SOCKS5 proxy the ``username`` and ``password`` portion
+of the ``proxy_url`` will be sent as the username/password to authenticate
+with the proxy:
+
+.. code-block:: python
+
+    proxy_url="socks5h://<username>:<password>@proxy-host"
+
+"""
+
+from __future__ import annotations
+
+try:
+    import socks  # type: ignore[import-not-found]
+except ImportError:
+    import warnings
+
+    from ..exceptions import DependencyWarning
+
+    warnings.warn(
+        (
+            "SOCKS support in urllib3 requires the installation of optional "
+            "dependencies: specifically, PySocks.  For more information, see "
+            "https://urllib3.readthedocs.io/en/latest/contrib.html#socks-proxies"
+        ),
+        DependencyWarning,
+    )
+    raise
+
+import typing
+from socket import timeout as SocketTimeout
+
+from .._typing import _TYPE_SOCKS_OPTIONS
+from ..connection import HTTPConnection, HTTPSConnection
+from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+from ..exceptions import ConnectTimeoutError, NewConnectionError
+from ..poolmanager import PoolManager
+from ..util.url import parse_url
+from ..backend import HttpVersion
+
+try:
+    import ssl
+except ImportError:
+    ssl = None  # type: ignore[assignment]
+
+
+class SOCKSConnection(HTTPConnection):
+    """
+    A plain-text HTTP connection that connects via a SOCKS proxy.
+    """
+
+    def __init__(
+        self,
+        _socks_options: _TYPE_SOCKS_OPTIONS,
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> None:
+        self._socks_options = _socks_options
+        super().__init__(*args, **kwargs)
+
+    def _new_conn(self) -> socks.socksocket:
+        """
+        Establish a new connection via the SOCKS proxy.
+        """
+        extra_kw: dict[str, typing.Any] = {}
+        if self.source_address:
+            extra_kw["source_address"] = self.source_address
+
+        if self.socket_options:
+            only_tcp_options = []
+
+            for opt in self.socket_options:
+                if len(opt) == 3:
+                    only_tcp_options.append(opt)
+                elif len(opt) == 4:
+                    protocol: str = opt[3].lower()  # type: ignore[misc]
+                    if protocol == "udp":
+                        continue
+                    only_tcp_options.append(opt[:3])
+
+            extra_kw["socket_options"] = only_tcp_options
+
+        try:
+            conn = socks.create_connection(
+                (self.host, self.port),
+                proxy_type=self._socks_options["socks_version"],
+                proxy_addr=self._socks_options["proxy_host"],
+                proxy_port=self._socks_options["proxy_port"],
+                proxy_username=self._socks_options["username"],
+                proxy_password=self._socks_options["password"],
+                proxy_rdns=self._socks_options["rdns"],
+                timeout=self.timeout,
+                **extra_kw,
+            )
+
+        except SocketTimeout as e:
+            raise ConnectTimeoutError(
+                self,
+                f"Connection to {self.host} timed out. (connect timeout={self.timeout})",
+            ) from e
+
+        except socks.ProxyError as e:
+            # This is fragile as hell, but it seems to be the only way to raise
+            # useful errors here.
+            if e.socket_err:
+                error = e.socket_err
+                if isinstance(error, SocketTimeout):
+                    raise ConnectTimeoutError(
+                        self,
+                        f"Connection to {self.host} timed out. (connect timeout={self.timeout})",
+                    ) from e
+                else:
+                    # Adding `from e` messes with coverage somehow, so it's omitted.
+                    # See #2386.
+                    raise NewConnectionError(
+                        self, f"Failed to establish a new connection: {error}"
+                    )
+            else:
+                raise NewConnectionError(
+                    self, f"Failed to establish a new connection: {e}"
+                ) from e
+
+        except OSError as e:  # Defensive: PySocks should catch all these.
+            raise NewConnectionError(
+                self, f"Failed to establish a new connection: {e}"
+            ) from e
+
+        return conn
+
+
+# We don't need to duplicate the Verified/Unverified distinction from
+# urllib3/connection.py here because the HTTPSConnection will already have been
+# correctly set to either the Verified or Unverified form by that module. This
+# means the SOCKSHTTPSConnection will automatically be the correct type.
+class SOCKSHTTPSConnection(SOCKSConnection, HTTPSConnection):
+    pass
+
+
+class SOCKSHTTPConnectionPool(HTTPConnectionPool):
+    ConnectionCls = SOCKSConnection
+
+
+class SOCKSHTTPSConnectionPool(HTTPSConnectionPool):
+    ConnectionCls = SOCKSHTTPSConnection
+
+
+class SOCKSProxyManager(PoolManager):
+    """
+    A version of the urllib3 ProxyManager that routes connections via the
+    defined SOCKS proxy.
+    """
+
+    pool_classes_by_scheme = {
+        "http": SOCKSHTTPConnectionPool,
+        "https": SOCKSHTTPSConnectionPool,
+    }
+
+    def __init__(
+        self,
+        proxy_url: str,
+        username: str | None = None,
+        password: str | None = None,
+        num_pools: int = 10,
+        headers: typing.Mapping[str, str] | None = None,
+        **connection_pool_kw: typing.Any,
+    ):
+        parsed = parse_url(proxy_url)
+
+        if username is None and password is None and parsed.auth is not None:
+            split = parsed.auth.split(":")
+            if len(split) == 2:
+                username, password = split
+        if parsed.scheme == "socks5":
+            socks_version = socks.PROXY_TYPE_SOCKS5
+            rdns = False
+        elif parsed.scheme == "socks5h":
+            socks_version = socks.PROXY_TYPE_SOCKS5
+            rdns = True
+        elif parsed.scheme == "socks4":
+            socks_version = socks.PROXY_TYPE_SOCKS4
+            rdns = False
+        elif parsed.scheme == "socks4a":
+            socks_version = socks.PROXY_TYPE_SOCKS4
+            rdns = True
+        else:
+            raise ValueError(f"Unable to determine SOCKS version from {proxy_url}")
+
+        self.proxy_url = proxy_url
+
+        socks_options = {
+            "socks_version": socks_version,
+            "proxy_host": parsed.host,
+            "proxy_port": parsed.port,
+            "username": username,
+            "password": password,
+            "rdns": rdns,
+        }
+        connection_pool_kw["_socks_options"] = socks_options
+
+        if "disabled_svn" not in connection_pool_kw:
+            connection_pool_kw["disabled_svn"] = set()
+
+        connection_pool_kw["disabled_svn"].add(HttpVersion.h3)
+
+        super().__init__(num_pools, headers, **connection_pool_kw)
+
+        self.pool_classes_by_scheme = SOCKSProxyManager.pool_classes_by_scheme

--- a/src/urllib3/contrib/_socks_legacy.py
+++ b/src/urllib3/contrib/_socks_legacy.py
@@ -61,12 +61,12 @@ import typing
 from socket import timeout as SocketTimeout
 
 from .._typing import _TYPE_SOCKS_OPTIONS
+from ..backend import HttpVersion
 from ..connection import HTTPConnection, HTTPSConnection
 from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from ..exceptions import ConnectTimeoutError, NewConnectionError
 from ..poolmanager import PoolManager
 from ..util.url import parse_url
-from ..backend import HttpVersion
 
 try:
     import ssl
@@ -103,7 +103,7 @@ class SOCKSConnection(HTTPConnection):
                 if len(opt) == 3:
                     only_tcp_options.append(opt)
                 elif len(opt) == 4:
-                    protocol: str = opt[3].lower()  # type: ignore[misc]
+                    protocol: str = opt[3].lower()
                     if protocol == "udp":
                         continue
                     only_tcp_options.append(opt[:3])

--- a/src/urllib3/contrib/hface/protocols/http1/_h11.py
+++ b/src/urllib3/contrib/hface/protocols/http1/_h11.py
@@ -265,9 +265,14 @@ class HTTP1ProtocolHyperImpl(HTTP1Protocol):
             elif isinstance(h11_event, h11.EndOfMessage):
                 # HTTP/2 and HTTP/3 send END_STREAM flag with HEADERS and DATA frames.
                 # We emulate similar behavior for HTTP/1.
-                last_event: DataReceived = DataReceived(
-                    self._current_stream_id, b"", self._connection.their_state != h11.MIGHT_SWITCH_PROTOCOL  # type: ignore[attr-defined]
-                )
+                if h11_event.headers:
+                    last_event: HeadersReceived = HeadersReceived(
+                        self._current_stream_id, h11_event.headers, self._connection.their_state != h11.MIGHT_SWITCH_PROTOCOL
+                    )
+                else:
+                    last_event: DataReceived = DataReceived(
+                        self._current_stream_id, b"", self._connection.their_state != h11.MIGHT_SWITCH_PROTOCOL  # type: ignore[attr-defined]
+                    )
                 a(last_event)
                 self._maybe_start_next_cycle()
             elif isinstance(h11_event, h11.ConnectionClosed):

--- a/src/urllib3/contrib/hface/protocols/http1/_h11.py
+++ b/src/urllib3/contrib/hface/protocols/http1/_h11.py
@@ -266,11 +266,13 @@ class HTTP1ProtocolHyperImpl(HTTP1Protocol):
                 # HTTP/2 and HTTP/3 send END_STREAM flag with HEADERS and DATA frames.
                 # We emulate similar behavior for HTTP/1.
                 if h11_event.headers:
-                    last_event: HeadersReceived = HeadersReceived(
-                        self._current_stream_id, h11_event.headers, self._connection.their_state != h11.MIGHT_SWITCH_PROTOCOL
+                    last_event: HeadersReceived | DataReceived = HeadersReceived(
+                        self._current_stream_id,
+                        h11_event.headers,
+                        self._connection.their_state != h11.MIGHT_SWITCH_PROTOCOL,  # type: ignore[attr-defined]
                     )
                 else:
-                    last_event: DataReceived = DataReceived(
+                    last_event = DataReceived(
                         self._current_stream_id, b"", self._connection.their_state != h11.MIGHT_SWITCH_PROTOCOL  # type: ignore[attr-defined]
                     )
                 a(last_event)

--- a/src/urllib3/contrib/resolver/_async/doh/_urllib3.py
+++ b/src/urllib3/contrib/resolver/_async/doh/_urllib3.py
@@ -403,7 +403,7 @@ class HTTPSResolver(AsyncBaseResolver):
                         rr: str = answer["data"]
 
                         if rr.startswith("\\#"):  # it means, raw, bytes.
-                            rr = rr[2:].replace(" ", "")
+                            rr = "".join(rr[2:].split(" ")[2:])
 
                             try:
                                 raw_record = bytes.fromhex(rr)

--- a/src/urllib3/contrib/resolver/doh/_urllib3.py
+++ b/src/urllib3/contrib/resolver/doh/_urllib3.py
@@ -403,7 +403,7 @@ class HTTPSResolver(BaseResolver):
                         rr: str = answer["data"]
 
                         if rr.startswith("\\#"):  # it means, raw, bytes.
-                            rr = rr[2:].replace(" ", "")
+                            rr = "".join(rr[2:].split(" ")[2:])
 
                             try:
                                 raw_record = bytes.fromhex(rr)

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -81,11 +81,11 @@ except ImportError:
         )
 
         from ._socks_legacy import (
-            SOCKSProxyManager,
             SOCKSConnection,
-            SOCKSHTTPSConnection,
             SOCKSHTTPConnectionPool,
+            SOCKSHTTPSConnection,
             SOCKSHTTPSConnectionPool,
+            SOCKSProxyManager,
         )
 
         BYPASS_SOCKS_LEGACY = True
@@ -100,7 +100,10 @@ if not BYPASS_SOCKS_LEGACY:
 
     # asynchronous part
     from .._async.connection import AsyncHTTPConnection, AsyncHTTPSConnection
-    from .._async.connectionpool import AsyncHTTPConnectionPool, AsyncHTTPSConnectionPool
+    from .._async.connectionpool import (
+        AsyncHTTPConnectionPool,
+        AsyncHTTPSConnectionPool,
+    )
     from .._async.poolmanager import AsyncPoolManager
     from .._typing import _TYPE_SOCKS_OPTIONS
     from ..backend import HttpVersion
@@ -118,8 +121,7 @@ if not BYPASS_SOCKS_LEGACY:
     except ImportError:
         ssl = None  # type: ignore[assignment]
 
-
-    class SOCKSConnection(HTTPConnection):
+    class SOCKSConnection(HTTPConnection):  # type: ignore[no-redef]
         """
         A plain-text HTTP connection that connects via a SOCKS proxy.
         """
@@ -202,24 +204,20 @@ if not BYPASS_SOCKS_LEGACY:
                     self, f"Failed to establish a new connection: {e}"
                 ) from e
 
-
     # We don't need to duplicate the Verified/Unverified distinction from
     # urllib3/connection.py here because the HTTPSConnection will already have been
     # correctly set to either the Verified or Unverified form by that module. This
     # means the SOCKSHTTPSConnection will automatically be the correct type.
-    class SOCKSHTTPSConnection(SOCKSConnection, HTTPSConnection):
+    class SOCKSHTTPSConnection(SOCKSConnection, HTTPSConnection):  # type: ignore[no-redef]
         pass
 
-
-    class SOCKSHTTPConnectionPool(HTTPConnectionPool):
+    class SOCKSHTTPConnectionPool(HTTPConnectionPool):  # type: ignore[no-redef]
         ConnectionCls = SOCKSConnection
 
-
-    class SOCKSHTTPSConnectionPool(HTTPSConnectionPool):
+    class SOCKSHTTPSConnectionPool(HTTPSConnectionPool):  # type: ignore[no-redef]
         ConnectionCls = SOCKSHTTPSConnection
 
-
-    class SOCKSProxyManager(PoolManager):
+    class SOCKSProxyManager(PoolManager):  # type: ignore[no-redef]
         """
         A version of the urllib3 ProxyManager that routes connections via the
         defined SOCKS proxy.
@@ -280,7 +278,6 @@ if not BYPASS_SOCKS_LEGACY:
             super().__init__(num_pools, headers, **connection_pool_kw)
 
             self.pool_classes_by_scheme = SOCKSProxyManager.pool_classes_by_scheme
-
 
     class AsyncSOCKSConnection(AsyncHTTPConnection):
         """
@@ -365,7 +362,6 @@ if not BYPASS_SOCKS_LEGACY:
                     self, f"Failed to establish a new connection: {e}"
                 ) from e
 
-
     # We don't need to duplicate the Verified/Unverified distinction from
     # urllib3/connection.py here because the HTTPSConnection will already have been
     # correctly set to either the Verified or Unverified form by that module. This
@@ -373,14 +369,11 @@ if not BYPASS_SOCKS_LEGACY:
     class AsyncSOCKSHTTPSConnection(AsyncSOCKSConnection, AsyncHTTPSConnection):
         pass
 
-
     class AsyncSOCKSHTTPConnectionPool(AsyncHTTPConnectionPool):
         ConnectionCls = AsyncSOCKSConnection
 
-
     class AsyncSOCKSHTTPSConnectionPool(AsyncHTTPSConnectionPool):
         ConnectionCls = AsyncSOCKSHTTPSConnection
-
 
     class AsyncSOCKSProxyManager(AsyncPoolManager):
         """
@@ -443,3 +436,21 @@ if not BYPASS_SOCKS_LEGACY:
             super().__init__(num_pools, headers, **connection_pool_kw)
 
             self.pool_classes_by_scheme = AsyncSOCKSProxyManager.pool_classes_by_scheme
+
+
+__all__ = [
+    "SOCKSConnection",
+    "SOCKSProxyManager",
+    "SOCKSHTTPSConnection",
+    "SOCKSHTTPSConnectionPool",
+    "SOCKSHTTPConnectionPool",
+]
+
+if not BYPASS_SOCKS_LEGACY:
+    __all__ += [
+        "AsyncSOCKSConnection",
+        "AsyncSOCKSHTTPSConnection",
+        "AsyncSOCKSHTTPConnectionPool",
+        "AsyncSOCKSHTTPSConnectionPool",
+        "AsyncSOCKSProxyManager",
+    ]

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -40,6 +40,9 @@ with the proxy:
 
 from __future__ import annotations
 
+#: We purposely want to support PySocks[...] due to our shadowing of the legacy "urllib3". "Dot not disturb" policy.
+BYPASS_SOCKS_LEGACY: bool = False
+
 try:
     from python_socks import (  # type: ignore[import-untyped]
         ProxyConnectionError,
@@ -77,354 +80,366 @@ except ImportError:
             DependencyWarning,
         )
 
-    raise
+        from ._socks_legacy import (
+            SOCKSProxyManager,
+            SOCKSConnection,
+            SOCKSHTTPSConnection,
+            SOCKSHTTPConnectionPool,
+            SOCKSHTTPSConnectionPool,
+        )
 
-import typing
-from socket import socket
-from socket import timeout as SocketTimeout
+        BYPASS_SOCKS_LEGACY = True
 
-# asynchronous part
-from .._async.connection import AsyncHTTPConnection, AsyncHTTPSConnection
-from .._async.connectionpool import AsyncHTTPConnectionPool, AsyncHTTPSConnectionPool
-from .._async.poolmanager import AsyncPoolManager
-from .._typing import _TYPE_SOCKS_OPTIONS
-from ..backend import HttpVersion
+    if not BYPASS_SOCKS_LEGACY:
+        raise
 
-# synchronous part
-from ..connection import HTTPConnection, HTTPSConnection
-from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
-from ..contrib.ssa import AsyncSocket
-from ..exceptions import ConnectTimeoutError, NewConnectionError
-from ..poolmanager import PoolManager
-from ..util.url import parse_url
+if not BYPASS_SOCKS_LEGACY:
+    import typing
+    from socket import socket
+    from socket import timeout as SocketTimeout
 
-try:
-    import ssl
-except ImportError:
-    ssl = None  # type: ignore[assignment]
+    # asynchronous part
+    from .._async.connection import AsyncHTTPConnection, AsyncHTTPSConnection
+    from .._async.connectionpool import AsyncHTTPConnectionPool, AsyncHTTPSConnectionPool
+    from .._async.poolmanager import AsyncPoolManager
+    from .._typing import _TYPE_SOCKS_OPTIONS
+    from ..backend import HttpVersion
+
+    # synchronous part
+    from ..connection import HTTPConnection, HTTPSConnection
+    from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+    from ..contrib.ssa import AsyncSocket
+    from ..exceptions import ConnectTimeoutError, NewConnectionError
+    from ..poolmanager import PoolManager
+    from ..util.url import parse_url
+
+    try:
+        import ssl
+    except ImportError:
+        ssl = None  # type: ignore[assignment]
 
 
-class SOCKSConnection(HTTPConnection):
-    """
-    A plain-text HTTP connection that connects via a SOCKS proxy.
-    """
-
-    def __init__(
-        self,
-        _socks_options: _TYPE_SOCKS_OPTIONS,
-        *args: typing.Any,
-        **kwargs: typing.Any,
-    ) -> None:
-        self._socks_options = _socks_options
-        super().__init__(*args, **kwargs)
-
-    def _new_conn(self) -> socket:
+    class SOCKSConnection(HTTPConnection):
         """
-        Establish a new connection via the SOCKS proxy.
+        A plain-text HTTP connection that connects via a SOCKS proxy.
         """
-        extra_kw: dict[str, typing.Any] = {}
-        if self.source_address:
-            extra_kw["source_address"] = self.source_address
 
-        if self.socket_options:
-            only_tcp_options = []
+        def __init__(
+            self,
+            _socks_options: _TYPE_SOCKS_OPTIONS,
+            *args: typing.Any,
+            **kwargs: typing.Any,
+        ) -> None:
+            self._socks_options = _socks_options
+            super().__init__(*args, **kwargs)
 
-            for opt in self.socket_options:
-                if len(opt) == 3:
-                    only_tcp_options.append(opt)
-                elif len(opt) == 4:
-                    protocol: str = opt[3].lower()
-                    if protocol == "udp":
-                        continue
-                    only_tcp_options.append(opt[:3])
+        def _new_conn(self) -> socket:
+            """
+            Establish a new connection via the SOCKS proxy.
+            """
+            extra_kw: dict[str, typing.Any] = {}
+            if self.source_address:
+                extra_kw["source_address"] = self.source_address
 
-            extra_kw["socket_options"] = only_tcp_options
+            if self.socket_options:
+                only_tcp_options = []
 
-        try:
-            assert self._socks_options["proxy_host"] is not None
-            assert self._socks_options["proxy_port"] is not None
+                for opt in self.socket_options:
+                    if len(opt) == 3:
+                        only_tcp_options.append(opt)
+                    elif len(opt) == 4:
+                        protocol: str = opt[3].lower()
+                        if protocol == "udp":
+                            continue
+                        only_tcp_options.append(opt[:3])
 
-            p = Proxy(
-                proxy_type=self._socks_options["socks_version"],
-                host=self._socks_options["proxy_host"],
-                port=int(self._socks_options["proxy_port"]),
-                username=self._socks_options["username"],
-                password=self._socks_options["password"],
-                rdns=self._socks_options["rdns"],
-            )
+                extra_kw["socket_options"] = only_tcp_options
 
-            _socket = self._resolver.create_connection(
-                (
-                    self._socks_options["proxy_host"],
-                    int(self._socks_options["proxy_port"]),
-                ),
-                timeout=self.timeout,
-                source_address=self.source_address,
-                socket_options=extra_kw["socket_options"],
-                quic_upgrade_via_dns_rr=False,
-                timing_hook=lambda _: setattr(self, "_connect_timings", _),
-            )
+            try:
+                assert self._socks_options["proxy_host"] is not None
+                assert self._socks_options["proxy_port"] is not None
 
-            return p.connect(  # type: ignore[no-any-return]
-                self.host,
-                self.port,
-                self.timeout,
-                _socket,
-            )
-        except (SocketTimeout, ProxyTimeoutError) as e:
-            raise ConnectTimeoutError(
-                self,
-                f"Connection to {self.host} timed out. (connect timeout={self.timeout})",
-            ) from e
+                p = Proxy(
+                    proxy_type=self._socks_options["socks_version"],
+                    host=self._socks_options["proxy_host"],
+                    port=int(self._socks_options["proxy_port"]),
+                    username=self._socks_options["username"],
+                    password=self._socks_options["password"],
+                    rdns=self._socks_options["rdns"],
+                )
 
-        except (ProxyConnectionError, ProxyError) as e:
-            raise NewConnectionError(
-                self, f"Failed to establish a new connection: {e}"
-            ) from e
+                _socket = self._resolver.create_connection(
+                    (
+                        self._socks_options["proxy_host"],
+                        int(self._socks_options["proxy_port"]),
+                    ),
+                    timeout=self.timeout,
+                    source_address=self.source_address,
+                    socket_options=extra_kw["socket_options"],
+                    quic_upgrade_via_dns_rr=False,
+                    timing_hook=lambda _: setattr(self, "_connect_timings", _),
+                )
 
-        except OSError as e:  # Defensive: PySocks should catch all these.
-            raise NewConnectionError(
-                self, f"Failed to establish a new connection: {e}"
-            ) from e
+                return p.connect(  # type: ignore[no-any-return]
+                    self.host,
+                    self.port,
+                    self.timeout,
+                    _socket,
+                )
+            except (SocketTimeout, ProxyTimeoutError) as e:
+                raise ConnectTimeoutError(
+                    self,
+                    f"Connection to {self.host} timed out. (connect timeout={self.timeout})",
+                ) from e
 
+            except (ProxyConnectionError, ProxyError) as e:
+                raise NewConnectionError(
+                    self, f"Failed to establish a new connection: {e}"
+                ) from e
 
-# We don't need to duplicate the Verified/Unverified distinction from
-# urllib3/connection.py here because the HTTPSConnection will already have been
-# correctly set to either the Verified or Unverified form by that module. This
-# means the SOCKSHTTPSConnection will automatically be the correct type.
-class SOCKSHTTPSConnection(SOCKSConnection, HTTPSConnection):
-    pass
-
-
-class SOCKSHTTPConnectionPool(HTTPConnectionPool):
-    ConnectionCls = SOCKSConnection
-
-
-class SOCKSHTTPSConnectionPool(HTTPSConnectionPool):
-    ConnectionCls = SOCKSHTTPSConnection
+            except OSError as e:  # Defensive: PySocks should catch all these.
+                raise NewConnectionError(
+                    self, f"Failed to establish a new connection: {e}"
+                ) from e
 
 
-class SOCKSProxyManager(PoolManager):
-    """
-    A version of the urllib3 ProxyManager that routes connections via the
-    defined SOCKS proxy.
-    """
+    # We don't need to duplicate the Verified/Unverified distinction from
+    # urllib3/connection.py here because the HTTPSConnection will already have been
+    # correctly set to either the Verified or Unverified form by that module. This
+    # means the SOCKSHTTPSConnection will automatically be the correct type.
+    class SOCKSHTTPSConnection(SOCKSConnection, HTTPSConnection):
+        pass
 
-    pool_classes_by_scheme = {
-        "http": SOCKSHTTPConnectionPool,
-        "https": SOCKSHTTPSConnectionPool,
-    }
 
-    def __init__(
-        self,
-        proxy_url: str,
-        username: str | None = None,
-        password: str | None = None,
-        num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
-        **connection_pool_kw: typing.Any,
-    ):
-        parsed = parse_url(proxy_url)
+    class SOCKSHTTPConnectionPool(HTTPConnectionPool):
+        ConnectionCls = SOCKSConnection
 
-        if username is None and password is None and parsed.auth is not None:
-            split = parsed.auth.split(":")
-            if len(split) == 2:
-                username, password = split
-        if parsed.scheme == "socks5":
-            socks_version = ProxyType.SOCKS5
-            rdns = False
-        elif parsed.scheme == "socks5h":
-            socks_version = ProxyType.SOCKS5
-            rdns = True
-        elif parsed.scheme == "socks4":
-            socks_version = ProxyType.SOCKS4
-            rdns = False
-        elif parsed.scheme == "socks4a":
-            socks_version = ProxyType.SOCKS4
-            rdns = True
-        else:
-            raise ValueError(f"Unable to determine SOCKS version from {proxy_url}")
 
-        self.proxy_url = proxy_url
+    class SOCKSHTTPSConnectionPool(HTTPSConnectionPool):
+        ConnectionCls = SOCKSHTTPSConnection
 
-        socks_options = {
-            "socks_version": socks_version,
-            "proxy_host": parsed.host,
-            "proxy_port": parsed.port,
-            "username": username,
-            "password": password,
-            "rdns": rdns,
+
+    class SOCKSProxyManager(PoolManager):
+        """
+        A version of the urllib3 ProxyManager that routes connections via the
+        defined SOCKS proxy.
+        """
+
+        pool_classes_by_scheme = {
+            "http": SOCKSHTTPConnectionPool,
+            "https": SOCKSHTTPSConnectionPool,
         }
-        connection_pool_kw["_socks_options"] = socks_options
 
-        if "disabled_svn" not in connection_pool_kw:
-            connection_pool_kw["disabled_svn"] = set()
+        def __init__(
+            self,
+            proxy_url: str,
+            username: str | None = None,
+            password: str | None = None,
+            num_pools: int = 10,
+            headers: typing.Mapping[str, str] | None = None,
+            **connection_pool_kw: typing.Any,
+        ):
+            parsed = parse_url(proxy_url)
 
-        connection_pool_kw["disabled_svn"].add(HttpVersion.h3)
+            if username is None and password is None and parsed.auth is not None:
+                split = parsed.auth.split(":")
+                if len(split) == 2:
+                    username, password = split
+            if parsed.scheme == "socks5":
+                socks_version = ProxyType.SOCKS5
+                rdns = False
+            elif parsed.scheme == "socks5h":
+                socks_version = ProxyType.SOCKS5
+                rdns = True
+            elif parsed.scheme == "socks4":
+                socks_version = ProxyType.SOCKS4
+                rdns = False
+            elif parsed.scheme == "socks4a":
+                socks_version = ProxyType.SOCKS4
+                rdns = True
+            else:
+                raise ValueError(f"Unable to determine SOCKS version from {proxy_url}")
 
-        super().__init__(num_pools, headers, **connection_pool_kw)
+            self.proxy_url = proxy_url
 
-        self.pool_classes_by_scheme = SOCKSProxyManager.pool_classes_by_scheme
+            socks_options = {
+                "socks_version": socks_version,
+                "proxy_host": parsed.host,
+                "proxy_port": parsed.port,
+                "username": username,
+                "password": password,
+                "rdns": rdns,
+            }
+            connection_pool_kw["_socks_options"] = socks_options
+
+            if "disabled_svn" not in connection_pool_kw:
+                connection_pool_kw["disabled_svn"] = set()
+
+            connection_pool_kw["disabled_svn"].add(HttpVersion.h3)
+
+            super().__init__(num_pools, headers, **connection_pool_kw)
+
+            self.pool_classes_by_scheme = SOCKSProxyManager.pool_classes_by_scheme
 
 
-class AsyncSOCKSConnection(AsyncHTTPConnection):
-    """
-    A plain-text HTTP connection that connects via a SOCKS proxy.
-    """
-
-    def __init__(
-        self,
-        _socks_options: _TYPE_SOCKS_OPTIONS,
-        *args: typing.Any,
-        **kwargs: typing.Any,
-    ) -> None:
-        self._socks_options = _socks_options
-        super().__init__(*args, **kwargs)
-
-    async def _new_conn(self) -> AsyncSocket:  # type: ignore[override]
+    class AsyncSOCKSConnection(AsyncHTTPConnection):
         """
-        Establish a new connection via the SOCKS proxy.
+        A plain-text HTTP connection that connects via a SOCKS proxy.
         """
-        extra_kw: dict[str, typing.Any] = {}
-        if self.source_address:
-            extra_kw["source_address"] = self.source_address
 
-        if self.socket_options:
-            only_tcp_options = []
+        def __init__(
+            self,
+            _socks_options: _TYPE_SOCKS_OPTIONS,
+            *args: typing.Any,
+            **kwargs: typing.Any,
+        ) -> None:
+            self._socks_options = _socks_options
+            super().__init__(*args, **kwargs)
 
-            for opt in self.socket_options:
-                if len(opt) == 3:
-                    only_tcp_options.append(opt)
-                elif len(opt) == 4:
-                    protocol: str = opt[3].lower()
-                    if protocol == "udp":
-                        continue
-                    only_tcp_options.append(opt[:3])
+        async def _new_conn(self) -> AsyncSocket:  # type: ignore[override]
+            """
+            Establish a new connection via the SOCKS proxy.
+            """
+            extra_kw: dict[str, typing.Any] = {}
+            if self.source_address:
+                extra_kw["source_address"] = self.source_address
 
-            extra_kw["socket_options"] = only_tcp_options
+            if self.socket_options:
+                only_tcp_options = []
 
-        try:
-            assert self._socks_options["proxy_host"] is not None
-            assert self._socks_options["proxy_port"] is not None
+                for opt in self.socket_options:
+                    if len(opt) == 3:
+                        only_tcp_options.append(opt)
+                    elif len(opt) == 4:
+                        protocol: str = opt[3].lower()
+                        if protocol == "udp":
+                            continue
+                        only_tcp_options.append(opt[:3])
 
-            p = AsyncioProxy(
-                proxy_type=self._socks_options["socks_version"],
-                host=self._socks_options["proxy_host"],
-                port=int(self._socks_options["proxy_port"]),
-                username=self._socks_options["username"],
-                password=self._socks_options["password"],
-                rdns=self._socks_options["rdns"],
-            )
+                extra_kw["socket_options"] = only_tcp_options
 
-            _socket = await self._resolver.create_connection(
-                (
-                    self._socks_options["proxy_host"],
-                    int(self._socks_options["proxy_port"]),
-                ),
-                timeout=self.timeout,
-                source_address=self.source_address,
-                socket_options=extra_kw["socket_options"],
-                quic_upgrade_via_dns_rr=False,
-                timing_hook=lambda _: setattr(self, "_connect_timings", _),
-            )
+            try:
+                assert self._socks_options["proxy_host"] is not None
+                assert self._socks_options["proxy_port"] is not None
 
-            return await p.connect(
-                self.host,
-                self.port,
-                self.timeout,
-                _socket,
-            )
-        except (SocketTimeout, ProxyTimeoutError) as e:
-            raise ConnectTimeoutError(
-                self,
-                f"Connection to {self.host} timed out. (connect timeout={self.timeout})",
-            ) from e
+                p = AsyncioProxy(
+                    proxy_type=self._socks_options["socks_version"],
+                    host=self._socks_options["proxy_host"],
+                    port=int(self._socks_options["proxy_port"]),
+                    username=self._socks_options["username"],
+                    password=self._socks_options["password"],
+                    rdns=self._socks_options["rdns"],
+                )
 
-        except (ProxyConnectionError, ProxyError) as e:
-            raise NewConnectionError(
-                self, f"Failed to establish a new connection: {e}"
-            ) from e
+                _socket = await self._resolver.create_connection(
+                    (
+                        self._socks_options["proxy_host"],
+                        int(self._socks_options["proxy_port"]),
+                    ),
+                    timeout=self.timeout,
+                    source_address=self.source_address,
+                    socket_options=extra_kw["socket_options"],
+                    quic_upgrade_via_dns_rr=False,
+                    timing_hook=lambda _: setattr(self, "_connect_timings", _),
+                )
 
-        except OSError as e:  # Defensive: PySocks should catch all these.
-            raise NewConnectionError(
-                self, f"Failed to establish a new connection: {e}"
-            ) from e
+                return await p.connect(
+                    self.host,
+                    self.port,
+                    self.timeout,
+                    _socket,
+                )
+            except (SocketTimeout, ProxyTimeoutError) as e:
+                raise ConnectTimeoutError(
+                    self,
+                    f"Connection to {self.host} timed out. (connect timeout={self.timeout})",
+                ) from e
 
+            except (ProxyConnectionError, ProxyError) as e:
+                raise NewConnectionError(
+                    self, f"Failed to establish a new connection: {e}"
+                ) from e
 
-# We don't need to duplicate the Verified/Unverified distinction from
-# urllib3/connection.py here because the HTTPSConnection will already have been
-# correctly set to either the Verified or Unverified form by that module. This
-# means the SOCKSHTTPSConnection will automatically be the correct type.
-class AsyncSOCKSHTTPSConnection(AsyncSOCKSConnection, AsyncHTTPSConnection):
-    pass
-
-
-class AsyncSOCKSHTTPConnectionPool(AsyncHTTPConnectionPool):
-    ConnectionCls = AsyncSOCKSConnection
-
-
-class AsyncSOCKSHTTPSConnectionPool(AsyncHTTPSConnectionPool):
-    ConnectionCls = AsyncSOCKSHTTPSConnection
+            except OSError as e:  # Defensive: PySocks should catch all these.
+                raise NewConnectionError(
+                    self, f"Failed to establish a new connection: {e}"
+                ) from e
 
 
-class AsyncSOCKSProxyManager(AsyncPoolManager):
-    """
-    A version of the urllib3 ProxyManager that routes connections via the
-    defined SOCKS proxy.
-    """
+    # We don't need to duplicate the Verified/Unverified distinction from
+    # urllib3/connection.py here because the HTTPSConnection will already have been
+    # correctly set to either the Verified or Unverified form by that module. This
+    # means the SOCKSHTTPSConnection will automatically be the correct type.
+    class AsyncSOCKSHTTPSConnection(AsyncSOCKSConnection, AsyncHTTPSConnection):
+        pass
 
-    pool_classes_by_scheme = {
-        "http": AsyncSOCKSHTTPConnectionPool,
-        "https": AsyncSOCKSHTTPSConnectionPool,
-    }
 
-    def __init__(
-        self,
-        proxy_url: str,
-        username: str | None = None,
-        password: str | None = None,
-        num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
-        **connection_pool_kw: typing.Any,
-    ):
-        parsed = parse_url(proxy_url)
+    class AsyncSOCKSHTTPConnectionPool(AsyncHTTPConnectionPool):
+        ConnectionCls = AsyncSOCKSConnection
 
-        if username is None and password is None and parsed.auth is not None:
-            split = parsed.auth.split(":")
-            if len(split) == 2:
-                username, password = split
-        if parsed.scheme == "socks5":
-            socks_version = ProxyType.SOCKS5
-            rdns = False
-        elif parsed.scheme == "socks5h":
-            socks_version = ProxyType.SOCKS5
-            rdns = True
-        elif parsed.scheme == "socks4":
-            socks_version = ProxyType.SOCKS4
-            rdns = False
-        elif parsed.scheme == "socks4a":
-            socks_version = ProxyType.SOCKS4
-            rdns = True
-        else:
-            raise ValueError(f"Unable to determine SOCKS version from {proxy_url}")
 
-        self.proxy_url = proxy_url
+    class AsyncSOCKSHTTPSConnectionPool(AsyncHTTPSConnectionPool):
+        ConnectionCls = AsyncSOCKSHTTPSConnection
 
-        socks_options = {
-            "socks_version": socks_version,
-            "proxy_host": parsed.host,
-            "proxy_port": parsed.port,
-            "username": username,
-            "password": password,
-            "rdns": rdns,
+
+    class AsyncSOCKSProxyManager(AsyncPoolManager):
+        """
+        A version of the urllib3 ProxyManager that routes connections via the
+        defined SOCKS proxy.
+        """
+
+        pool_classes_by_scheme = {
+            "http": AsyncSOCKSHTTPConnectionPool,
+            "https": AsyncSOCKSHTTPSConnectionPool,
         }
-        connection_pool_kw["_socks_options"] = socks_options
 
-        if "disabled_svn" not in connection_pool_kw:
-            connection_pool_kw["disabled_svn"] = set()
+        def __init__(
+            self,
+            proxy_url: str,
+            username: str | None = None,
+            password: str | None = None,
+            num_pools: int = 10,
+            headers: typing.Mapping[str, str] | None = None,
+            **connection_pool_kw: typing.Any,
+        ):
+            parsed = parse_url(proxy_url)
 
-        connection_pool_kw["disabled_svn"].add(HttpVersion.h3)
+            if username is None and password is None and parsed.auth is not None:
+                split = parsed.auth.split(":")
+                if len(split) == 2:
+                    username, password = split
+            if parsed.scheme == "socks5":
+                socks_version = ProxyType.SOCKS5
+                rdns = False
+            elif parsed.scheme == "socks5h":
+                socks_version = ProxyType.SOCKS5
+                rdns = True
+            elif parsed.scheme == "socks4":
+                socks_version = ProxyType.SOCKS4
+                rdns = False
+            elif parsed.scheme == "socks4a":
+                socks_version = ProxyType.SOCKS4
+                rdns = True
+            else:
+                raise ValueError(f"Unable to determine SOCKS version from {proxy_url}")
 
-        super().__init__(num_pools, headers, **connection_pool_kw)
+            self.proxy_url = proxy_url
 
-        self.pool_classes_by_scheme = AsyncSOCKSProxyManager.pool_classes_by_scheme
+            socks_options = {
+                "socks_version": socks_version,
+                "proxy_host": parsed.host,
+                "proxy_port": parsed.port,
+                "username": username,
+                "password": password,
+                "rdns": rdns,
+            }
+            connection_pool_kw["_socks_options"] = socks_options
+
+            if "disabled_svn" not in connection_pool_kw:
+                connection_pool_kw["disabled_svn"] = set()
+
+            connection_pool_kw["disabled_svn"].add(HttpVersion.h3)
+
+            super().__init__(num_pools, headers, **connection_pool_kw)
+
+            self.pool_classes_by_scheme = AsyncSOCKSProxyManager.pool_classes_by_scheme

--- a/src/urllib3/contrib/ssa/__init__.py
+++ b/src/urllib3/contrib/ssa/__init__.py
@@ -76,10 +76,13 @@ class AsyncSocket:
         if self._writer is not None:
             self._writer.close()
 
-        if hasattr(self._sock, "shutdown"):
-            self._sock.shutdown(SHUT_RD)
-        elif hasattr(self._sock, "close"):
-            self._sock.close()
+        try:
+            if hasattr(self._sock, "shutdown"):
+                self._sock.shutdown(SHUT_RD)
+            elif hasattr(self._sock, "close"):
+                self._sock.close()
+        except OSError:
+            pass
 
         self._connect_called = False
         self._established.clear()

--- a/src/urllib3/contrib/ssa/__init__.py
+++ b/src/urllib3/contrib/ssa/__init__.py
@@ -5,6 +5,7 @@ import platform
 import socket
 import typing
 
+SHUT_RD = 0  # taken from the "_socket" module
 StandardTimeoutError = socket.timeout
 
 try:
@@ -74,11 +75,14 @@ class AsyncSocket:
     def close(self) -> None:
         if self._writer is not None:
             self._writer.close()
+
+        if hasattr(self._sock, "shutdown"):
+            self._sock.shutdown(SHUT_RD)
+        elif hasattr(self._sock, "close"):
+            self._sock.close()
+
         self._connect_called = False
         self._established.clear()
-        # elif self._sock is not None:
-        #     if hasattr(self._sock, "close"):
-        #         self._sock.close()
 
     async def wait_for_readiness(self) -> None:
         await self._established.wait()

--- a/src/urllib3/contrib/ssa/__init__.py
+++ b/src/urllib3/contrib/ssa/__init__.py
@@ -81,6 +81,10 @@ class AsyncSocket:
                 self._sock.shutdown(SHUT_RD)
             elif hasattr(self._sock, "close"):
                 self._sock.close()
+            # we have to force call close() on our sock object in UDP ctx. (even after shutdown)
+            # or we'll get a resource warning for sure!
+            if self.type == socket.SOCK_DGRAM and hasattr(self._sock, "close"):
+                self._sock.close()
         except OSError:
             pass
 

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -440,6 +440,20 @@ class HTTPResponse(io.IOBase):
             return self.headers.get("location")
         return False
 
+    @property
+    def trailers(self) -> HTTPHeaderDict | None:
+        """
+        Retrieve post-response (trailing headers) if any.
+        This WILL return None if no HTTP Trailer Headers have been received.
+        """
+        if self._fp is None:
+            return None
+
+        if hasattr(self._fp, "trailers"):
+            return self._fp.trailers
+
+        return None
+
     def json(self) -> typing.Any:
         """
         Parses the body of the HTTP response as JSON.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="attr-defined"
 from __future__ import annotations
 
 import asyncio
@@ -16,6 +17,8 @@ from dummyserver.handlers import TestingApp
 from dummyserver.proxy import ProxyHandler
 from dummyserver.server import HAS_IPV6, run_loop_in_thread, run_tornado_app
 from dummyserver.testcase import HTTPSDummyServerTestCase
+from urllib3.backend._async.hface import _HAS_HTTP3_SUPPORT as _ASYNC_HAS_HTTP3_SUPPORT
+from urllib3.backend.hface import _HAS_HTTP3_SUPPORT as _SYNC_HAS_HTTP3_SUPPORT
 from urllib3.util import ssl_
 
 from .tz_stub import stub_timezone_ctx
@@ -376,3 +379,13 @@ def requires_traefik() -> None:
     else:
         _TRAEFIK_AVAILABLE = True
         sock.close()
+
+
+@pytest.fixture(scope="function")
+def requires_http3(for_async: bool = False) -> None:
+    _TARGET_METHOD = (
+        _SYNC_HAS_HTTP3_SUPPORT if not for_async else _ASYNC_HAS_HTTP3_SUPPORT
+    )
+
+    if _TARGET_METHOD() is False:
+        pytest.skip("Test requires HTTP/3 support")

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -916,8 +916,10 @@ class TestResponse:
         assert ctx.value.expected == content_length
 
     def test_chunked_head_response(self) -> None:
-        def mock_sock(amt: int | None, stream_id: int | None) -> tuple[bytes, bool]:
-            return b"", True
+        def mock_sock(
+            amt: int | None, stream_id: int | None
+        ) -> tuple[bytes, bool, HTTPHeaderDict | None]:
+            return b"", True, None
 
         r = LowLevelResponse("HEAD", 200, HttpVersion.h11, "OK", HTTPHeaderDict(), mock_sock)  # type: ignore[arg-type]
         resp = HTTPResponse(
@@ -1013,13 +1015,15 @@ class TestResponse:
         chunks = list(stream())
         idx = 0
 
-        def mock_sock(amt: int | None, stream_id: int | None) -> tuple[bytes, bool]:
+        def mock_sock(
+            amt: int | None, stream_id: int | None
+        ) -> tuple[bytes, bool, HTTPHeaderDict | None]:
             nonlocal chunks, idx
             if idx >= len(chunks):
-                return b"", True
+                return b"", True, None
             d = chunks[idx]
             idx += 1
-            return d, False
+            return d, False, None
 
         r = LowLevelResponse("GET", 200, HttpVersion.h11, "OK", HTTPHeaderDict(), mock_sock)  # type: ignore[arg-type]
 

--- a/test/with_traefik/asynchronous/test_conn_info.py
+++ b/test/with_traefik/asynchronous/test_conn_info.py
@@ -50,6 +50,7 @@ class TestConnectionInfo(TraefikTestCase):
         assert conn_info.tls_version is not None
         assert conn_info.cipher is not None
 
+    @pytest.mark.usefixtures("requires_http3")
     async def test_tls_on_udp(self) -> None:
         p = AsyncPoolManager(
             preemptive_quic_cache={

--- a/test/with_traefik/asynchronous/test_connection.py
+++ b/test/with_traefik/asynchronous/test_connection.py
@@ -12,6 +12,7 @@ from .. import TraefikTestCase
 
 @pytest.mark.asyncio
 class TestConnection(TraefikTestCase):
+    @pytest.mark.usefixtures("requires_http3")
     async def test_h3_probe_after_close(self) -> None:
         conn = AsyncHTTPSConnection(
             self.host,
@@ -78,6 +79,7 @@ class TestConnection(TraefikTestCase):
         with pytest.raises(ResponseNotReady):
             await conn.getresponse()
 
+    @pytest.mark.usefixtures("requires_http3")
     async def test_quic_cache_capable(self) -> None:
         quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = {
             (self.host, self.https_port): ("", self.https_port)
@@ -156,6 +158,7 @@ class TestConnection(TraefikTestCase):
         assert len(quic_cache_resumption.keys()) == 1
         assert (self.host, self.https_port) in quic_cache_resumption
 
+    @pytest.mark.usefixtures("requires_http3")
     async def test_quic_extract_ssl_ctx_ca_root(self) -> None:
         quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = {
             (self.host, self.https_port): ("", self.https_port)

--- a/test/with_traefik/asynchronous/test_connection.py
+++ b/test/with_traefik/asynchronous/test_connection.py
@@ -99,6 +99,7 @@ class TestConnection(TraefikTestCase):
         assert resp.status == 200
         assert resp.version == 30
 
+    @pytest.mark.usefixtures("requires_http3")
     async def test_quic_cache_capable_but_disabled(self) -> None:
         quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = {
             (self.host, self.https_port): ("", self.https_port)
@@ -119,6 +120,7 @@ class TestConnection(TraefikTestCase):
         assert resp.status == 200
         assert resp.version == 20
 
+    @pytest.mark.usefixtures("requires_http3")
     async def test_quic_cache_explicit_not_capable(self) -> None:
         quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = {
             (self.host, self.https_port): None
@@ -138,6 +140,7 @@ class TestConnection(TraefikTestCase):
         assert resp.status == 200
         assert resp.version == 20
 
+    @pytest.mark.usefixtures("requires_http3")
     async def test_quic_cache_implicit_not_capable(self) -> None:
         quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = dict()
 

--- a/test/with_traefik/asynchronous/test_connection_multiplexed.py
+++ b/test/with_traefik/asynchronous/test_connection_multiplexed.py
@@ -99,6 +99,7 @@ class TestConnectionMultiplexed(TraefikTestCase):
 
         assert len(conn._promises) == 0
 
+    @pytest.mark.usefixtures("requires_http3")
     async def test_multiplexing_upgrade_h3(self) -> None:
         conn = AsyncHTTPSConnection(
             self.host,

--- a/test/with_traefik/asynchronous/test_protolevel.py
+++ b/test/with_traefik/asynchronous/test_protolevel.py
@@ -115,27 +115,29 @@ class TestProtocolLevel(TraefikTestCase):
     @pytest.mark.parametrize(
         "expected_trailers",
         (
-                {"test-trailer-1": "v1"},
-                {"test-trailer-1": "v1", "foobar": "baz", "x-proto-winner": "woops"},
-                {"hello": "world", "this": "shall work", "every": "single time!"},
-                {}
-        )
+            {"test-trailer-1": "v1"},
+            {"test-trailer-1": "v1", "foobar": "baz", "x-proto-winner": "woops"},
+            {"hello": "world", "this": "shall work", "every": "single time!"},
+            {},
+        ),
     )
     @pytest.mark.parametrize(
         "disabled_svn",
         (
-                {HttpVersion.h2, HttpVersion.h3},  # Force HTTP/1
-                {HttpVersion.h11, HttpVersion.h3},  # ...   HTTP/2
-                {HttpVersion.h11, HttpVersion.h2},  # ...   HTTP/3
-        )
+            {HttpVersion.h2, HttpVersion.h3},  # Force HTTP/1
+            {HttpVersion.h11, HttpVersion.h3},  # ...   HTTP/2
+            {HttpVersion.h11, HttpVersion.h2},  # ...   HTTP/3
+        ),
     )
-    async def test_http_trailers(self, expected_trailers: dict[str, str], disabled_svn: set[HttpVersion]) -> None:
+    async def test_http_trailers(
+        self, expected_trailers: dict[str, str], disabled_svn: set[HttpVersion]
+    ) -> None:
         async with AsyncHTTPSConnectionPool(
-                self.host,
-                self.https_port,
-                ca_certs=self.ca_authority,
-                resolver=self.test_async_resolver,
-                disabled_svn=disabled_svn,
+            self.host,
+            self.https_port,
+            ca_certs=self.ca_authority,
+            resolver=self.test_async_resolver,
+            disabled_svn=disabled_svn,
         ) as p:
             resp = await p.request_encode_url(
                 "GET",

--- a/test/with_traefik/asynchronous/test_protolevel.py
+++ b/test/with_traefik/asynchronous/test_protolevel.py
@@ -133,6 +133,18 @@ class TestProtocolLevel(TraefikTestCase):
     async def test_http_trailers(
         self, expected_trailers: dict[str, str], disabled_svn: set[HttpVersion]
     ) -> None:
+        if HttpVersion.h11 not in disabled_svn:
+            expected_http_version = 11
+        elif HttpVersion.h2 not in disabled_svn:
+            expected_http_version = 20
+        elif HttpVersion.h3 not in disabled_svn:
+            expected_http_version = 30
+        else:
+            assert False, "unable to asses expected protocol"
+
+        if _HAS_HTTP3_SUPPORT() is False and expected_http_version == 30:
+            pytest.skip("Test requires http3")
+
         async with AsyncHTTPSConnectionPool(
             self.host,
             self.https_port,
@@ -148,15 +160,6 @@ class TestProtocolLevel(TraefikTestCase):
             )
 
             assert resp.status == 200
-
-            if HttpVersion.h11 not in disabled_svn:
-                expected_http_version = 11
-            elif HttpVersion.h2 not in disabled_svn:
-                expected_http_version = 20
-            elif HttpVersion.h3 not in disabled_svn:
-                expected_http_version = 30
-            else:
-                assert False, "unable to asses expected protocol"
 
             assert resp.version == expected_http_version
 

--- a/test/with_traefik/asynchronous/test_protolevel.py
+++ b/test/with_traefik/asynchronous/test_protolevel.py
@@ -4,7 +4,7 @@ import socket
 
 import pytest
 
-from urllib3 import AsyncHTTPSConnectionPool, HTTPHeaderDict
+from urllib3 import AsyncHTTPSConnectionPool, HTTPHeaderDict, HttpVersion
 from urllib3.exceptions import InsecureRequestWarning, ProtocolError
 from urllib3.util import parse_url
 from urllib3.util.request import SKIP_HEADER
@@ -111,3 +111,57 @@ class TestProtocolLevel(TraefikTestCase):
 
                 assert resp.status == 200
                 assert resp.version == 30
+
+    @pytest.mark.parametrize(
+        "expected_trailers",
+        (
+                {"test-trailer-1": "v1"},
+                {"test-trailer-1": "v1", "foobar": "baz", "x-proto-winner": "woops"},
+                {"hello": "world", "this": "shall work", "every": "single time!"},
+                {}
+        )
+    )
+    @pytest.mark.parametrize(
+        "disabled_svn",
+        (
+                {HttpVersion.h2, HttpVersion.h3},  # Force HTTP/1
+                {HttpVersion.h11, HttpVersion.h3},  # ...   HTTP/2
+                {HttpVersion.h11, HttpVersion.h2},  # ...   HTTP/3
+        )
+    )
+    async def test_http_trailers(self, expected_trailers: dict[str, str], disabled_svn: set[HttpVersion]) -> None:
+        async with AsyncHTTPSConnectionPool(
+                self.host,
+                self.https_port,
+                ca_certs=self.ca_authority,
+                resolver=self.test_async_resolver,
+                disabled_svn=disabled_svn,
+        ) as p:
+            resp = await p.request_encode_url(
+                "GET",
+                f"{self.https_url}/trailers",
+                fields=expected_trailers,
+                retries=False,
+            )
+
+            assert resp.status == 200
+
+            if HttpVersion.h11 not in disabled_svn:
+                expected_http_version = 11
+            elif HttpVersion.h2 not in disabled_svn:
+                expected_http_version = 20
+            elif HttpVersion.h3 not in disabled_svn:
+                expected_http_version = 30
+            else:
+                assert False, "unable to asses expected protocol"
+
+            assert resp.version == expected_http_version
+
+            if expected_trailers:
+                assert resp.trailers is not None
+
+                for k, v in expected_trailers.items():
+                    assert k in resp.trailers
+                    assert resp.trailers[k] == v
+            else:
+                assert resp.trailers is None

--- a/test/with_traefik/asynchronous/test_protolevel.py
+++ b/test/with_traefik/asynchronous/test_protolevel.py
@@ -5,6 +5,7 @@ import socket
 import pytest
 
 from urllib3 import AsyncHTTPSConnectionPool, HTTPHeaderDict, HttpVersion
+from urllib3.backend.hface import _HAS_HTTP3_SUPPORT
 from urllib3.exceptions import InsecureRequestWarning, ProtocolError
 from urllib3.util import parse_url
 from urllib3.util.request import SKIP_HEADER
@@ -110,7 +111,7 @@ class TestProtocolLevel(TraefikTestCase):
                 )
 
                 assert resp.status == 200
-                assert resp.version == 30
+                assert resp.version == 30 if _HAS_HTTP3_SUPPORT() else 20
 
     @pytest.mark.parametrize(
         "expected_trailers",

--- a/test/with_traefik/asynchronous/test_send_data.py
+++ b/test/with_traefik/asynchronous/test_send_data.py
@@ -86,21 +86,6 @@ class TestPostBody(TraefikTestCase):
                 if isinstance(body, BytesIO):
                     body.seek(0, 0)
 
-                # in some cases, urllib3 cannot infer in advance the body full length
-                # it will trigger a stream upload
-                # http1.1 => (Transfer-Encoding: chunked) legacy algorithm
-                # http2+  => send data frames, server aware of the end with the FIN bit.
-                expect_no_content_length = isinstance(body, BytesIO) or hasattr(
-                    body, "__next__"
-                )
-
-                # traefik bug with http3, should not happen!
-                # see https://github.com/traefik/traefik/issues/10185
-                if i > 0 and expect_no_content_length:
-                    pytest.skip(
-                        "traefik bug with http3 forbid stream upload without content-length"
-                    )
-
                 resp = await p.request(method, f"/{method.lower()}", body=body)
 
                 assert resp.status == 200

--- a/test/with_traefik/asynchronous/test_send_data.py
+++ b/test/with_traefik/asynchronous/test_send_data.py
@@ -7,6 +7,7 @@ from io import BytesIO
 import pytest
 
 from urllib3 import AsyncHTTPSConnectionPool
+from urllib3.backend._async.hface import _HAS_HTTP3_SUPPORT  # type: ignore
 
 from .. import TraefikTestCase
 
@@ -89,7 +90,11 @@ class TestPostBody(TraefikTestCase):
                 resp = await p.request(method, f"/{method.lower()}", body=body)
 
                 assert resp.status == 200
-                assert resp.version == (20 if i == 0 else 30)
+
+                if _HAS_HTTP3_SUPPORT():
+                    assert resp.version == (20 if i == 0 else 30)
+                else:
+                    assert resp.version == 20
 
                 echo_data_from_httpbin = (await resp.json())["data"]
                 need_b64_decode = echo_data_from_httpbin.startswith(
@@ -146,7 +151,10 @@ class TestPostBody(TraefikTestCase):
                 resp = await p.request(method, f"/{method.lower()}", fields=fields)
 
                 assert resp.status == 200
-                assert resp.version == (20 if i == 0 else 30)
+                if _HAS_HTTP3_SUPPORT():
+                    assert resp.version == (20 if i == 0 else 30)
+                else:
+                    assert resp.version == 20
 
                 payload = await resp.json()
 

--- a/test/with_traefik/asynchronous/test_stream.py
+++ b/test/with_traefik/asynchronous/test_stream.py
@@ -5,6 +5,7 @@ from json import JSONDecodeError, loads
 import pytest
 
 from urllib3 import AsyncHTTPSConnectionPool
+from urllib3.backend._async.hface import _HAS_HTTP3_SUPPORT  # type: ignore
 
 from .. import TraefikTestCase
 
@@ -35,7 +36,10 @@ class TestStreamResponse(TraefikTestCase):
                 resp = await p.request("GET", "/get", preload_content=False)
 
                 assert resp.status == 200
-                assert resp.version == (20 if i == 0 else 30)
+                if _HAS_HTTP3_SUPPORT():
+                    assert resp.version == (20 if i == 0 else 30)
+                else:
+                    assert resp.version == 20
 
                 chunks = []
 

--- a/test/with_traefik/asynchronous/test_svn.py
+++ b/test/with_traefik/asynchronous/test_svn.py
@@ -42,6 +42,7 @@ class TestSvnCapability(TraefikTestCase):
 
             assert resp.version == 20
 
+    @pytest.mark.usefixtures("requires_http3")
     async def test_upgrade_h3(self) -> None:
         async with AsyncHTTPSConnectionPool(
             self.host,
@@ -171,6 +172,7 @@ class TestSvnCapability(TraefikTestCase):
                     == 'h3-25=":443"; ma=3600, h3="evil.httpbin.local:443"; ma=3600'
                 )
 
+    @pytest.mark.usefixtures("requires_http3")
     async def test_other_port_upgrade_h3(self) -> None:
         async with AsyncHTTPSConnectionPool(
             self.host,
@@ -240,6 +242,7 @@ class TestSvnCapability(TraefikTestCase):
         assert resp.version == 20
         assert resp.status == 200
 
+    @pytest.mark.usefixtures("requires_http3")
     async def test_drop_post_established_h3(self) -> None:
         conn = AsyncHTTPSConnection(
             self.host,
@@ -272,6 +275,7 @@ class TestSvnCapability(TraefikTestCase):
         assert resp.version == 20
         assert resp.status == 200
 
+    @pytest.mark.usefixtures("requires_http3")
     async def test_pool_manager_quic_cache(self) -> None:
         dumb_cache: dict[tuple[str, int], tuple[str, int] | None] = dict()
         pm = AsyncPoolManager(

--- a/test/with_traefik/asynchronous/test_svn.py
+++ b/test/with_traefik/asynchronous/test_svn.py
@@ -87,7 +87,7 @@ class TestSvnCapability(TraefikTestCase):
                 if _HAS_HTTP3_SUPPORT():
                     assert resp.version == (11 if i == 0 else 30)
                 else:
-                    assert resp.version == (11 if i == 0 else 20)
+                    assert resp.version == 11
 
     async def test_can_disable_h11(self) -> None:
         p = AsyncHTTPSConnectionPool(

--- a/test/with_traefik/asynchronous/test_svn.py
+++ b/test/with_traefik/asynchronous/test_svn.py
@@ -338,7 +338,4 @@ class TestSvnCapability(TraefikTestCase):
                 assert resp.version == 11 if i == 0 else 20
 
                 assert "Alt-Svc" in resp.headers
-                assert (
-                    resp.headers.get("Alt-Svc")
-                    == f'h2c=":{self.http_alt_port}"'
-                )
+                assert resp.headers.get("Alt-Svc") == f'h2c=":{self.http_alt_port}"'

--- a/test/with_traefik/test_conn_info.py
+++ b/test/with_traefik/test_conn_info.py
@@ -75,6 +75,7 @@ class TestConnectionInfo(TraefikTestCase):
         assert conn_info.tls_version is not None
         assert conn_info.cipher is not None
 
+    @pytest.mark.usefixtures("requires_http3")
     def test_tls_on_udp(self) -> None:
         p = PoolManager(
             preemptive_quic_cache={

--- a/test/with_traefik/test_connection.py
+++ b/test/with_traefik/test_connection.py
@@ -11,6 +11,7 @@ from . import TraefikTestCase
 
 
 class TestConnection(TraefikTestCase):
+    @pytest.mark.usefixtures("requires_http3")
     def test_h3_probe_after_close(self) -> None:
         conn = HTTPSConnection(
             self.host,
@@ -77,6 +78,7 @@ class TestConnection(TraefikTestCase):
         with pytest.raises(ResponseNotReady):
             conn.getresponse()
 
+    @pytest.mark.usefixtures("requires_http3")
     def test_quic_cache_capable(self) -> None:
         quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = {
             (self.host, self.https_port): ("", self.https_port)
@@ -155,6 +157,7 @@ class TestConnection(TraefikTestCase):
         assert len(quic_cache_resumption.keys()) == 1
         assert (self.host, self.https_port) in quic_cache_resumption
 
+    @pytest.mark.usefixtures("requires_http3")
     def test_quic_extract_ssl_ctx_ca_root(self) -> None:
         quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = {
             (self.host, self.https_port): ("", self.https_port)

--- a/test/with_traefik/test_connection.py
+++ b/test/with_traefik/test_connection.py
@@ -118,6 +118,7 @@ class TestConnection(TraefikTestCase):
         assert resp.status == 200
         assert resp.version == 20
 
+    @pytest.mark.usefixtures("requires_http3")
     def test_quic_cache_explicit_not_capable(self) -> None:
         quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = {
             (self.host, self.https_port): None
@@ -137,6 +138,7 @@ class TestConnection(TraefikTestCase):
         assert resp.status == 200
         assert resp.version == 20
 
+    @pytest.mark.usefixtures("requires_http3")
     def test_quic_cache_implicit_not_capable(self) -> None:
         quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = dict()
 

--- a/test/with_traefik/test_connection_multiplexed.py
+++ b/test/with_traefik/test_connection_multiplexed.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from time import time
 
+import pytest
+
 from urllib3.connection import HTTPSConnection
 
 from . import TraefikTestCase
@@ -96,6 +98,7 @@ class TestConnectionMultiplexed(TraefikTestCase):
 
         assert len(conn._promises) == 0
 
+    @pytest.mark.usefixtures("requires_http3")
     def test_multiplexing_upgrade_h3(self) -> None:
         conn = HTTPSConnection(
             self.host,

--- a/test/with_traefik/test_protolevel.py
+++ b/test/with_traefik/test_protolevel.py
@@ -130,27 +130,29 @@ class TestProtocolLevel(TraefikTestCase):
     @pytest.mark.parametrize(
         "expected_trailers",
         (
-                {"test-trailer-1": "v1"},
-                {"test-trailer-1": "v1", "foobar": "baz", "x-proto-winner": "woops"},
-                {"hello": "world", "this": "shall work", "every": "single time!"},
-                {}
-        )
+            {"test-trailer-1": "v1"},
+            {"test-trailer-1": "v1", "foobar": "baz", "x-proto-winner": "woops"},
+            {"hello": "world", "this": "shall work", "every": "single time!"},
+            {},
+        ),
     )
     @pytest.mark.parametrize(
         "disabled_svn",
         (
             {HttpVersion.h2, HttpVersion.h3},  # Force HTTP/1
-            {HttpVersion.h11, HttpVersion.h3}, # ...   HTTP/2
-            {HttpVersion.h11, HttpVersion.h2}, # ...   HTTP/3
-        )
+            {HttpVersion.h11, HttpVersion.h3},  # ...   HTTP/2
+            {HttpVersion.h11, HttpVersion.h2},  # ...   HTTP/3
+        ),
     )
-    def test_http_trailers(self, expected_trailers: dict[str, str], disabled_svn: set[HttpVersion]) -> None:
+    def test_http_trailers(
+        self, expected_trailers: dict[str, str], disabled_svn: set[HttpVersion]
+    ) -> None:
         with HTTPSConnectionPool(
-                self.host,
-                self.https_port,
-                ca_certs=self.ca_authority,
-                resolver=self.test_resolver,
-                disabled_svn=disabled_svn,
+            self.host,
+            self.https_port,
+            ca_certs=self.ca_authority,
+            resolver=self.test_resolver,
+            disabled_svn=disabled_svn,
         ) as p:
             resp = p.request_encode_url(
                 "GET",

--- a/test/with_traefik/test_protolevel.py
+++ b/test/with_traefik/test_protolevel.py
@@ -126,3 +126,57 @@ class TestProtocolLevel(TraefikTestCase):
 
             assert resp.status == 200
             assert resp.version == 20
+
+    @pytest.mark.parametrize(
+        "expected_trailers",
+        (
+                {"test-trailer-1": "v1"},
+                {"test-trailer-1": "v1", "foobar": "baz", "x-proto-winner": "woops"},
+                {"hello": "world", "this": "shall work", "every": "single time!"},
+                {}
+        )
+    )
+    @pytest.mark.parametrize(
+        "disabled_svn",
+        (
+            {HttpVersion.h2, HttpVersion.h3},  # Force HTTP/1
+            {HttpVersion.h11, HttpVersion.h3}, # ...   HTTP/2
+            {HttpVersion.h11, HttpVersion.h2}, # ...   HTTP/3
+        )
+    )
+    def test_http_trailers(self, expected_trailers: dict[str, str], disabled_svn: set[HttpVersion]) -> None:
+        with HTTPSConnectionPool(
+                self.host,
+                self.https_port,
+                ca_certs=self.ca_authority,
+                resolver=self.test_resolver,
+                disabled_svn=disabled_svn,
+        ) as p:
+            resp = p.request_encode_url(
+                "GET",
+                f"{self.https_url}/trailers",
+                fields=expected_trailers,
+                retries=False,
+            )
+
+            assert resp.status == 200
+
+            if HttpVersion.h11 not in disabled_svn:
+                expected_http_version = 11
+            elif HttpVersion.h2 not in disabled_svn:
+                expected_http_version = 20
+            elif HttpVersion.h3 not in disabled_svn:
+                expected_http_version = 30
+            else:
+                assert False, "unable to asses expected protocol"
+
+            assert resp.version == expected_http_version
+
+            if expected_trailers:
+                assert resp.trailers is not None
+
+                for k, v in expected_trailers.items():
+                    assert k in resp.trailers
+                    assert resp.trailers[k] == v
+            else:
+                assert resp.trailers is None

--- a/test/with_traefik/test_protolevel.py
+++ b/test/with_traefik/test_protolevel.py
@@ -5,6 +5,7 @@ import socket
 import pytest
 
 from urllib3 import HTTPConnectionPool, HTTPHeaderDict, HTTPSConnectionPool, HttpVersion
+from urllib3.backend.hface import _HAS_HTTP3_SUPPORT
 from urllib3.exceptions import InsecureRequestWarning, ProtocolError
 from urllib3.util import parse_url
 from urllib3.util.request import SKIP_HEADER
@@ -109,7 +110,7 @@ class TestProtocolLevel(TraefikTestCase):
                 )
 
                 assert resp.status == 200
-                assert resp.version == 30
+                assert resp.version == 30 if _HAS_HTTP3_SUPPORT() else 20
 
     def test_http2_with_prior_knowledge(self) -> None:
         with HTTPConnectionPool(

--- a/test/with_traefik/test_protolevel.py
+++ b/test/with_traefik/test_protolevel.py
@@ -148,6 +148,18 @@ class TestProtocolLevel(TraefikTestCase):
     def test_http_trailers(
         self, expected_trailers: dict[str, str], disabled_svn: set[HttpVersion]
     ) -> None:
+        if HttpVersion.h11 not in disabled_svn:
+            expected_http_version = 11
+        elif HttpVersion.h2 not in disabled_svn:
+            expected_http_version = 20
+        elif HttpVersion.h3 not in disabled_svn:
+            expected_http_version = 30
+        else:
+            assert False, "unable to asses expected protocol"
+
+        if _HAS_HTTP3_SUPPORT() is False and expected_http_version == 30:
+            pytest.skip("Test requires http3")
+
         with HTTPSConnectionPool(
             self.host,
             self.https_port,
@@ -163,16 +175,6 @@ class TestProtocolLevel(TraefikTestCase):
             )
 
             assert resp.status == 200
-
-            if HttpVersion.h11 not in disabled_svn:
-                expected_http_version = 11
-            elif HttpVersion.h2 not in disabled_svn:
-                expected_http_version = 20
-            elif HttpVersion.h3 not in disabled_svn:
-                expected_http_version = 30
-            else:
-                assert False, "unable to asses expected protocol"
-
             assert resp.version == expected_http_version
 
             if expected_trailers:

--- a/test/with_traefik/test_send_data.py
+++ b/test/with_traefik/test_send_data.py
@@ -85,21 +85,6 @@ class TestPostBody(TraefikTestCase):
                 if isinstance(body, BytesIO):
                     body.seek(0, 0)
 
-                # in some cases, urllib3 cannot infer in advance the body full length
-                # it will trigger a stream upload
-                # http1.1 => (Transfer-Encoding: chunked) legacy algorithm
-                # http2+  => send data frames, server aware of the end with the FIN bit.
-                expect_no_content_length = isinstance(body, BytesIO) or hasattr(
-                    body, "__next__"
-                )
-
-                # traefik bug with http3, should not happen!
-                # see https://github.com/traefik/traefik/issues/10185
-                if i > 0 and expect_no_content_length:
-                    pytest.skip(
-                        "traefik bug with http3 forbid stream upload without content-length"
-                    )
-
                 resp = p.request(method, f"/{method.lower()}", body=body)
 
                 assert resp.status == 200

--- a/test/with_traefik/test_send_data.py
+++ b/test/with_traefik/test_send_data.py
@@ -7,6 +7,7 @@ from io import BytesIO
 import pytest
 
 from urllib3 import HTTPSConnectionPool
+from urllib3.backend.hface import _HAS_HTTP3_SUPPORT
 
 from . import TraefikTestCase
 
@@ -88,7 +89,11 @@ class TestPostBody(TraefikTestCase):
                 resp = p.request(method, f"/{method.lower()}", body=body)
 
                 assert resp.status == 200
-                assert resp.version == (20 if i == 0 else 30)
+
+                if _HAS_HTTP3_SUPPORT():
+                    assert resp.version == (20 if i == 0 else 30)
+                else:
+                    assert resp.version == 20
 
                 echo_data_from_httpbin = resp.json()["data"]
                 need_b64_decode = echo_data_from_httpbin.startswith(
@@ -145,7 +150,10 @@ class TestPostBody(TraefikTestCase):
                 resp = p.request(method, f"/{method.lower()}", fields=fields)
 
                 assert resp.status == 200
-                assert resp.version == (20 if i == 0 else 30)
+                if _HAS_HTTP3_SUPPORT():
+                    assert resp.version == (20 if i == 0 else 30)
+                else:
+                    assert resp.version == 20
 
                 payload = resp.json()
 

--- a/test/with_traefik/test_stream.py
+++ b/test/with_traefik/test_stream.py
@@ -5,6 +5,7 @@ from json import JSONDecodeError, loads
 import pytest
 
 from urllib3 import HTTPSConnectionPool
+from urllib3.backend.hface import _HAS_HTTP3_SUPPORT
 
 from . import TraefikTestCase
 
@@ -34,7 +35,10 @@ class TestStreamResponse(TraefikTestCase):
                 resp = p.request("GET", "/get", preload_content=False)
 
                 assert resp.status == 200
-                assert resp.version == (20 if i == 0 else 30)
+                if _HAS_HTTP3_SUPPORT():
+                    assert resp.version == (20 if i == 0 else 30)
+                else:
+                    assert resp.version == 20
 
                 chunks = []
 

--- a/test/with_traefik/test_svn.py
+++ b/test/with_traefik/test_svn.py
@@ -36,6 +36,7 @@ class TestSvnCapability(TraefikTestCase):
 
             assert resp.version == 20
 
+    @pytest.mark.usefixtures("requires_http3")
     def test_upgrade_h3(self) -> None:
         with HTTPSConnectionPool(
             self.host,
@@ -163,6 +164,7 @@ class TestSvnCapability(TraefikTestCase):
                     == 'h3-25=":443"; ma=3600, h3="evil.httpbin.local:443"; ma=3600'
                 )
 
+    @pytest.mark.usefixtures("requires_http3")
     def test_other_port_upgrade_h3(self) -> None:
         with HTTPSConnectionPool(
             self.host,
@@ -232,6 +234,7 @@ class TestSvnCapability(TraefikTestCase):
         assert resp.version == 20
         assert resp.status == 200
 
+    @pytest.mark.usefixtures("requires_http3")
     def test_drop_post_established_h3(self) -> None:
         conn = HTTPSConnection(
             self.host,
@@ -264,6 +267,7 @@ class TestSvnCapability(TraefikTestCase):
         assert resp.version == 20
         assert resp.status == 200
 
+    @pytest.mark.usefixtures("requires_http3")
     def test_pool_manager_quic_cache(self) -> None:
         dumb_cache: dict[tuple[str, int], tuple[str, int] | None] = dict()
         pm = PoolManager(

--- a/test/with_traefik/test_svn.py
+++ b/test/with_traefik/test_svn.py
@@ -81,7 +81,7 @@ class TestSvnCapability(TraefikTestCase):
                 if _HAS_HTTP3_SUPPORT():
                     assert resp.version == (11 if i == 0 else 30)
                 else:
-                    assert resp.version == (11 if i == 0 else 20)
+                    assert resp.version == 11
 
     def test_can_disable_h11(self) -> None:
         p = HTTPSConnectionPool(

--- a/test/with_traefik/test_svn.py
+++ b/test/with_traefik/test_svn.py
@@ -314,7 +314,4 @@ class TestSvnCapability(TraefikTestCase):
                 assert resp.version == 11 if i == 0 else 20
 
                 assert "Alt-Svc" in resp.headers
-                assert (
-                    resp.headers.get("Alt-Svc")
-                    == f'h2c=":{self.http_alt_port}"'
-                )
+                assert resp.headers.get("Alt-Svc") == f'h2c=":{self.http_alt_port}"'

--- a/test/with_traefik/test_svn.py
+++ b/test/with_traefik/test_svn.py
@@ -296,3 +296,25 @@ class TestSvnCapability(TraefikTestCase):
         assert resp.version == 30
 
         assert len(dumb_cache.keys()) == 1
+
+    def test_can_upgrade_h2c_via_altsvc(self) -> None:
+        with HTTPConnectionPool(
+            self.host,
+            self.http_alt_port,
+            timeout=1,
+            retries=False,
+            resolver=self.test_resolver,
+        ) as p:
+            for i in range(3):
+                resp = p.request(
+                    "GET",
+                    f"/response-headers?Alt-Svc=h2c%3D%22%3A{self.http_alt_port}%22",
+                )
+
+                assert resp.version == 11 if i == 0 else 20
+
+                assert "Alt-Svc" in resp.headers
+                assert (
+                    resp.headers.get("Alt-Svc")
+                    == f'h2c=":{self.http_alt_port}"'
+                )


### PR DESCRIPTION
2.9.900 (2024-09-24)
====================

- Fixed a rare issue where HTTPS record is misinterpreted, thus leading to a missed preemptive HTTP/3 negotiation.
- Restored support for older-and-deprecated ``PySocks`` if installed and ``python-socks`` is absent for synchronous support of SOCKS proxies.
- Added support for HTTP Trailers across HTTP/1, HTTP/2 and HTTP/3 responses. We added the property ``trailers`` in ``HTTPResponse`` to reflect that.
- Fixed unclosed resource warning for socket created in asynchronous mode.
- Added support for Upgrading to HTTP/2 (If coming from HTTP/1) via Alt-Svc. Whether it's h2c (http/2 over cleartext) or h2.
- Largely improve download speed on the QUIC layer by increasing automatically the blocksize to the largest value allowed on UDP (value taken from sysconf).
- Fixed the test suite outcome if no support for HTTP/3 exist in current environment.

