### PR TITLE
Doc: Fix emcscripten warning with too much install arguments

### DIFF
--- a/src/urllib3/contrib/emscripten/__init__.py
+++ b/src/urllib3/contrib/emscripten/__init__.py
@@ -15,8 +15,8 @@ def inject_into_urllib3() -> None:
         (
             "urllib3-future does not support WASM / Emscripten platform. "
             "Please reinstall legacy urllib3 in the meantime. "
-            "Run `pip install uninstall -y urllib3 urllib3-future` then "
-            "`pip install install urllib3-future`, finally `pip install install urllib3`. "
+            "Run `pip uninstall -y urllib3 urllib3-future` then "
+            "`pip install urllib3-future`, finally `pip install urllib3`. "
             "Sorry for the inconvenience."
         ),
         DeprecationWarning,


### PR DESCRIPTION
The extra "install" slipped in from https://github.com/jawah/urllib3.future/commit/46f3bce4ab6ae96bf3c6fbdc05e7a502763f5f16 commit