### PR TITLE
Bugfix uvloop and mac rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.11.905 (2024-10-26)
+=====================
+
+- Fixed custom loop like uvloop needing advanced error handling on transport close.
+- Fixed MacOS connection reset by peer handling to detect connection close (continuation of fix in 2.11.902)
+
 2.11.904 (2024-10-25)
 =====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.11.904"
+__version__ = "2.11.905"


### PR DESCRIPTION
2.11.905 (2024-10-26)
=====================

- Fixed custom loop like uvloop needing advanced error handling on transport close.
- Fixed MacOS connection reset by peer handling to detect connection close (continuation of fix in 2.11.902)
