### PR TITLE
Release 2.10.903

### DIFF
--- a/.github/workflows/ci-dead-things.yml
+++ b/.github/workflows/ci-dead-things.yml
@@ -38,3 +38,23 @@ jobs:
 
       - name: "Run against Python 3.7 built with OpenSSL 1.0.2q"
         run: ./ci/run_legacy_openssl.sh
+
+  dead-pip:
+    name: Ensure pip <21.2.4
+    runs-on: ubuntu-20.04
+    timeout-minutes: 5
+
+    steps:
+      - name: "Checkout repository"
+        uses: "actions/checkout@d632683dd7b4114ad314bca15554477dd762a938"
+
+      - name: "Setup Python"
+        uses: "actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3"
+        with:
+          python-version: "3.7"
+
+      - name: "Enforce pip 20.x"
+        run: python -m pip install "pip<21"
+
+      - name: "Ensure that urllib3-future can be installed"
+        run: python -m pip install .

--- a/.github/workflows/ci-dead-things.yml
+++ b/.github/workflows/ci-dead-things.yml
@@ -38,23 +38,3 @@ jobs:
 
       - name: "Run against Python 3.7 built with OpenSSL 1.0.2q"
         run: ./ci/run_legacy_openssl.sh
-
-  dead-pip:
-    name: Ensure pip <21.2.4
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    steps:
-      - name: "Checkout repository"
-        uses: "actions/checkout@d632683dd7b4114ad314bca15554477dd762a938"
-
-      - name: "Setup Python"
-        uses: "actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3"
-        with:
-          python-version: "3.7"
-
-      - name: "Enforce pip 20.x"
-        run: python -m pip install "pip<21"
-
-      - name: "Ensure that urllib3-future can be installed"
-        run: python -m pip install .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           - macos-13
           - windows-2022
           - ubuntu-20.04  # OpenSSL 1.1.1
-          - ubuntu-latest  # OpenSSL 3.0
+          - ubuntu-22.04  # OpenSSL 3.0
         nox-session: ['']
         include:
           - experimental: false
@@ -91,7 +91,7 @@ jobs:
             os: ubuntu-22.04
 
     runs-on: ${{ matrix.os }}
-    name: ${{ fromJson('{"macos-13":"macOS","windows-2022":"Windows","ubuntu-latest":"Ubuntu","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)","ubuntu-latest":"Ubuntu Latest (OpenSSL 3+)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session }}
+    name: ${{ fromJson('{"macos-13":"macOS","windows-2022":"Windows","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)","ubuntu-22.04":"Ubuntu 22 (OpenSSL 3+)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session }}
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 40
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.10.903 (2024-10-12)
+=====================
+
+- Fixed exception leaks in ExtensionFromHTTP plugins. Now every extension behave and raise urllib3 own exceptions.
+- Added automatic connection downgrade HTTP/2 -> HTTP/1.1 or HTTP/3 -> (HTTP/2 or HTTP/1.1) in case of known recoverable issues.
+- Fixed a rare issue where the write semaphore (async context) for a datagram socket would be locked forever in case of an error.
+
 2.10.902 (2024-10-09)
 =====================
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - Helpers for retrying requests and dealing with HTTP redirects.
 - Support for gzip, deflate, brotli, and zstd encoding.
 - Support for Python/PyPy 3.7+, no compromise.
+- Automatic Connection Upgrade / Downgrade.
 - Early (Informational) Responses / Hints.
 - HTTP/1.1, HTTP/2 and HTTP/3 support.
 - WebSocket over HTTP/2+ (RFC8441).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ urllib3.future
 
 - ⚡ urllib3.future is a powerful, *user-friendly* HTTP client for Python.
 - ⚡ urllib3.future goes beyond supported features while remaining compatible.
-- ⚡ urllib3.future brings many critical features that are missing from both the Python standard libraries and **urllib3**:
+- ⚡ urllib3.future brings many critical features that are missing from both the Python standard libraries and **urllib3**!
 
 
 - Async.
@@ -31,13 +31,19 @@ urllib3.future
 - Helpers for retrying requests and dealing with HTTP redirects.
 - Support for gzip, deflate, brotli, and zstd encoding.
 - Support for Python/PyPy 3.7+, no compromise.
+- Automatic Connection Upgrade / Downgrade.
+- Early (Informational) Responses / Hints.
 - HTTP/1.1, HTTP/2 and HTTP/3 support.
+- WebSocket over HTTP/2+ (RFC8441).
 - Proxy support for HTTP and SOCKS.
+- Post-Quantum Security with QUIC.
 - Detailed connection inspection.
 - HTTP/2 with prior knowledge.
 - Multiplexed connection.
 - Mirrored Sync & Async.
+- Trailer Headers.
 - Amazingly Fast.
+- WebSocket.
 
 urllib3 is powerful and easy to use:
 
@@ -49,6 +55,8 @@ urllib3 is powerful and easy to use:
    200
    >>> resp.data
    b"User-agent: *\nDisallow: /deny\n"
+   >>> resp.version
+   20
 
 Installing
 ----------

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -195,6 +195,16 @@ class AsyncHTTPConnection(AsyncHfaceBackend):
         """
         await super()._new_conn()
 
+        backup_timeout: float | None = -1.0
+
+        # we want to purposely mitigate the following scenario:
+        #   "A server yield its support for HTTP/2 or HTTP/3 through Alt-Svc, but
+        #    it cannot connect to the alt-svc, thus confusing the end-user on why it
+        #    waits forever for the 2nd request."
+        if self._max_tolerable_delay_for_upgrade is not None:
+            backup_timeout = self.timeout
+            self.timeout = self._max_tolerable_delay_for_upgrade
+
         try:
             sock = await self._resolver.create_connection(
                 (self._dns_host, self.port or self.default_port),
@@ -220,6 +230,9 @@ class AsyncHTTPConnection(AsyncHfaceBackend):
             raise NewConnectionError(
                 self, f"Failed to establish a new connection: {e}"
             ) from e
+        finally:
+            if backup_timeout != -1:
+                self.timeout = backup_timeout
 
         # We can, migrate to a DGRAM socket if DNS HTTPS/RR record exist and yield HTTP/3+QUIC support.
         if sock.type == socket.SOCK_DGRAM and self.socket_kind == socket.SOCK_STREAM:

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.10.902"
+__version__ = "2.10.903"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -251,9 +251,9 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                     self._max_tolerable_delay_for_upgrade += (
                         self.conn_info.tls_handshake_latency.total_seconds()
                     )
-                self._max_tolerable_delay_for_upgrade *= 1.5
-            else:  # by default (fallback) to 1000ms
-                self._max_tolerable_delay_for_upgrade = 1.0
+                self._max_tolerable_delay_for_upgrade *= 10.0
+            else:  # by default (safe/conservative fallback) to 3000ms
+                self._max_tolerable_delay_for_upgrade = 3.0
 
             if upgradable_svn == HttpVersion.h3:
                 if self._preemptive_quic_cache is not None:
@@ -562,6 +562,9 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                     alt_key = (self.host, self.__origin_port or 443)
                     if alt_key in self._preemptive_quic_cache:
                         del self._preemptive_quic_cache[alt_key]
+
+                # this avoid the close() to attempt re-use the (dead) sock
+                self._protocol = None
 
                 raise MustDowngradeError(
                     f"The server yielded its support for {self._svn} through the Alt-Svc header while unable to do so. "

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -547,6 +547,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
             TimeoutError,
             SocketTimeout,
             ConnectionRefusedError,
+            ConnectionResetError,
         ) as e:
             if (
                 isinstance(self._protocol, HTTPOverQUICProtocol)

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -6,6 +6,7 @@ import typing
 from datetime import datetime, timezone
 from functools import lru_cache
 from socket import SOCK_DGRAM, SOCK_STREAM
+from socket import timeout as SocketTimeout
 
 try:  # Compiled with SSL?
     import ssl
@@ -45,6 +46,7 @@ from ..exceptions import (
     EarlyResponse,
     IncompleteRead,
     InvalidHeader,
+    MustDowngradeError,
     ProtocolError,
     ResponseNotReady,
     SSLError,
@@ -126,7 +128,11 @@ class HfaceBackend(BaseBackend):
         # h3 specifics
         self.__custom_tls_settings: QuicTLSConfig | None = None
         self.__alt_authority: tuple[str, int] | None = None
+        self.__origin_port: int | None = None
         self.__session_ticket: typing.Any | None = None
+
+        # automatic upgrade shield against errors!
+        self._max_tolerable_delay_for_upgrade: float | None = None
 
     @property
     def is_saturated(self) -> bool:
@@ -241,6 +247,24 @@ class HfaceBackend(BaseBackend):
                 self.__alt_authority = self.__altsvc_probe(svc="h2")
 
         if self.__alt_authority:
+            # we want to infer a "best delay" to wait for silent upgrade.
+            # for that we use the previous known delay for handshake or establishment.
+            # and apply a "safe" margin of 50%.
+            if (
+                self.conn_info is not None
+                and self.conn_info.established_latency is not None
+            ):
+                self._max_tolerable_delay_for_upgrade = (
+                    self.conn_info.established_latency.total_seconds()
+                )
+                if self.conn_info.tls_handshake_latency is not None:
+                    self._max_tolerable_delay_for_upgrade += (
+                        self.conn_info.tls_handshake_latency.total_seconds()
+                    )
+                self._max_tolerable_delay_for_upgrade *= 1.5
+            else:  # by default (fallback) to 1000ms
+                self._max_tolerable_delay_for_upgrade = 1.0
+
             if upgradable_svn == HttpVersion.h3:
                 if self._preemptive_quic_cache is not None:
                     self._preemptive_quic_cache[
@@ -251,6 +275,7 @@ class HfaceBackend(BaseBackend):
                         return
 
             self._svn = upgradable_svn
+            self.__origin_port = self.port
             # We purposely ignore setting the Hostname. Avoid MITM attack from local cache attack.
             self.port = self.__alt_authority[1]
             self.close()
@@ -558,22 +583,47 @@ class HfaceBackend(BaseBackend):
 
             return
 
-        # it may be required to send some initial data, aka. magic header (PRI * HTTP/2..)
+        # we want to purposely mitigate the following scenario:
+        #   "A server yield its support for HTTP/2 or HTTP/3 through Alt-Svc, but
+        #    it cannot connect to the alt-svc, thus confusing the end-user on why it
+        #    waits forever for the 2nd request."
+        if self._max_tolerable_delay_for_upgrade is not None:
+            self.sock.settimeout(self._max_tolerable_delay_for_upgrade)
+
         try:
             self.__exchange_until(
                 HandshakeCompleted,
                 receive_first=False,
             )
-        except ProtocolError as e:
-            if (
-                isinstance(self._protocol, HTTPOverQUICProtocol)
-                and self.__alt_authority is not None
-            ):
-                raise ProtocolError(
-                    "The server yielded its support for HTTP/3 through the Alt-Svc header while unable to do so. "
-                    "To remediate that issue, either disable http3 or reach out to the server admin."
+        except (
+            ProtocolError,
+            TimeoutError,
+            SocketTimeout,
+            ConnectionRefusedError,
+        ) as e:
+            if self.__alt_authority is not None:
+                # we want to remove invalid quic cache capability
+                # because the alt-svc was probably bogus...
+                if (
+                    self._svn == HttpVersion.h3
+                    and self._preemptive_quic_cache is not None
+                ):
+                    alt_key = (self.host, self.__origin_port or 443)
+                    if alt_key in self._preemptive_quic_cache:
+                        del self._preemptive_quic_cache[alt_key]
+
+                raise MustDowngradeError(
+                    f"The server yielded its support for {self._svn} through the Alt-Svc header while unable to do so. "
+                    f"To remediate that issue, either disable {self._svn} or reach out to the server admin."
                 ) from e
             raise
+
+        if self._max_tolerable_delay_for_upgrade is not None:
+            self.sock.settimeout(self.timeout)
+
+        self._max_tolerable_delay_for_upgrade = (
+            None  # upgrade went fine. discard the value!
+        )
 
         #: Populating ConnectionInfo using QUIC TLS interfaces
         if isinstance(self._protocol, HTTPOverQUICProtocol):
@@ -836,6 +886,15 @@ class HfaceBackend(BaseBackend):
 
                     raise ProtocolError(event.message)
                 elif stream_related_event and isinstance(event, StreamResetReceived):
+                    # we want to catch MUST_USE_HTTP_1_1 or H3_VERSION_FALLBACK
+                    # HTTP/2 https://www.rfc-editor.org/rfc/rfc9113.html#name-error-codes
+                    # HTTP/3 https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#http3-parameters-error-codes
+                    if (self._svn == HttpVersion.h2 and event.error_code == 0xD) or (
+                        self._svn == HttpVersion.h3 and event.error_code == 0x0110
+                    ):
+                        raise MustDowngradeError(
+                            f"The remote server is unable to serve this resource over {self._svn}"
+                        )
                     raise ProtocolError(
                         f"Stream {event.stream_id} was reset by remote peer. Reason: {hex(event.error_code)}."
                     )

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -600,6 +600,7 @@ class HfaceBackend(BaseBackend):
             TimeoutError,
             SocketTimeout,
             ConnectionRefusedError,
+            ConnectionResetError,
         ) as e:
             if self.__alt_authority is not None:
                 # we want to remove invalid quic cache capability

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -261,9 +261,9 @@ class HfaceBackend(BaseBackend):
                     self._max_tolerable_delay_for_upgrade += (
                         self.conn_info.tls_handshake_latency.total_seconds()
                     )
-                self._max_tolerable_delay_for_upgrade *= 1.5
-            else:  # by default (fallback) to 1000ms
-                self._max_tolerable_delay_for_upgrade = 1.0
+                self._max_tolerable_delay_for_upgrade *= 10.0
+            else:  # by default (safe/conservative fallback) to 3000ms
+                self._max_tolerable_delay_for_upgrade = 3.0
 
             if upgradable_svn == HttpVersion.h3:
                 if self._preemptive_quic_cache is not None:
@@ -612,6 +612,9 @@ class HfaceBackend(BaseBackend):
                     alt_key = (self.host, self.__origin_port or 443)
                     if alt_key in self._preemptive_quic_cache:
                         del self._preemptive_quic_cache[alt_key]
+
+                # this avoid the close() to attempt re-use the (dead) sock
+                self._protocol = None
 
                 raise MustDowngradeError(
                     f"The server yielded its support for {self._svn} through the Alt-Svc header while unable to do so. "

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -42,10 +42,12 @@ from .exceptions import (
     InsecureRequestWarning,
     LocationValueError,
     MaxRetryError,
+    MustDowngradeError,
     NewConnectionError,
     ProtocolError,
     ProxyError,
     ReadTimeoutError,
+    RecoverableError,
     SSLError,
     TimeoutError,
 )
@@ -1524,6 +1526,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             SSLError,
             CertificateError,
             ProxyError,
+            RecoverableError,
         ) as e:
             # Discard the connection for these exceptions. It will be
             # replaced during the next _get_conn() call.
@@ -1548,6 +1551,16 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 method, url, error=new_e, _pool=self, _stacktrace=sys.exc_info()[2]
             )
             retries.sleep()
+
+            # todo: allow the conn to be reusable.
+            #       the MustDowngradeError only means that a single request cannot be
+            #       served over the current svn. does not means all requests to endpoint
+            #       are concerned.
+            if isinstance(new_e, MustDowngradeError) and conn is not None:
+                if "disabled_svn" not in self.conn_kw:
+                    self.conn_kw["disabled_svn"] = set()
+
+                self.conn_kw["disabled_svn"].add(conn._svn)
 
             # Keep track of the error for the retry warning.
             err = e

--- a/src/urllib3/contrib/webextensions/_async/raw.py
+++ b/src/urllib3/contrib/webextensions/_async/raw.py
@@ -41,7 +41,8 @@ class AsyncRawExtensionFromHTTP(AsyncExtensionFromHTTP):
         if self._police_officer is None or self._dsa is None:
             raise OSError("The HTTP extension is closed or uninitialized")
         async with self._police_officer.borrow(self._response):
-            data, eot, _ = await self._dsa.recv_extended(None)
+            async with self._read_error_catcher():
+                data, eot, _ = await self._dsa.recv_extended(None)
             return data
 
     async def send_payload(self, buf: str | bytes) -> None:
@@ -52,4 +53,5 @@ class AsyncRawExtensionFromHTTP(AsyncExtensionFromHTTP):
             if isinstance(buf, str):
                 buf = buf.encode()
 
-            await self._dsa.sendall(buf)
+            async with self._write_error_catcher():
+                await self._dsa.sendall(buf)

--- a/src/urllib3/contrib/webextensions/raw.py
+++ b/src/urllib3/contrib/webextensions/raw.py
@@ -18,7 +18,8 @@ class RawExtensionFromHTTP(ExtensionFromHTTP):
     def close(self) -> None:
         """End/Notify close for sub protocol."""
         if self._dsa is not None:
-            self._dsa.close()
+            with self._write_error_catcher():
+                self._dsa.close()
             self._dsa = None
         if self._response is not None:
             self._response.close()
@@ -41,7 +42,8 @@ class RawExtensionFromHTTP(ExtensionFromHTTP):
         if self._police_officer is None or self._dsa is None:
             raise OSError("The HTTP extension is closed or uninitialized")
         with self._police_officer.borrow(self._response):
-            data, eot, _ = self._dsa.recv_extended(None)
+            with self._read_error_catcher():
+                data, eot, _ = self._dsa.recv_extended(None)
             return data
 
     def send_payload(self, buf: str | bytes) -> None:
@@ -52,4 +54,5 @@ class RawExtensionFromHTTP(ExtensionFromHTTP):
             if isinstance(buf, str):
                 buf = buf.encode()
 
-            self._dsa.sendall(buf)
+            with self._write_error_catcher():
+                self._dsa.sendall(buf)

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -343,3 +343,11 @@ class EarlyResponse(HTTPError):
 
 class ResponseNotReady(HTTPError):
     """Kept for BC"""
+
+
+class RecoverableError(HTTPError):
+    """This error is never leaked in the upper stack, it serves only an internal purpose."""
+
+
+class MustDowngradeError(RecoverableError):
+    """An error occurred with a protocol and can be circumvented using an older protocol."""

--- a/test/with_traefik/asynchronous/test_svn.py
+++ b/test/with_traefik/asynchronous/test_svn.py
@@ -48,7 +48,7 @@ class TestSvnCapability(TraefikTestCase):
         async with AsyncHTTPSConnectionPool(
             self.host,
             self.https_port,
-            timeout=1,
+            timeout=5,
             retries=0,
             ca_certs=self.ca_authority,
             resolver=self.test_async_resolver,
@@ -62,7 +62,7 @@ class TestSvnCapability(TraefikTestCase):
         async with AsyncHTTPSConnectionPool(
             self.host,
             self.https_port,
-            timeout=1,
+            timeout=5,
             retries=0,
             ca_certs=self.ca_authority,
             disabled_svn={HttpVersion.h3},
@@ -76,7 +76,7 @@ class TestSvnCapability(TraefikTestCase):
         async with AsyncHTTPSConnectionPool(
             self.host,
             self.https_port,
-            timeout=1,
+            timeout=5,
             retries=0,
             ca_certs=self.ca_authority,
             disabled_svn={HttpVersion.h2},
@@ -93,7 +93,7 @@ class TestSvnCapability(TraefikTestCase):
         p = AsyncHTTPSConnectionPool(
             self.host,
             self.https_port,
-            timeout=1,
+            timeout=5,
             retries=0,
             ca_certs=self.ca_authority,
             disabled_svn={HttpVersion.h11},
@@ -112,7 +112,7 @@ class TestSvnCapability(TraefikTestCase):
             p = AsyncHTTPSConnectionPool(
                 self.host,
                 self.https_port,
-                timeout=1,
+                timeout=5,
                 retries=0,
                 ca_certs=self.ca_authority,
                 disabled_svn={HttpVersion.h11, HttpVersion.h2, HttpVersion.h3},
@@ -125,7 +125,7 @@ class TestSvnCapability(TraefikTestCase):
             p = AsyncHTTPConnectionPool(  # type: ignore[assignment]
                 self.host,
                 self.http_port,
-                timeout=1,
+                timeout=5,
                 retries=0,
                 disabled_svn={HttpVersion.h11, HttpVersion.h2},
                 resolver=self.test_async_resolver,
@@ -137,7 +137,7 @@ class TestSvnCapability(TraefikTestCase):
         async with AsyncHTTPSConnectionPool(
             self.host,
             self.https_alt_port,
-            timeout=1,
+            timeout=5,
             retries=False,
             ca_certs=self.ca_authority,
             resolver=self.test_async_resolver,
@@ -188,7 +188,7 @@ class TestSvnCapability(TraefikTestCase):
         async with AsyncHTTPSConnectionPool(
             self.host,
             self.https_alt_port,
-            timeout=1,
+            timeout=5,
             retries=False,
             ca_certs=self.ca_authority,
             resolver=self.test_async_resolver,
@@ -211,7 +211,7 @@ class TestSvnCapability(TraefikTestCase):
         async with AsyncHTTPSConnectionPool(
             self.host,
             self.https_alt_port,
-            timeout=1,
+            timeout=5,
             retries=False,
             ca_certs=self.ca_authority,
             resolver=self.test_async_resolver,
@@ -233,7 +233,7 @@ class TestSvnCapability(TraefikTestCase):
         async with AsyncHTTPSConnectionPool(
             self.host,
             self.https_alt_port,
-            timeout=1,
+            timeout=5,
             retries=False,
             ca_certs=self.ca_authority,
             resolver=self.test_async_resolver,
@@ -363,7 +363,7 @@ class TestSvnCapability(TraefikTestCase):
         async with AsyncHTTPConnectionPool(
             self.host,
             self.http_alt_port,
-            timeout=1,
+            timeout=5,
             retries=False,
             resolver=self.test_async_resolver,
         ) as p:

--- a/test/with_traefik/test_svn.py
+++ b/test/with_traefik/test_svn.py
@@ -42,7 +42,7 @@ class TestSvnCapability(TraefikTestCase):
         with HTTPSConnectionPool(
             self.host,
             self.https_port,
-            timeout=1,
+            timeout=5,
             retries=0,
             ca_certs=self.ca_authority,
             resolver=self.test_resolver,
@@ -56,7 +56,7 @@ class TestSvnCapability(TraefikTestCase):
         with HTTPSConnectionPool(
             self.host,
             self.https_port,
-            timeout=1,
+            timeout=5,
             retries=0,
             ca_certs=self.ca_authority,
             disabled_svn={HttpVersion.h3},
@@ -70,7 +70,7 @@ class TestSvnCapability(TraefikTestCase):
         with HTTPSConnectionPool(
             self.host,
             self.https_port,
-            timeout=1,
+            timeout=5,
             retries=0,
             ca_certs=self.ca_authority,
             disabled_svn={HttpVersion.h2},
@@ -87,7 +87,7 @@ class TestSvnCapability(TraefikTestCase):
         p = HTTPSConnectionPool(
             self.host,
             self.https_port,
-            timeout=1,
+            timeout=5,
             retries=0,
             ca_certs=self.ca_authority,
             disabled_svn={HttpVersion.h11},
@@ -104,7 +104,7 @@ class TestSvnCapability(TraefikTestCase):
             p = HTTPSConnectionPool(
                 self.host,
                 self.https_port,
-                timeout=1,
+                timeout=5,
                 retries=0,
                 ca_certs=self.ca_authority,
                 disabled_svn={HttpVersion.h11, HttpVersion.h2, HttpVersion.h3},
@@ -117,7 +117,7 @@ class TestSvnCapability(TraefikTestCase):
             p = HTTPConnectionPool(  # type: ignore[assignment]
                 self.host,
                 self.http_port,
-                timeout=1,
+                timeout=5,
                 retries=0,
                 disabled_svn={HttpVersion.h11, HttpVersion.h2},
                 resolver=self.test_resolver,
@@ -129,7 +129,7 @@ class TestSvnCapability(TraefikTestCase):
         with HTTPSConnectionPool(
             self.host,
             self.https_alt_port,
-            timeout=1,
+            timeout=5,
             retries=False,
             ca_certs=self.ca_authority,
             resolver=self.test_resolver,
@@ -151,7 +151,7 @@ class TestSvnCapability(TraefikTestCase):
         with HTTPSConnectionPool(
             self.host,
             self.https_alt_port,
-            timeout=1,
+            timeout=5,
             retries=False,
             ca_certs=self.ca_authority,
             resolver=self.test_resolver,
@@ -174,7 +174,7 @@ class TestSvnCapability(TraefikTestCase):
         with HTTPSConnectionPool(
             self.host,
             self.https_alt_port,
-            timeout=1,
+            timeout=5,
             retries=False,
             ca_certs=self.ca_authority,
             resolver=self.test_resolver,
@@ -225,7 +225,7 @@ class TestSvnCapability(TraefikTestCase):
         with HTTPSConnectionPool(
             self.host,
             self.https_alt_port,
-            timeout=1,
+            timeout=5,
             retries=False,
             ca_certs=self.ca_authority,
             resolver=self.test_resolver,
@@ -339,7 +339,7 @@ class TestSvnCapability(TraefikTestCase):
         with HTTPConnectionPool(
             self.host,
             self.http_alt_port,
-            timeout=1,
+            timeout=5,
             retries=False,
             resolver=self.test_resolver,
         ) as p:

--- a/test/with_traefik/test_svn.py
+++ b/test/with_traefik/test_svn.py
@@ -192,6 +192,35 @@ class TestSvnCapability(TraefikTestCase):
                     == f'h3-25=":443"; ma=3600, h3=":{self.https_port}"; ma=3600'
                 )
 
+    @pytest.mark.usefixtures("requires_http3")
+    def test_misleading_upgrade_h3(self) -> None:
+        dumb_cache: dict[tuple[str, int], tuple[str, int] | None] = dict()
+
+        with HTTPSConnectionPool(
+            self.host,
+            self.https_alt_port,
+            retries=False,
+            ca_certs=self.ca_authority,
+            resolver=self.test_resolver,
+            preemptive_quic_cache=dumb_cache,
+        ) as p:
+            for i in range(2):
+                resp = p.request(
+                    "GET",
+                    "/response-headers?Alt-Svc=h3-25%3D%22%3A443%22%3B%20ma%3D3600%2C%20h3%3D%22%3A6547%22%3B%20ma%3D3600",
+                )
+
+                assert resp.version == 20
+                assert "Alt-Svc" in resp.headers
+                assert (
+                    resp.headers.get("Alt-Svc")
+                    == 'h3-25=":443"; ma=3600, h3=":6547"; ma=3600'
+                )
+
+        # this asserts tell us that we correctly unset the entry from "preemptive_quic_cache"
+        # because the alt-svc entry was misleading, thus invalid.
+        assert len(dumb_cache) == 0
+
     def test_invalid_alt_svc_h3_upgrade(self) -> None:
         with HTTPSConnectionPool(
             self.host,

--- a/test/with_traefik/test_webextensions.py
+++ b/test/with_traefik/test_webextensions.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import pytest
 
-from urllib3 import HttpVersion, PoolManager
+from urllib3 import HttpVersion, PoolManager, Timeout
 from urllib3.contrib.webextensions import (
     RawExtensionFromHTTP,
     WebSocketExtensionFromHTTP,
 )
+from urllib3.exceptions import ReadTimeoutError
 
 from . import TraefikTestCase
 
@@ -212,4 +213,50 @@ class TestWebExtensions(TraefikTestCase):
             assert resp.extension.next_payload() == b"Foo Bar Baz!"
 
             # gracefully close the sub protocol.
+            resp.extension.close()
+
+    @pytest.mark.skipif(
+        WebSocketExtensionFromHTTP is None, reason="test requires wsproto"
+    )
+    @pytest.mark.parametrize(
+        "target_protocol",
+        [
+            "wss",
+            "ws",
+        ],
+    )
+    def test_exception_leak_read_timeout(self, target_protocol: str) -> None:
+        """Here we test both wss and ws because the low-level exception differ, we must
+        check that both lead to our unified ReadTimeoutError."""
+        target_url = self.https_url if target_protocol == "wss" else self.http_url
+        target_url = (
+            target_url.replace("https://", "wss://")
+            if target_protocol == "wss"
+            else target_url.replace("http://", "ws://")
+        )
+
+        with PoolManager(
+            resolver=self.test_resolver,
+            ca_certs=self.ca_authority,
+            timeout=Timeout(read=1),
+        ) as pm:
+            resp = pm.urlopen("GET", target_url + "/websocket/echo")
+
+            # The response ends with a "101 Switching Protocol"!
+            assert resp.status == 101
+
+            # The HTTP extension should be automatically loaded!
+            assert resp.extension is not None
+
+            # This response should not have a body, therefor don't try to read from
+            # socket in there!
+            assert resp.data == b""
+            assert resp.read() == b""
+
+            # the extension here should be WebSocketExtensionFromHTTP
+            assert isinstance(resp.extension, WebSocketExtensionFromHTTP)
+
+            with pytest.raises(ReadTimeoutError):
+                resp.extension.next_payload()
+
             resp.extension.close()


### PR DESCRIPTION
2.10.903 (2024-10-12)
=====================

- Fixed exception leaks in ExtensionFromHTTP plugins. Now every extension behave and raise urllib3 own exceptions.
- Added automatic connection downgrade HTTP/2 -> HTTP/1.1 or HTTP/3 -> (HTTP/2 or HTTP/1.1) in case of known recoverable issues. https://github.com/jawah/niquests/issues/150 https://github.com/jawah/niquests/issues/134
- Fixed a rare issue where the write semaphore (async context) for a datagram socket would be locked forever in case of an error.
