### PR TITLE
:bug: fix async connection shutdown in HTTP/1.1 and HTTP/2 leaving a `asyncio.TransportSocket` and `_SelectorSocketTransport` partially closed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.11.908 (2024-11-03)
+=====================
+
+- Fixed async connection shutdown in HTTP/1.1 and HTTP/2 leaving a ``asyncio.TransportSocket`` and ``_SelectorSocketTransport`` partially closed.
+- Added automatic mitigation of using deprecated ``PROTOCOL_TLS_*`` constants in ``ssl_version`` parameter.
+
 2.11.907 (2024-10-30)
 =====================
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,4 +160,5 @@ nitpick_ignore = [
     ("py:class", "_TYPE_ASYNC_BODY"),
     ("py:class", "ExtensionFromHTTP"),
     ("py:class", "AsyncExtensionFromHTTP"),
+    ("py:class", "urllib3.AsyncResolverDescription"),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,14 +108,12 @@ filterwarnings = [
     "error",
     '''default:No IPv6 support. Falling back to IPv4:urllib3.exceptions.HTTPWarning''',
     '''default:No IPv6 support. skipping:urllib3.exceptions.HTTPWarning''',
-    '''default:ssl\.TLSVersion\.TLSv1 is deprecated:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLS is deprecated:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLSv1 is deprecated:DeprecationWarning''',
     '''default:ssl\.TLSVersion\.TLSv1_1 is deprecated:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLSv1_1 is deprecated:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLSv1_2 is deprecated:DeprecationWarning''',
     '''default:unclosed .*:ResourceWarning''',
-    '''default:loop is closed:ResourceWarning''',
     '''default:ssl NPN is deprecated, use ALPN instead:DeprecationWarning''',
     # https://github.com/pytest-dev/pytest/issues/10977
     '''default:ast\.(Num|NameConstant|Str) is deprecated and will be removed in Python 3\.14; use ast\.Constant instead:DeprecationWarning:_pytest''',
@@ -129,6 +127,9 @@ filterwarnings = [
     '''ignore:Exception in thread:pytest.PytestUnhandledThreadExceptionWarning''',
     '''ignore:function _SSLProtocolTransport\.__del__:pytest.PytestUnraisableExceptionWarning''',
     '''ignore:The `hash` argument is deprecated in favor of `unsafe_hash`:DeprecationWarning''',
+    '''ignore:ssl\.TLSVersion\.TLSv1 is deprecated:DeprecationWarning''',
+    '''ignore:ssl\.TLSVersion\.TLSv1_1 is deprecated:DeprecationWarning''',
+    '''ignore:loop is closed:ResourceWarning''',
 ]
 
 [tool.isort]

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -920,7 +920,7 @@ async def _ssl_wrap_socket_and_match_hostname(
     """
     default_ssl_context = False
     sharable_ext_options: dict[str, int | str | None] = {
-        "ssl_version": resolve_ssl_version(ssl_version),
+        "ssl_version": resolve_ssl_version(ssl_version, mitigate_tls_version=True),
         "ssl_minimum_version": ssl_minimum_version,
         "ssl_maximum_version": ssl_maximum_version,
         "cert_reqs": resolve_cert_reqs(cert_reqs),

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.11.907"
+__version__ = "2.11.908"

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -200,7 +200,10 @@ class HfaceBackend(BaseBackend):
             # if conn target another host.
             if self._response and self._response.authority != self.host:
                 self._svn = None
-                self._new_conn()  # restore socket defaults
+                self._response = None  # type: ignore[assignment]
+                if self.blocksize == UDP_DEFAULT_BLOCKSIZE:
+                    self.blocksize = DEFAULT_BLOCKSIZE
+                self.socket_kind = SOCK_STREAM
         else:
             if self.blocksize == UDP_DEFAULT_BLOCKSIZE:
                 self.blocksize = DEFAULT_BLOCKSIZE

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -776,7 +776,7 @@ class HfaceBackend(BaseBackend):
         For example, google/quiche send regular unsolicited data and expect regular ACKs, otherwise will
         deduct that network conn is dead.
         see: https://github.com/google/quiche/commit/c4bb0723f0a03e135bc9328b59a39382761f3de6
-             https://github.com/google/quiche/blob/92b45f743288ea2f43ae8cdc4a783ef252e41d93/quiche/quic/core/quic_connection.cc#L6322
+        and: https://github.com/google/quiche/blob/92b45f743288ea2f43ae8cdc4a783ef252e41d93/quiche/quic/core/quic_connection.cc#L6322
         """
         if self.sock is None or self._protocol is None:
             return False

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -893,7 +893,7 @@ def _ssl_wrap_socket_and_match_hostname(
     """
     default_ssl_context = False
     sharable_ext_options: dict[str, int | str | None] = {
-        "ssl_version": resolve_ssl_version(ssl_version),
+        "ssl_version": resolve_ssl_version(ssl_version, mitigate_tls_version=True),
         "ssl_minimum_version": ssl_minimum_version,
         "ssl_maximum_version": ssl_maximum_version,
         "cert_reqs": resolve_cert_reqs(cert_reqs),

--- a/src/urllib3/contrib/resolver/_async/doq/_qh3.py
+++ b/src/urllib3/contrib/resolver/_async/doq/_qh3.py
@@ -104,6 +104,7 @@ class QUICResolver(PlainResolver):
                     await self._socket.sendall(data)
 
             self._socket.close()
+            await self._socket.wait_for_close()
             self._terminated = True
         if self._socket.should_connect():
             self._terminated = True

--- a/src/urllib3/contrib/resolver/_async/dou/_socket.py
+++ b/src/urllib3/contrib/resolver/_async/dou/_socket.py
@@ -70,6 +70,7 @@ class PlainResolver(AsyncBaseResolver):
         if not self._terminated:
             with self._lock:
                 self._socket.close()
+                await self._socket.wait_for_close()
                 self._terminated = True
 
     def is_available(self) -> bool:

--- a/src/urllib3/contrib/resolver/_async/protocols.py
+++ b/src/urllib3/contrib/resolver/_async/protocols.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import socket
 import typing
 from abc import ABCMeta, abstractmethod
@@ -131,7 +132,11 @@ class AsyncBaseResolver(BaseResolver, metaclass=ABCMeta):
                 if source_address:
                     sock.bind(source_address)
 
-                await sock.connect(sa)
+                try:
+                    await sock.connect(sa)
+                except asyncio.CancelledError:
+                    sock.close()
+                    raise
 
                 # Break explicitly a reference cycle
                 err = None

--- a/src/urllib3/contrib/resolver/protocols.py
+++ b/src/urllib3/contrib/resolver/protocols.py
@@ -224,7 +224,10 @@ class BaseResolver(metaclass=ABCMeta):
                 if source_address is not None:
                     try:
                         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-                    except (OSError, AttributeError):  # Defensive: very old OS?
+                    except (
+                        OSError,
+                        AttributeError,
+                    ):  # Defensive: Windows or very old OS?
                         try:
                             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                         except (

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -90,7 +90,7 @@ def _can_resolve(host: str, should_match: str | None = None) -> bool:
 def has_alpn(ctx_cls: type[ssl.SSLContext] | None = None) -> bool:
     """Detect if ALPN support is enabled."""
     ctx_cls = ctx_cls or util.SSLContext
-    ctx = ctx_cls(protocol=ssl_.PROTOCOL_TLS)  # type: ignore[misc, attr-defined]
+    ctx = ctx_cls(protocol=ssl_.PROTOCOL_TLS_CLIENT)  # type: ignore[misc, attr-defined]
     try:
         if hasattr(ctx, "set_alpn_protocols"):
             ctx.set_alpn_protocols(ssl_.ALPN_PROTOCOLS)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -982,6 +982,27 @@ class TestUtilSSL:
     def test_resolve_ssl_version(self, candidate: int | str, version: int) -> None:
         assert resolve_ssl_version(candidate) == version
 
+    @pytest.mark.parametrize(
+        "candidate, version",
+        [
+            (ssl.PROTOCOL_TLSv1, "TLSv1"),
+            ("PROTOCOL_TLSv1", "TLSv1"),
+            ("TLSv1", "TLSv1"),
+        ],
+    )
+    @pytest.mark.skipif(
+        hasattr(ssl, "TLSVersion") is False, reason="test requires ssl.TLSVersion"
+    )
+    def test_resolve_ssl_version_mitigated(
+        self, candidate: int | str, version: str
+    ) -> None:
+        version_ = getattr(ssl.TLSVersion, version, None)
+
+        if version_ is None:
+            pytest.skip(f"unsupported TLSVersion.{version}")
+
+        assert resolve_ssl_version(candidate, mitigate_tls_version=True) == version_
+
     def test_ssl_wrap_socket_loads_the_cert_chain(self) -> None:
         socket = Mock()
         mock_context = Mock()

--- a/test/with_dummyserver/asynchronous/test_connectionpool.py
+++ b/test/with_dummyserver/asynchronous/test_connectionpool.py
@@ -1091,6 +1091,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             else:
                 conn = await pool._get_conn()
                 await conn.request("GET", "/headers", chunked=chunked)
+                await pool._put_conn(conn)
 
             assert pool.headers == {"key": "val"}
             assert isinstance(pool.headers, header_type)
@@ -1101,6 +1102,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             else:
                 conn = await pool._get_conn()
                 await conn.request("GET", "/headers", headers=headers, chunked=chunked)
+                await pool._put_conn(conn)
 
             assert headers == {"key": "val"}
 

--- a/test/with_dummyserver/asynchronous/test_poolmanager.py
+++ b/test/with_dummyserver/asynchronous/test_poolmanager.py
@@ -286,6 +286,7 @@ class TestAsyncPoolManager(HTTPDummyServerTestCase):
             assert r._pool.num_requests == 2
             assert r._pool.num_connections == 1
             assert len(http.pools) == 1
+            await r.data  # consume content, avoid resource warning
 
     async def test_303_redirect_makes_request_lose_body(self) -> None:
         async with AsyncPoolManager() as http:
@@ -300,6 +301,7 @@ class TestAsyncPoolManager(HTTPDummyServerTestCase):
             data = await response.json()
             assert data["params"] == {}
             assert "Content-Type" not in HTTPHeaderDict(data["headers"])
+            await response.data  # consume content, avoid resource warning
 
     async def test_unknown_scheme(self) -> None:
         async with AsyncPoolManager() as http:

--- a/test/with_dummyserver/test_connection.py
+++ b/test/with_dummyserver/test_connection.py
@@ -31,6 +31,7 @@ def test_returns_urllib3_HTTPResponse(pool: HTTPConnectionPool) -> None:
     response = conn.getresponse()
 
     assert isinstance(response, HTTPResponse)
+    pool._put_conn(conn)
 
 
 def test_does_not_release_conn(pool: HTTPConnectionPool) -> None:

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -1014,6 +1014,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             else:
                 conn = pool._get_conn()
                 conn.request("GET", "/headers", chunked=chunked)
+                pool._put_conn(conn)
 
             assert pool.headers == {"key": "val"}
             assert isinstance(pool.headers, header_type)
@@ -1024,6 +1025,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             else:
                 conn = pool._get_conn()
                 conn.request("GET", "/headers", headers=headers, chunked=chunked)
+                pool._put_conn(conn)
 
             assert headers == {"key": "val"}
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -173,19 +173,21 @@ class TestHTTPS(HTTPSDummyServerTestCase):
     @notWindows()
     @notMacOS()
     def test_in_memory_client_intermediate(self) -> None:
-        with HTTPSConnectionPool(
-            self.host,
-            self.port,
-            key_data=open(os.path.join(self.certs_dir, CLIENT_INTERMEDIATE_KEY)).read(),
-            cert_data=open(
+        with open(os.path.join(self.certs_dir, CLIENT_INTERMEDIATE_KEY)) as fp_key_data:
+            with open(
                 os.path.join(self.certs_dir, CLIENT_INTERMEDIATE_PEM)
-            ).read(),
-            ca_certs=DEFAULT_CA,
-            ssl_minimum_version=self.tls_version(),
-        ) as https_pool:
-            r = https_pool.request("GET", "/certificate")
-            subject = r.json()
-            assert subject["organizationalUnitName"].startswith("Testing cert")
+            ) as fp_cert_data:
+                with HTTPSConnectionPool(
+                    self.host,
+                    self.port,
+                    key_data=fp_key_data.read(),
+                    cert_data=fp_cert_data.read(),
+                    ca_certs=DEFAULT_CA,
+                    ssl_minimum_version=self.tls_version(),
+                ) as https_pool:
+                    r = https_pool.request("GET", "/certificate")
+                    subject = r.json()
+                    assert subject["organizationalUnitName"].startswith("Testing cert")
 
     def test_client_no_intermediate(self) -> None:
         """Check that missing links in certificate chains indeed break
@@ -221,18 +223,20 @@ class TestHTTPS(HTTPSDummyServerTestCase):
     @notWindows()
     @notMacOS()
     def test_in_memory_client_key_password(self) -> None:
-        with HTTPSConnectionPool(
-            self.host,
-            self.port,
-            ca_certs=DEFAULT_CA,
-            key_data=open(os.path.join(self.certs_dir, PASSWORD_CLIENT_KEYFILE)).read(),
-            cert_data=open(os.path.join(self.certs_dir, CLIENT_CERT)).read(),
-            key_password="letmein",
-            ssl_minimum_version=self.tls_version(),
-        ) as https_pool:
-            r = https_pool.request("GET", "/certificate")
-            subject = r.json()
-            assert subject["organizationalUnitName"].startswith("Testing cert")
+        with open(os.path.join(self.certs_dir, PASSWORD_CLIENT_KEYFILE)) as fp_key_data:
+            with open(os.path.join(self.certs_dir, CLIENT_CERT)) as fp_cert_data:
+                with HTTPSConnectionPool(
+                    self.host,
+                    self.port,
+                    ca_certs=DEFAULT_CA,
+                    key_data=fp_key_data.read(),
+                    cert_data=fp_cert_data.read(),
+                    key_password="letmein",
+                    ssl_minimum_version=self.tls_version(),
+                ) as https_pool:
+                    r = https_pool.request("GET", "/certificate")
+                    subject = r.json()
+                    assert subject["organizationalUnitName"].startswith("Testing cert")
 
     def test_client_encrypted_key_requires_password(self) -> None:
         with HTTPSConnectionPool(

--- a/test/with_traefik/asynchronous/test_conn_info.py
+++ b/test/with_traefik/asynchronous/test_conn_info.py
@@ -29,6 +29,8 @@ class TestConnectionInfo(TraefikTestCase):
         assert conn_info.http_version == HttpVersion.h11
         assert conn_info.certificate_dict is None
 
+        await p.clear()
+
     async def test_tls_on_tcp(self) -> None:
         p = AsyncPoolManager(
             ca_certs=self.ca_authority, resolver=self.test_async_resolver
@@ -49,6 +51,8 @@ class TestConnectionInfo(TraefikTestCase):
         assert conn_info.http_version == HttpVersion.h2
         assert conn_info.tls_version is not None
         assert conn_info.cipher is not None
+
+        await p.clear()
 
     @pytest.mark.usefixtures("requires_http3")
     async def test_tls_on_udp(self) -> None:
@@ -75,3 +79,5 @@ class TestConnectionInfo(TraefikTestCase):
         assert conn_info.tls_version is not None
         assert conn_info.cipher is not None
         assert conn_info.http_version == HttpVersion.h3
+
+        await p.clear()

--- a/test/with_traefik/asynchronous/test_connection.py
+++ b/test/with_traefik/asynchronous/test_connection.py
@@ -66,6 +66,8 @@ class TestConnection(TraefikTestCase):
 
         assert resp.version == 20
 
+        await conn.close()
+
     async def test_getresponse_not_ready(self) -> None:
         conn = AsyncHTTPSConnection(
             self.host,
@@ -99,6 +101,8 @@ class TestConnection(TraefikTestCase):
         assert resp.status == 200
         assert resp.version == 30
 
+        await conn.close()
+
     @pytest.mark.usefixtures("requires_http3")
     async def test_quic_cache_capable_but_disabled(self) -> None:
         quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = {
@@ -120,6 +124,8 @@ class TestConnection(TraefikTestCase):
         assert resp.status == 200
         assert resp.version == 20
 
+        await conn.close()
+
     @pytest.mark.usefixtures("requires_http3")
     async def test_quic_cache_explicit_not_capable(self) -> None:
         quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = {
@@ -139,6 +145,8 @@ class TestConnection(TraefikTestCase):
 
         assert resp.status == 200
         assert resp.version == 20
+
+        await conn.close()
 
     @pytest.mark.usefixtures("requires_http3")
     async def test_quic_cache_implicit_not_capable(self) -> None:
@@ -160,6 +168,8 @@ class TestConnection(TraefikTestCase):
 
         assert len(quic_cache_resumption.keys()) == 1
         assert (self.host, self.https_port) in quic_cache_resumption
+
+        await conn.close()
 
     @pytest.mark.usefixtures("requires_http3")
     async def test_quic_extract_ssl_ctx_ca_root(self) -> None:
@@ -194,6 +204,8 @@ class TestConnection(TraefikTestCase):
         assert resp.status == 200
         assert resp.version == 30
 
+        await conn.close()
+
     @pytest.mark.xfail(
         reason="experimental support for reusable outgoing port", strict=False
     )
@@ -206,6 +218,8 @@ class TestConnection(TraefikTestCase):
                 resolver=self.test_async_resolver.new(),
                 source_address=("0.0.0.0", 8745),
             )
+
+            await conn.connect()
 
             await conn.request("GET", "/get")
             resp = await conn.getresponse()

--- a/test/with_traefik/asynchronous/test_connection_multiplexed.py
+++ b/test/with_traefik/asynchronous/test_connection_multiplexed.py
@@ -121,3 +121,5 @@ class TestConnectionMultiplexed(TraefikTestCase):
         for i in range(3):
             r = await conn.getresponse()
             assert r.version == 30
+
+        await conn.close()

--- a/test/with_traefik/asynchronous/test_svn.py
+++ b/test/with_traefik/asynchronous/test_svn.py
@@ -276,6 +276,8 @@ class TestSvnCapability(TraefikTestCase):
         assert resp.version == 20
         assert resp.status == 200
 
+        await conn.close()
+
     @pytest.mark.usefixtures("requires_http3")
     async def test_drop_post_established_h3(self) -> None:
         conn = AsyncHTTPSConnection(
@@ -309,6 +311,8 @@ class TestSvnCapability(TraefikTestCase):
         assert resp.version == 20
         assert resp.status == 200
 
+        await conn.close()
+
     @pytest.mark.usefixtures("requires_http3")
     async def test_pool_manager_quic_cache(self) -> None:
         dumb_cache: dict[tuple[str, int], tuple[str, int] | None] = dict()
@@ -329,6 +333,8 @@ class TestSvnCapability(TraefikTestCase):
 
         await conn.close()
 
+        await pm.clear()
+
         pm = AsyncPoolManager(
             ca_certs=self.ca_authority,
             preemptive_quic_cache=dumb_cache,
@@ -342,6 +348,9 @@ class TestSvnCapability(TraefikTestCase):
         assert resp.version == 30
 
         assert len(dumb_cache.keys()) == 1
+
+        await conn.close()
+        await pm.clear()
 
     async def test_http2_with_prior_knowledge(self) -> None:
         async with AsyncHTTPConnectionPool(

--- a/test/with_traefik/test_conn_info.py
+++ b/test/with_traefik/test_conn_info.py
@@ -29,6 +29,8 @@ class TestConnectionInfo(TraefikTestCase):
         assert conn_info.http_version == HttpVersion.h11
         assert conn_info.certificate_dict is None
 
+        p.clear()
+
     def test_tls_on_tcp(self) -> None:
         p = PoolManager(ca_certs=self.ca_authority, resolver=self.test_resolver)
 
@@ -47,6 +49,8 @@ class TestConnectionInfo(TraefikTestCase):
         assert conn_info.http_version == HttpVersion.h2
         assert conn_info.tls_version is not None
         assert conn_info.cipher is not None
+
+        p.clear()
 
     @pytest.mark.skipif(
         sys.version_info < (3, 10),
@@ -75,6 +79,8 @@ class TestConnectionInfo(TraefikTestCase):
         assert conn_info.tls_version is not None
         assert conn_info.cipher is not None
 
+        p.clear()
+
     @pytest.mark.usefixtures("requires_http3")
     def test_tls_on_udp(self) -> None:
         p = PoolManager(
@@ -100,3 +106,5 @@ class TestConnectionInfo(TraefikTestCase):
         assert conn_info.tls_version is not None
         assert conn_info.cipher is not None
         assert conn_info.http_version == HttpVersion.h3
+
+        p.clear()

--- a/test/with_traefik/test_connection.py
+++ b/test/with_traefik/test_connection.py
@@ -65,6 +65,8 @@ class TestConnection(TraefikTestCase):
 
         assert resp.version == 20
 
+        conn.close()
+
     def test_getresponse_not_ready(self) -> None:
         conn = HTTPSConnection(
             self.host,
@@ -97,6 +99,8 @@ class TestConnection(TraefikTestCase):
 
         assert resp.status == 200
         assert resp.version == 30
+
+        conn.close()
 
     def test_quic_cache_capable_but_disabled(self) -> None:
         quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = {
@@ -192,6 +196,8 @@ class TestConnection(TraefikTestCase):
         assert resp.status == 200
         assert resp.version == 30
 
+        conn.close()
+
     @pytest.mark.xfail(
         reason="experimental support for reusable outgoing port", strict=False
     )
@@ -204,6 +210,8 @@ class TestConnection(TraefikTestCase):
                 resolver=self.test_resolver.new(),
                 source_address=("0.0.0.0", 8845),
             )
+
+            conn.connect()
 
             conn.request("GET", "/get")
             resp = conn.getresponse()

--- a/test/with_traefik/test_connection_multiplexed.py
+++ b/test/with_traefik/test_connection_multiplexed.py
@@ -120,3 +120,5 @@ class TestConnectionMultiplexed(TraefikTestCase):
         for i in range(3):
             r = conn.getresponse()
             assert r.version == 30
+
+        conn.close()

--- a/test/with_traefik/test_svn.py
+++ b/test/with_traefik/test_svn.py
@@ -99,6 +99,8 @@ class TestSvnCapability(TraefikTestCase):
         assert r.status == 200
         assert r.version == 20
 
+        p.close()
+
     def test_cannot_disable_everything(self) -> None:
         with pytest.raises(RuntimeError):
             p = HTTPSConnectionPool(
@@ -268,6 +270,8 @@ class TestSvnCapability(TraefikTestCase):
         assert resp.version == 20
         assert resp.status == 200
 
+        conn.close()
+
     @pytest.mark.usefixtures("requires_http3")
     def test_drop_post_established_h3(self) -> None:
         conn = HTTPSConnection(
@@ -321,6 +325,8 @@ class TestSvnCapability(TraefikTestCase):
 
         conn.close()
 
+        pm.clear()
+
         pm = PoolManager(
             ca_certs=self.ca_authority,
             preemptive_quic_cache=dumb_cache,
@@ -334,6 +340,9 @@ class TestSvnCapability(TraefikTestCase):
         assert resp.version == 30
 
         assert len(dumb_cache.keys()) == 1
+
+        conn.close()
+        pm.clear()
 
     def test_can_upgrade_h2c_via_altsvc(self) -> None:
         with HTTPConnectionPool(


### PR DESCRIPTION
2.11.908 (2024-11-03)
=====================

- Fixed async connection shutdown in HTTP/1.1 and HTTP/2 leaving a ``asyncio.TransportSocket`` and ``_SelectorSocketTransport`` partially closed.
- Added automatic mitigation of using deprecated ``PROTOCOL_TLS_*`` constants in ``ssl_version`` parameter.
