### PR TITLE
Various improvements in test and resolver

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,8 +13,8 @@ source =
 [report]
 omit =
     src/urllib3/contrib/pyopenssl.py
-    src/urllib3/contrib/securetransport.py
-    src/urllib3/contrib/_securetransport/*
+    src/urllib3/contrib/emscripten/*
+    src/urllib3/http2/*
 
 exclude_lines =
     except ModuleNotFoundError:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@
 - Preemptively disabled QUIC (HTTP/3 included) with interpreter built with FIPS-compliant SSL module.
   Our QUIC implementation isn't FIPS-compliant for the moment. To force using non-FIPS QUIC implementation,
   please patch ``urllib3.util.ssl_.IS_FIPS`` and set it to ``False``.
+- Fixed DoQ default certs loading as done in DoT, and DoH.
 
 2.11.908 (2024-11-03)
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,15 @@
+2.11.909 (2024-11-??)
+=====================
+
+- Fixed DNS-over-QUIC, DNS-over-TLS, and DNS-over-UDP(Cleartext) connection procedure on network that lacks IPv6 access.
+- Fixed DNS-over-TLS unstable over a slow network.
+- Fixed a bug when setting a specific port in ``source_address`` and setting ``happy_eyeballs=True``.
+  We now silently discard the specific port to avoid a conflict / race condition with OS outgoing port allocation.
+- Improved reliability of our tests and fixed warnings in them.
+- Preemptively disabled QUIC (HTTP/3 included) with interpreter built with FIPS-compliant SSL module.
+  Our QUIC implementation isn't FIPS-compliant for the moment. To force using non-FIPS QUIC implementation,
+  please patch ``urllib3.util.ssl_.IS_FIPS`` and set it to ``False``.
+
 2.11.908 (2024-11-03)
 =====================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-2.11.909 (2024-11-??)
+2.11.909 (2024-11-07)
 =====================
 
 - Fixed DNS-over-QUIC, DNS-over-TLS, and DNS-over-UDP(Cleartext) connection procedure on network that lacks IPv6 access.
@@ -10,6 +10,8 @@
   Our QUIC implementation isn't FIPS-compliant for the moment. To force using non-FIPS QUIC implementation,
   please patch ``urllib3.util.ssl_.IS_FIPS`` and set it to ``False``.
 - Fixed DoQ default certs loading as done in DoT, and DoH.
+- Improved reusability of a specific outgoing port. This is still an experimental feature, it is
+  likely that CPython have a bug that prevent consistent behavior for this.
 
 2.11.908 (2024-11-03)
 =====================

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.13-alpine
+
+WORKDIR /app
+
+RUN pip install --upgrade pip setuptools
+RUN pip install nox coverage
+
+ENV TRAEFIK_HTTPBIN_ENABLE=false
+ENV CI=true
+ENV TERM=xterm-256color
+
+COPY ./src/urllib3 src/urllib3/
+COPY ./test test/
+COPY ./dummyserver dummyserver/
+COPY ./ci ci/
+
+COPY noxfile.py LICENSE.txt pyproject.toml README.md setup.cfg hatch_build.py dev-requirements.txt mypy-requirements.txt .coveragerc ./
+
+CMD nox -s test-3.13 && python -m coverage combine && coverage report --ignore-errors --show-missing --fail-under=80

--- a/LibreSSL.Dockerfile
+++ b/LibreSSL.Dockerfile
@@ -9,6 +9,7 @@ RUN pip install nox
 
 ENV TRAEFIK_HTTPBIN_ENABLE=false
 ENV CI=true
+ENV TERM=xterm-256color
 
 COPY ./src/urllib3 src/urllib3/
 COPY ./test test/

--- a/OpenSSL.Dockerfile
+++ b/OpenSSL.Dockerfile
@@ -9,6 +9,7 @@ RUN pip install nox
 
 ENV TRAEFIK_HTTPBIN_ENABLE=false
 ENV CI=true
+ENV TERM=xterm-256color
 
 COPY ./src/urllib3 src/urllib3/
 COPY ./test test/

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ what was graciously made by our predecessors. So much knowledge has been poured 
 we must just extend it.
 
 We attempted to participate in urllib3 development only to find that we were in disagreement on how
-to proceed. It happens all the time, even on the biggest projects out there (e.g. OpenSSL vs BoringSSL or NSS or LibreSSL...))
+to proceed. It happens all the time, even on the biggest projects out there (e.g. OpenSSL vs BoringSSL or NSS or LibreSSL...)
 
 - **OK, but I got there because I saw that urllib3 was replaced in my environment!**
 
@@ -230,7 +230,44 @@ In addition to that, we enforced key integration tests to watch how urllib3-futu
 Top-priorities issues are those impacting users with the "shadowing" part. Meaning, if a user is suffering
 an error or something that ends up causing an undesirable outcome from a third-party library that leverage urllib3.
 
-- **OS Package Managers**
+- **Can I contribute to this?**
+
+Yes! But keep in mind that it is going to be hard to contribute as we have huge constraints.
+Some of them: Python 3.7+, OpenSSL <1.1.1,>1, LibreSSL, Downstream Perfect Compat, API Compatibility with urllib3, and so on.
+
+If you like a good challenge, then this project will definitely suit you.
+
+Make sure everything passes before submitting a PR, unless you need guidance on a specific topic.
+
+After applying your patch, run (Unix, Linux):
+
+```
+./ci/run_legacy_openssl.sh
+./ci/run_legacy_libressl.sh
+./ci/run_dockerized.sh
+nox -s test-3.11
+```
+
+replace the `3.11` part in `test-3.11` by your interpreter version.
+
+If the tests all passes, then it is a firm good start.
+
+Complete them with:
+
+```
+nox -s downstream_requests
+nox -s downstream_niquests
+nox -s downstream_boto3
+nox -s downstream_sphinx
+```
+
+Finally make sure to fix any lint errors:
+
+```
+nox -s lint
+```
+
+- **OS Package Managers, beware!**
 
 Fellow OS package maintainers, you cannot _just_ build and ship this package to your package registry.
 As it override `urllib3` and due to its current criticality, you'll have to set:

--- a/ci/run_dockerized.sh
+++ b/ci/run_dockerized.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+docker build -f Dockerfile -t urllib3:main .
+docker run -t urllib3:main

--- a/ci/run_legacy_libressl.sh
+++ b/ci/run_legacy_libressl.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 docker build -f LibreSSL.Dockerfile -t urllib3:legacy-libressl .
-docker run urllib3:legacy-libressl
+docker run -t urllib3:legacy-libressl

--- a/ci/run_legacy_openssl.sh
+++ b/ci/run_legacy_openssl.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 docker build -f OpenSSL.Dockerfile -t urllib3:legacy-openssl .
-docker run urllib3:legacy-openssl
+docker run -t urllib3:legacy-openssl

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,4 @@
-mypy==1.12.1; python_version >= '3.8'
+mypy==1.13.0; python_version >= '3.8'
 mypy==1.4.1; python_version < '3.8'
 idna>=2.0.0
 cryptography==42.0.5
@@ -6,7 +6,6 @@ tornado>=6.1
 pytest>=6.2
 trustme==0.9.0
 types-backports
-types-requests
 nox
 qh3>=1.2.0,<2.0.0
 h11>=0.11.0,<1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,18 +106,15 @@ markers = ["limit_memory"]
 log_level = "DEBUG"
 filterwarnings = [
     "error",
-    '''default:No IPv6 support. Falling back to IPv4:urllib3.exceptions.HTTPWarning''',
-    '''default:No IPv6 support. skipping:urllib3.exceptions.HTTPWarning''',
     '''default:ssl\.PROTOCOL_TLS is deprecated:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLSv1 is deprecated:DeprecationWarning''',
     '''default:ssl\.TLSVersion\.TLSv1_1 is deprecated:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLSv1_1 is deprecated:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLSv1_2 is deprecated:DeprecationWarning''',
     '''default:unclosed .*:ResourceWarning''',
-    '''default:ssl NPN is deprecated, use ALPN instead:DeprecationWarning''',
-    # https://github.com/pytest-dev/pytest/issues/10977
-    '''default:ast\.(Num|NameConstant|Str) is deprecated and will be removed in Python 3\.14; use ast\.Constant instead:DeprecationWarning:_pytest''',
-    '''default:Attribute s is deprecated and will be removed in Python 3\.14; use value instead:DeprecationWarning:_pytest''',
+    '''ignore:No IPv6 support. Falling back to IPv4:urllib3.exceptions.HTTPWarning''',
+    '''ignore:No IPv6 support. skipping:urllib3.exceptions.HTTPWarning''',
+    '''ignore:ssl NPN is deprecated, use ALPN instead:DeprecationWarning''',
     '''default:A conflicting charset has been set in Content-Type:UserWarning''',
     '''ignore:util\.connection\.create_connection\(\) is deprecated and scheduled for removal:DeprecationWarning''',
     '''ignore:RecentlyUsedContainer is deprecated and scheduled for removal:DeprecationWarning''',

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -552,6 +552,12 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
                     ).new()
                     conn_kw["socket_family"] = ip_address[0]
 
+                    if (
+                        "source_address" in conn_kw
+                        and conn_kw["source_address"] is not None
+                    ):
+                        conn_kw["source_address"] = (conn_kw["source_address"][0], 0)
+
                     challengers.append(
                         self.ConnectionCls(
                             host=self.host,

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -161,10 +161,9 @@ async def idle_conn_watch_task(
     try:
         while pool.pool is not None:
             pool.num_background_watch_iter += 1
-            try:
-                await asyncio.sleep(waiting_delay)
-            except asyncio.CancelledError:
-                return
+
+            await asyncio.sleep(waiting_delay)
+
             if pool.pool is None:
                 return
             try:
@@ -197,7 +196,7 @@ async def idle_conn_watch_task(
                                     await conn.ping()
             except AttributeError:
                 return
-    except ReferenceError:
+    except (ReferenceError, asyncio.CancelledError):
         return
 
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.11.908"
+__version__ = "2.11.909"

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -77,6 +77,11 @@ _HAS_SYS_AUDIT = hasattr(sys, "audit")
 
 @lru_cache(maxsize=1)
 def _HAS_HTTP3_SUPPORT() -> bool:
+    from ..util.ssl_ import IS_FIPS
+
+    if IS_FIPS:
+        return False
+
     import importlib.util
 
     try:

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -557,6 +557,12 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                     ).new()
                     conn_kw["socket_family"] = ip_address[0]
 
+                    if (
+                        "source_address" in conn_kw
+                        and conn_kw["source_address"] is not None
+                    ):
+                        conn_kw["source_address"] = (conn_kw["source_address"][0], 0)
+
                     challengers.append(
                         self.ConnectionCls(
                             host=self.host,

--- a/src/urllib3/contrib/resolver/_async/factories.py
+++ b/src/urllib3/contrib/resolver/_async/factories.py
@@ -79,7 +79,9 @@ class AsyncResolverFactory(metaclass=ABCMeta):
             and issubclass(e, AsyncBaseResolver)
             and (
                 (specifier is None and e.specifier is None) or specifier == e.specifier
-            ),
+            )
+            and hasattr(e, "protocol")
+            and e.protocol == protocol,
         )
 
         if not implementations:

--- a/src/urllib3/contrib/resolver/_async/protocols.py
+++ b/src/urllib3/contrib/resolver/_async/protocols.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import socket
 import typing
 from abc import ABCMeta, abstractmethod
@@ -87,6 +88,14 @@ class AsyncBaseResolver(BaseResolver, metaclass=ABCMeta):
 
         if family != socket.AF_UNSPEC:
             default_socket_family = family
+
+        if source_address is not None:
+            if isinstance(
+                ipaddress.ip_address(source_address[0]), ipaddress.IPv4Address
+            ):
+                default_socket_family = socket.AF_INET
+            else:
+                default_socket_family = socket.AF_INET6
 
         try:
             host.encode("idna")

--- a/src/urllib3/contrib/resolver/doq/_qh3.py
+++ b/src/urllib3/contrib/resolver/doq/_qh3.py
@@ -62,11 +62,21 @@ class QUICResolver(PlainResolver):
                     kwargs["ca_cert_data"].append(ssl.DER_cert_to_PEM_cert(der))
 
                 if kwargs["ca_cert_data"]:
-                    kwargs["ca_cert_data"] = "\n".join(kwargs["ca_cert_data"])
+                    kwargs["ca_cert_data"] = "".join(kwargs["ca_cert_data"])
                 else:
                     del kwargs["ca_cert_data"]
             except (AttributeError, ValueError, OSError):
                 del kwargs["ca_cert_data"]
+
+        if "ca_cert_data" not in kwargs and "ca_certs" not in kwargs:
+            if (
+                "cert_reqs" not in kwargs
+                or resolve_cert_reqs(kwargs["cert_reqs"]) is ssl.CERT_REQUIRED
+            ):
+                raise ssl.SSLError(
+                    "DoQ requires at least one CA loaded in order to verify the remote peer certificate. "
+                    "Add ?cert_reqs=0 to disable certificate checks."
+                )
 
         configuration = QuicConfiguration(
             is_client=True,

--- a/src/urllib3/contrib/resolver/factories.py
+++ b/src/urllib3/contrib/resolver/factories.py
@@ -38,7 +38,9 @@ class ResolverFactory(metaclass=ABCMeta):
             and issubclass(e, BaseResolver)
             and (
                 (specifier is None and e.specifier is None) or specifier == e.specifier
-            ),
+            )
+            and hasattr(e, "protocol")
+            and e.protocol == protocol,
         )
 
         if not implementations:

--- a/src/urllib3/contrib/resolver/protocols.py
+++ b/src/urllib3/contrib/resolver/protocols.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ipaddress
 import socket
 import struct
 import threading
@@ -197,6 +198,14 @@ class BaseResolver(metaclass=ABCMeta):
         if family != socket.AF_UNSPEC:
             default_socket_family = family
 
+        if source_address is not None:
+            if isinstance(
+                ipaddress.ip_address(source_address[0]), ipaddress.IPv4Address
+            ):
+                default_socket_family = socket.AF_INET
+            else:
+                default_socket_family = socket.AF_INET6
+
         try:
             host.encode("idna")
         except UnicodeError:
@@ -236,13 +245,13 @@ class BaseResolver(metaclass=ABCMeta):
                         ):  # Defensive: we can't do anything better than this.
                             pass
 
+                    sock.bind(source_address)
+
                 # If provided, set socket level options before connecting.
                 _set_socket_options(sock, socket_options)
 
                 if timeout is not _DEFAULT_TIMEOUT:
                     sock.settimeout(timeout)
-                if source_address:
-                    sock.bind(source_address)
 
                 if self._unsafe_expose:
                     self._sock_cursor = sock

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -7,7 +7,6 @@ import logging
 import re
 import sys
 import typing
-import warnings
 import zlib
 from contextlib import contextmanager
 from socket import timeout as SocketTimeout
@@ -389,14 +388,7 @@ class HTTPResponse(io.IOBase):
         self._original_response = original_response
         self._fp_bytes_read = 0
 
-        if msg is not None:
-            warnings.warn(
-                "Passing msg=.. is deprecated and no-op in urllib3.future and is scheduled to be removed in a future major.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        self.msg = msg
+        self.msg = msg  # no-op, kept for BC.
 
         if body and isinstance(body, (str, bytes)):
             self._body = body

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -356,7 +356,7 @@ def requires_tlsv1_3(supported_tls_versions: typing.AbstractSet[str]) -> None:
 _TRAEFIK_AVAILABLE = None
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def requires_traefik() -> None:
     global _TRAEFIK_AVAILABLE
 
@@ -378,6 +378,7 @@ def requires_traefik() -> None:
         )
     else:
         _TRAEFIK_AVAILABLE = True
+        sock.shutdown(0)
         sock.close()
 
 

--- a/test/contrib/asynchronous/test_resolver.py
+++ b/test/contrib/asynchronous/test_resolver.py
@@ -68,7 +68,7 @@ async def test_null_resolver(hostname: str, expect_error: bool) -> None:
         ("dou://1.1.1.1", PlainResolver),
         ("dox://ooooo.com", None),
         ("doh://dns.google/resolve", HTTPSResolver),
-        ("doq://dns.nextdns.io/?timeout=3", QUICResolver),
+        ("doq://dns.nextdns.io/?timeout=3&cert_reqs=0", QUICResolver),
         ("dns://dns.nextdns.io", None),
         ("null://default", NullResolver),
         ("default://null", None),
@@ -82,7 +82,10 @@ async def test_null_resolver(hostname: str, expect_error: bool) -> None:
         ("dot://1.1.1.1/?implementation=nonexistent", None),
         ("system://", SystemResolver),
         ("dot://", None),
-        ("doq://dns.nextdns.io/?implementation=qh3&timeout=1", QUICResolver),
+        (
+            "doq://dns.nextdns.io/?implementation=qh3&timeout=1&cert_reqs=0",
+            QUICResolver,
+        ),
     ],
 )
 @pytest.mark.asyncio
@@ -121,7 +124,7 @@ async def test_url_resolver(
         "system://default",
         "dot://dns.google",
         "dot://one.one.one.one",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
         "doh+google://",
         "doh+cloudflare://default",
     ],
@@ -156,7 +159,7 @@ async def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
         "doh://dns.google",
         "dot://dns.google",
         "dot://one.one.one.one",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
     ],
 )
 @pytest.mark.parametrize(
@@ -291,7 +294,7 @@ async def test_many_resolver_host_constraint_distribution() -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -377,7 +380,7 @@ async def test_doh_rfc8484(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -461,7 +464,7 @@ async def test_many_resolver_task_safe() -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -497,7 +500,7 @@ async def test_resolver_recycle(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -521,7 +524,7 @@ async def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -559,7 +562,7 @@ async def test_ipv6_always_preferred(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],

--- a/test/contrib/asynchronous/test_resolver.py
+++ b/test/contrib/asynchronous/test_resolver.py
@@ -14,13 +14,20 @@ from urllib3.contrib.resolver._async import (
     AsyncResolverDescription,
 )
 from urllib3.contrib.resolver._async.doh import HTTPSResolver
-from urllib3.contrib.resolver._async.doq import QUICResolver
-from urllib3.contrib.resolver._async.dot import TLSResolver
-from urllib3.contrib.resolver._async.dou import PlainResolver
-from urllib3.contrib.resolver._async.in_memory import InMemoryResolver
-from urllib3.contrib.resolver._async.null import NullResolver
-from urllib3.contrib.resolver._async.system import SystemResolver
-from urllib3.exceptions import InsecureRequestWarning
+
+_MISSING_QUIC_SENTINEL = object()
+
+try:
+    from urllib3.contrib.resolver._async.doq._qh3 import QUICResolver
+except ImportError:
+    QUICResolver = _MISSING_QUIC_SENTINEL  # type: ignore
+
+from urllib3.contrib.resolver._async.dot import TLSResolver  # noqa: E402
+from urllib3.contrib.resolver._async.dou import PlainResolver  # noqa: E402
+from urllib3.contrib.resolver._async.in_memory import InMemoryResolver  # noqa: E402
+from urllib3.contrib.resolver._async.null import NullResolver  # noqa: E402
+from urllib3.contrib.resolver._async.system import SystemResolver  # noqa: E402
+from urllib3.exceptions import InsecureRequestWarning  # noqa: E402
 
 
 @pytest.mark.parametrize(
@@ -82,6 +89,9 @@ async def test_null_resolver(hostname: str, expect_error: bool) -> None:
 async def test_url_resolver(
     url: str, expected_resolver_class: type[AsyncBaseResolver] | None
 ) -> None:
+    if expected_resolver_class is _MISSING_QUIC_SENTINEL:
+        pytest.skip("Test requires qh3 installed")
+
     if expected_resolver_class is None:
         with pytest.raises(
             (
@@ -118,6 +128,9 @@ async def test_url_resolver(
 )
 @pytest.mark.asyncio
 async def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     res = await resolver.getaddrinfo(
@@ -158,6 +171,9 @@ async def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
 async def test_dnssec_exception(
     dns_url: str, hostname: str, expected_failure: bool
 ) -> None:
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     if expected_failure:
@@ -282,6 +298,9 @@ async def test_many_resolver_host_constraint_distribution() -> None:
 )
 @pytest.mark.asyncio
 async def test_short_endurance_sprint(dns_url: str) -> None:
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     for host in [
@@ -365,6 +384,9 @@ async def test_doh_rfc8484(dns_url: str) -> None:
 )
 @pytest.mark.asyncio
 async def test_task_safe_resolver(dns_url: str) -> None:
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     tasks = []
@@ -446,6 +468,9 @@ async def test_many_resolver_task_safe() -> None:
 )
 @pytest.mark.asyncio
 async def test_resolver_recycle(dns_url: str) -> None:
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     await resolver.close()
@@ -479,6 +504,9 @@ async def test_resolver_recycle(dns_url: str) -> None:
 )
 @pytest.mark.asyncio
 async def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     with pytest.raises(RuntimeError):
@@ -501,6 +529,9 @@ async def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
 @pytest.mark.asyncio
 async def test_ipv6_always_preferred(dns_url: str) -> None:
     """Our resolvers must place IPV6 address in the beginning of returned list."""
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     inet_classes = []
@@ -536,6 +567,9 @@ async def test_ipv6_always_preferred(dns_url: str) -> None:
 @pytest.mark.asyncio
 async def test_dgram_upgrade(dns_url: str) -> None:
     """www.cloudflare.com records HTTPS exist, we know it. This verify that we are able to propose a DGRAM upgrade."""
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     sock_types = []

--- a/test/contrib/asynchronous/test_resolver.py
+++ b/test/contrib/asynchronous/test_resolver.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
-import platform
 import socket
 from test import requires_network
 
@@ -22,6 +20,7 @@ from urllib3.contrib.resolver._async.dou import PlainResolver
 from urllib3.contrib.resolver._async.in_memory import InMemoryResolver
 from urllib3.contrib.resolver._async.null import NullResolver
 from urllib3.contrib.resolver._async.system import SystemResolver
+from urllib3.exceptions import InsecureRequestWarning
 
 
 @pytest.mark.parametrize(
@@ -62,16 +61,7 @@ async def test_null_resolver(hostname: str, expect_error: bool) -> None:
         ("dou://1.1.1.1", PlainResolver),
         ("dox://ooooo.com", None),
         ("doh://dns.google/resolve", HTTPSResolver),
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            QUICResolver,
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        ("doq://dns.nextdns.io/?timeout=3", QUICResolver),
         ("dns://dns.nextdns.io", None),
         ("null://default", NullResolver),
         ("default://null", None),
@@ -85,16 +75,7 @@ async def test_null_resolver(hostname: str, expect_error: bool) -> None:
         ("dot://1.1.1.1/?implementation=nonexistent", None),
         ("system://", SystemResolver),
         ("dot://", None),
-        pytest.param(
-            "doq://dns.nextdns.io/?implementation=qh3&timeout=1",
-            QUICResolver,
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        ("doq://dns.nextdns.io/?implementation=qh3&timeout=1", QUICResolver),
     ],
 )
 @pytest.mark.asyncio
@@ -130,15 +111,7 @@ async def test_url_resolver(
         "system://default",
         "dot://dns.google",
         "dot://one.one.one.one",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
         "doh+google://",
         "doh+cloudflare://default",
     ],
@@ -170,15 +143,7 @@ async def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
         "doh://dns.google",
         "dot://dns.google",
         "dot://one.one.one.one",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
     ],
 )
 @pytest.mark.parametrize(
@@ -310,15 +275,7 @@ async def test_many_resolver_host_constraint_distribution() -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -401,15 +358,7 @@ async def test_doh_rfc8484(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -490,15 +439,7 @@ async def test_many_resolver_task_safe() -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -531,15 +472,7 @@ async def test_resolver_recycle(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -560,15 +493,7 @@ async def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -603,15 +528,7 @@ async def test_ipv6_always_preferred(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -741,28 +658,26 @@ async def test_doh_http11() -> None:
 
     assert len(res)
 
+    await resolver.close()
+
 
 @requires_network()
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    os.environ.get("CI", None) is not None and platform.system() != "Darwin",
-    reason="Github Action CI: Network Unreachable UDP/QUIC",
-    strict=False,
-)
 async def test_doh_http11_upgradable() -> None:
     """Ensure we can do DoH over HTTP/1.1 that can upgrade to HTTP/3"""
     resolver = AsyncResolverDescription.from_url(
-        "doh+google://default/?disabled_svn=h2"
+        "doh+google://default/?disabled_svn=h2&cert_reqs=0"
     ).new()
+    with pytest.warns(InsecureRequestWarning):
+        res = await resolver.getaddrinfo(
+            "www.cloudflare.com",
+            80,
+            socket.AF_UNSPEC,
+            socket.SOCK_STREAM,
+        )
 
-    res = await resolver.getaddrinfo(
-        "www.cloudflare.com",
-        80,
-        socket.AF_UNSPEC,
-        socket.SOCK_STREAM,
-    )
-
-    assert len(res)
+        assert len(res)
+    await resolver.close()
 
 
 @requires_network()

--- a/test/contrib/asynchronous/test_socks.py
+++ b/test/contrib/asynchronous/test_socks.py
@@ -635,7 +635,7 @@ class TestSOCKSWithTLS(IPV4SocketDummyServerTestCase):
                 handler.send(True)
 
             # Wrap in TLS
-            context = better_ssl.SSLContext(ssl.PROTOCOL_SSLv23)  # type: ignore[misc]
+            context = better_ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)  # type: ignore[misc]
             context.load_cert_chain(DEFAULT_CERTS["certfile"], DEFAULT_CERTS["keyfile"])
             tls = context.wrap_socket(sock, server_side=True)
             buf = b""

--- a/test/contrib/test_resolver.py
+++ b/test/contrib/test_resolver.py
@@ -15,13 +15,20 @@ from urllib3.contrib.resolver import (
     ResolverDescription,
 )
 from urllib3.contrib.resolver.doh import HTTPSResolver
-from urllib3.contrib.resolver.doq import QUICResolver
-from urllib3.contrib.resolver.dot import TLSResolver
-from urllib3.contrib.resolver.dou import PlainResolver
-from urllib3.contrib.resolver.in_memory import InMemoryResolver
-from urllib3.contrib.resolver.null import NullResolver
-from urllib3.contrib.resolver.system import SystemResolver
-from urllib3.exceptions import InsecureRequestWarning
+
+_MISSING_QUIC_SENTINEL = object()
+
+try:
+    from urllib3.contrib.resolver.doq._qh3 import QUICResolver
+except ImportError:
+    QUICResolver = _MISSING_QUIC_SENTINEL  # type: ignore
+
+from urllib3.contrib.resolver.dot import TLSResolver  # noqa: E402
+from urllib3.contrib.resolver.dou import PlainResolver  # noqa: E402
+from urllib3.contrib.resolver.in_memory import InMemoryResolver  # noqa: E402
+from urllib3.contrib.resolver.null import NullResolver  # noqa: E402
+from urllib3.contrib.resolver.system import SystemResolver  # noqa: E402
+from urllib3.exceptions import InsecureRequestWarning  # noqa: E402
 
 
 @pytest.mark.parametrize(
@@ -81,6 +88,9 @@ def test_null_resolver(hostname: str, expect_error: bool) -> None:
 def test_url_resolver(
     url: str, expected_resolver_class: type[BaseResolver] | None
 ) -> None:
+    if expected_resolver_class is _MISSING_QUIC_SENTINEL:
+        pytest.skip("Test requires qh3 installed")
+
     if expected_resolver_class is None:
         with pytest.raises(
             (
@@ -116,6 +126,9 @@ def test_url_resolver(
     ],
 )
 def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = ResolverDescription.from_url(dns_url).new()
 
     res = resolver.getaddrinfo(
@@ -152,6 +165,9 @@ def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
     ],
 )
 def test_dnssec_exception(dns_url: str, hostname: str, expected_failure: bool) -> None:
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = ResolverDescription.from_url(dns_url).new()
 
     if expected_failure:
@@ -273,6 +289,9 @@ def test_many_resolver_host_constraint_distribution() -> None:
     ],
 )
 def test_short_endurance_sprint(dns_url: str) -> None:
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = ResolverDescription.from_url(dns_url).new()
 
     for host in [
@@ -354,6 +373,9 @@ def test_doh_rfc8484(dns_url: str) -> None:
     ],
 )
 def test_thread_safe_resolver(dns_url: str) -> None:
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = ResolverDescription.from_url(dns_url).new()
 
     def _run(
@@ -453,6 +475,9 @@ def test_many_resolver_thread_safe() -> None:
     ],
 )
 def test_resolver_recycle(dns_url: str) -> None:
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = ResolverDescription.from_url(dns_url).new()
 
     resolver.close()
@@ -485,6 +510,9 @@ def test_resolver_recycle(dns_url: str) -> None:
     ],
 )
 def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = ResolverDescription.from_url(dns_url).new()
 
     with pytest.raises(RuntimeError):
@@ -506,6 +534,9 @@ def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
 )
 def test_ipv6_always_preferred(dns_url: str) -> None:
     """Our resolvers must place IPV6 address in the beginning of returned list."""
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = ResolverDescription.from_url(dns_url).new()
 
     inet_classes = []
@@ -540,6 +571,9 @@ def test_ipv6_always_preferred(dns_url: str) -> None:
 )
 def test_dgram_upgrade(dns_url: str) -> None:
     """www.cloudflare.com records HTTPS exist, we know it. This verify that we are able to propose a DGRAM upgrade."""
+    if QUICResolver is _MISSING_QUIC_SENTINEL and dns_url.startswith("doq"):
+        pytest.skip("Test requires qh3 installed")
+
     resolver = ResolverDescription.from_url(dns_url).new()
 
     sock_types = []

--- a/test/contrib/test_resolver.py
+++ b/test/contrib/test_resolver.py
@@ -68,7 +68,7 @@ def test_null_resolver(hostname: str, expect_error: bool) -> None:
         ("dou://1.1.1.1", PlainResolver),
         ("dox://ooooo.com", None),
         ("doh://dns.google/resolve", HTTPSResolver),
-        ("doq://dns.nextdns.io/?timeout=3", QUICResolver),
+        ("doq://dns.nextdns.io/?timeout=3&cert_reqs=0", QUICResolver),
         ("dns://dns.nextdns.io", None),
         ("null://default", NullResolver),
         ("default://null", None),
@@ -82,7 +82,10 @@ def test_null_resolver(hostname: str, expect_error: bool) -> None:
         ("dot://1.1.1.1/?implementation=nonexistent", None),
         ("system://", SystemResolver),
         ("dot://", None),
-        ("doq://dns.nextdns.io/?implementation=qh3&timeout=1", QUICResolver),
+        (
+            "doq://dns.nextdns.io/?implementation=qh3&timeout=1&cert_reqs=0",
+            QUICResolver,
+        ),
     ],
 )
 def test_url_resolver(
@@ -120,7 +123,7 @@ def test_url_resolver(
         "system://default",
         "dot://dns.google",
         "dot://one.one.one.one",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
         "doh+google://",
         "doh+cloudflare://default",
     ],
@@ -153,7 +156,7 @@ def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
         "doh://dns.google",
         "dot://dns.google",
         "dot://one.one.one.one",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
     ],
 )
 @pytest.mark.parametrize(
@@ -283,7 +286,7 @@ def test_many_resolver_host_constraint_distribution() -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -367,7 +370,7 @@ def test_doh_rfc8484(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -469,7 +472,7 @@ def test_many_resolver_thread_safe() -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -504,7 +507,7 @@ def test_resolver_recycle(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -527,7 +530,7 @@ def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -564,7 +567,7 @@ def test_ipv6_always_preferred(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.nextdns.io/?timeout=3",
+        "doq://dns.nextdns.io/?timeout=3&cert_reqs=0",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],

--- a/test/contrib/test_resolver.py
+++ b/test/contrib/test_resolver.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-import platform
 import socket
 from concurrent.futures import ThreadPoolExecutor
 from socket import AddressFamily, SocketKind
@@ -23,6 +21,7 @@ from urllib3.contrib.resolver.dou import PlainResolver
 from urllib3.contrib.resolver.in_memory import InMemoryResolver
 from urllib3.contrib.resolver.null import NullResolver
 from urllib3.contrib.resolver.system import SystemResolver
+from urllib3.exceptions import InsecureRequestWarning
 
 
 @pytest.mark.parametrize(
@@ -62,16 +61,7 @@ def test_null_resolver(hostname: str, expect_error: bool) -> None:
         ("dou://1.1.1.1", PlainResolver),
         ("dox://ooooo.com", None),
         ("doh://dns.google/resolve", HTTPSResolver),
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            QUICResolver,
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        ("doq://dns.nextdns.io/?timeout=3", QUICResolver),
         ("dns://dns.nextdns.io", None),
         ("null://default", NullResolver),
         ("default://null", None),
@@ -85,16 +75,7 @@ def test_null_resolver(hostname: str, expect_error: bool) -> None:
         ("dot://1.1.1.1/?implementation=nonexistent", None),
         ("system://", SystemResolver),
         ("dot://", None),
-        pytest.param(
-            "doq://dns.nextdns.io/?implementation=qh3&timeout=1",
-            QUICResolver,
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        ("doq://dns.nextdns.io/?implementation=qh3&timeout=1", QUICResolver),
     ],
 )
 def test_url_resolver(
@@ -129,15 +110,7 @@ def test_url_resolver(
         "system://default",
         "dot://dns.google",
         "dot://one.one.one.one",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
         "doh+google://",
         "doh+cloudflare://default",
     ],
@@ -167,15 +140,7 @@ def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
         "doh://dns.google",
         "dot://dns.google",
         "dot://one.one.one.one",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
     ],
 )
 @pytest.mark.parametrize(
@@ -302,15 +267,7 @@ def test_many_resolver_host_constraint_distribution() -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -391,15 +348,7 @@ def test_doh_rfc8484(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -498,15 +447,7 @@ def test_many_resolver_thread_safe() -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -538,15 +479,7 @@ def test_resolver_recycle(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -566,15 +499,7 @@ def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -608,15 +533,7 @@ def test_ipv6_always_preferred(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        pytest.param(
-            "doq://dns.nextdns.io/?timeout=1",
-            marks=pytest.mark.xfail(
-                os.environ.get("CI", None) is not None
-                and platform.system() != "Darwin",
-                reason="Github Action CI: Network Unreachable UDP/QUIC",
-                strict=False,
-            ),
-        ),
+        "doq://dns.nextdns.io/?timeout=3",
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -743,27 +660,25 @@ def test_doh_http11() -> None:
 
     assert len(res)
 
+    resolver.close()
+
 
 @requires_network()
-@pytest.mark.xfail(
-    os.environ.get("CI", None) is not None and platform.system() != "Darwin",
-    reason="Github Action CI: Network Unreachable UDP/QUIC",
-    strict=False,
-)
 def test_doh_http11_upgradable() -> None:
     """Ensure we can do DoH over HTTP/1.1 that can upgrade to HTTP/3"""
     resolver = ResolverDescription.from_url(
-        "doh+google://default/?disabled_svn=h2"
+        "doh+google://default/?disabled_svn=h2&cert_reqs=0"
     ).new()
+    with pytest.warns(InsecureRequestWarning):
+        res = resolver.getaddrinfo(
+            "www.cloudflare.com",
+            80,
+            socket.AF_UNSPEC,
+            socket.SOCK_STREAM,
+        )
 
-    res = resolver.getaddrinfo(
-        "www.cloudflare.com",
-        80,
-        socket.AF_UNSPEC,
-        socket.SOCK_STREAM,
-    )
-
-    assert len(res)
+        assert len(res)
+    resolver.close()
 
 
 @requires_network()

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -743,7 +743,7 @@ class TestSOCKSWithTLS(IPV4SocketDummyServerTestCase):
                 handler.send(True)
 
             # Wrap in TLS
-            context = better_ssl.SSLContext(ssl.PROTOCOL_SSLv23)  # type: ignore[misc]
+            context = better_ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)  # type: ignore[misc]
             context.load_cert_chain(DEFAULT_CERTS["certfile"], DEFAULT_CERTS["keyfile"])
             tls = context.wrap_socket(sock, server_side=True)
             buf = b""

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import gc
 import socket
 from test import resolvesLocalhostFQDN
+from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -268,11 +269,14 @@ class TestPoolManager:
         assert pool is other_pool
         # assert all(isinstance(key, PoolKey) for key in p.pools.keys())
 
-    def test_deprecated_no_scheme(self) -> None:
+    @patch("urllib3.poolmanager.PoolManager.connection_from_host")
+    def test_deprecated_no_scheme(self, connection_from_host: mock.MagicMock) -> None:
+        connection_from_host.side_effect = ConnectionError("Not attempting connection")
         p = PoolManager()
 
         with pytest.warns(DeprecationWarning) as records:
-            p.request(method="GET", url="evil.com://good.com")
+            with pytest.raises(ConnectionError):
+                p.request(method="GET", url="evil.com://good.com")
 
         msg = (
             "URLs without a scheme (ie 'https://') are deprecated and will raise an error "
@@ -284,6 +288,8 @@ class TestPoolManager:
         assert len(records) == 1
         assert isinstance(records[0].message, DeprecationWarning)
         assert records[0].message.args[0] == msg
+
+        p.clear()
 
     def test_custom_pool_key(self) -> None:
         """Assert it is possible to define a custom key function."""

--- a/test/test_ssltransport.py
+++ b/test/test_ssltransport.py
@@ -182,6 +182,8 @@ class SingleTLSLayerTestCase(SocketDummyServerTestCase):
             validate_request(request)
             unwrapped_sock.sendall(sample_response())
 
+            unwrapped_sock.close()
+
         self.start_dummy_server(shutdown_handler)
         sock = socket.create_connection((self.host, self.port))
         ssock = SSLTransport(sock, self.client_context, server_hostname="localhost")
@@ -196,6 +198,8 @@ class SingleTLSLayerTestCase(SocketDummyServerTestCase):
         sock.sendall(sample_request())
         response = consume_socket(sock)
         validate_response(response)
+
+        ssock.close()
 
     @pytest.mark.timeout(PER_TEST_TIMEOUT)
     def test_ssl_object_attributes(self) -> None:

--- a/test/with_dummyserver/test_connection.py
+++ b/test/with_dummyserver/test_connection.py
@@ -46,6 +46,7 @@ def test_does_not_release_conn(pool: HTTPConnectionPool) -> None:
 
     response.release_conn()
     assert pool.pool.qsize() == 0  # type: ignore[union-attr]
+    conn.close()
 
 
 def test_releases_conn(pool: HTTPConnectionPool) -> None:
@@ -68,6 +69,7 @@ def test_releases_conn(pool: HTTPConnectionPool) -> None:
 
     response.release_conn()
     assert pool.pool.qsize() == 1  # type: ignore[union-attr]
+    conn.close()
 
 
 def test_double_getresponse(pool: HTTPConnectionPool) -> None:
@@ -83,6 +85,8 @@ def test_double_getresponse(pool: HTTPConnectionPool) -> None:
     # Calling getrepsonse() twice should cause an error
     with pytest.raises(ResponseNotReady):
         conn.getresponse()
+
+    conn.close()
 
 
 def test_connection_state_properties(pool: HTTPConnectionPool) -> None:

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -771,12 +771,8 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         with HTTPConnectionPool(
             self.host, self.port, source_address=invalid_source_address, retries=False
         ) as pool:
-            if is_ipv6:
-                with pytest.raises(NameResolutionError):
-                    pool.request("GET", f"/source_address?{invalid_source_address}")
-            else:
-                with pytest.raises(NewConnectionError):
-                    pool.request("GET", f"/source_address?{invalid_source_address}")
+            with pytest.raises(NewConnectionError):
+                pool.request("GET", f"/source_address?{invalid_source_address}")
 
     def test_stream_keepalive(self) -> None:
         x = 2
@@ -1014,7 +1010,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             else:
                 conn = pool._get_conn()
                 conn.request("GET", "/headers", chunked=chunked)
-                pool._put_conn(conn)
+                conn.close()
 
             assert pool.headers == {"key": "val"}
             assert isinstance(pool.headers, header_type)
@@ -1025,7 +1021,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             else:
                 conn = pool._get_conn()
                 conn.request("GET", "/headers", headers=headers, chunked=chunked)
-                pool._put_conn(conn)
+                conn.close()
 
             assert headers == {"key": "val"}
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -55,7 +55,7 @@ TLSv1_2_CERTS = DEFAULT_CERTS.copy()
 TLSv1_2_CERTS["ssl_version"] = getattr(ssl, "PROTOCOL_TLSv1_2", None)
 
 TLSv1_3_CERTS = DEFAULT_CERTS.copy()
-TLSv1_3_CERTS["ssl_version"] = getattr(ssl, "PROTOCOL_TLS", None)
+TLSv1_3_CERTS["ssl_version"] = getattr(ssl, "PROTOCOL_TLS_CLIENT", None)
 
 
 CLIENT_INTERMEDIATE_PEM = "client_intermediate.pem"
@@ -511,6 +511,8 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             # the python ssl module).
             if hasattr(conn.sock, "server_hostname"):
                 assert conn.sock.server_hostname == "localhost"  # type: ignore[union-attr]
+
+            conn.close()
 
     def test_assert_fingerprint_md5(self) -> None:
         with HTTPSConnectionPool(

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -175,6 +175,8 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             assert conn.__class__ == VerifiedHTTPSConnection
             https_pool.request("GET", "/")  # Should succeed without exceptions.
 
+            https_pool.close()
+
             http = proxy_from_url(
                 self.proxy_url, cert_reqs="REQUIRED", ca_certs=DEFAULT_CA
             )

--- a/test/with_traefik/asynchronous/test_connection_multiplexed.py
+++ b/test/with_traefik/asynchronous/test_connection_multiplexed.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from test import notMacOS
 from time import time
 
 import pytest
@@ -11,6 +12,7 @@ from .. import TraefikTestCase
 
 @pytest.mark.asyncio
 class TestConnectionMultiplexed(TraefikTestCase):
+    @notMacOS()
     async def test_multiplexing_fastest_to_slowest(self) -> None:
         conn = AsyncHTTPSConnection(
             self.host,
@@ -41,6 +43,7 @@ class TestConnectionMultiplexed(TraefikTestCase):
 
         await conn.close()
 
+    @notMacOS()
     async def test_multiplexing_slowest_to_fastest(self) -> None:
         conn = AsyncHTTPSConnection(
             self.host,

--- a/test/with_traefik/asynchronous/test_connectionpool_multiplexed.py
+++ b/test/with_traefik/asynchronous/test_connectionpool_multiplexed.py
@@ -13,6 +13,7 @@ from .. import TraefikTestCase
 
 @pytest.mark.asyncio
 class TestConnectionPoolMultiplexed(TraefikTestCase):
+    @notMacOS()
     async def test_multiplexing_fastest_to_slowest(self) -> None:
         async with AsyncHTTPSConnectionPool(
             self.host,
@@ -52,6 +53,7 @@ class TestConnectionPoolMultiplexed(TraefikTestCase):
             assert 3.5 >= round(time() - before, 2)
             assert await pool.get_response() is None
 
+    @notMacOS()
     async def test_multiplexing_without_preload(self) -> None:
         async with AsyncHTTPSConnectionPool(
             self.host,

--- a/test/with_traefik/test_connection.py
+++ b/test/with_traefik/test_connection.py
@@ -122,6 +122,8 @@ class TestConnection(TraefikTestCase):
         assert resp.status == 200
         assert resp.version == 20
 
+        conn.close()
+
     @pytest.mark.usefixtures("requires_http3")
     def test_quic_cache_explicit_not_capable(self) -> None:
         quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = {
@@ -208,7 +210,7 @@ class TestConnection(TraefikTestCase):
                 self.https_port,
                 ca_certs=self.ca_authority,
                 resolver=self.test_resolver.new(),
-                source_address=("0.0.0.0", 8845),
+                source_address=("0.0.0.0", 50010),
             )
 
             conn.connect()

--- a/test/with_traefik/test_connection_multiplexed.py
+++ b/test/with_traefik/test_connection_multiplexed.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from test import notMacOS
 from time import time
 
 import pytest
@@ -10,6 +11,7 @@ from . import TraefikTestCase
 
 
 class TestConnectionMultiplexed(TraefikTestCase):
+    @notMacOS()
     def test_multiplexing_fastest_to_slowest(self) -> None:
         conn = HTTPSConnection(
             self.host,
@@ -40,6 +42,7 @@ class TestConnectionMultiplexed(TraefikTestCase):
 
         conn.close()
 
+    @notMacOS()
     def test_multiplexing_slowest_to_fastest(self) -> None:
         conn = HTTPSConnection(
             self.host,

--- a/test/with_traefik/test_connectionpool_multiplexed.py
+++ b/test/with_traefik/test_connectionpool_multiplexed.py
@@ -12,6 +12,7 @@ from . import TraefikTestCase
 
 
 class TestConnectionPoolMultiplexed(TraefikTestCase):
+    @notMacOS()
     def test_multiplexing_fastest_to_slowest(self) -> None:
         with HTTPSConnectionPool(
             self.host,


### PR DESCRIPTION
2.11.909 (2024-11-07)
=====================

- Fixed DNS-over-QUIC, DNS-over-TLS, and DNS-over-UDP(Cleartext) connection procedure on network that lacks IPv6 access.
- Fixed DNS-over-TLS unstable over a slow network.
- Fixed a bug when setting a specific port in ``source_address`` and setting ``happy_eyeballs=True``.
  We now silently discard the specific port to avoid a conflict / race condition with OS outgoing port allocation.
- Improved reliability of our tests and fixed warnings in them.
- Preemptively disabled QUIC (HTTP/3 included) with interpreter built with FIPS-compliant SSL module.
  Our QUIC implementation isn't FIPS-compliant for the moment. To force using non-FIPS QUIC implementation,
  please patch ``urllib3.util.ssl_.IS_FIPS`` and set it to ``False``.
- Fixed DoQ default certs loading as done in DoT, and DoH.
- Improved reusability of a specific outgoing port. This is still an experimental feature, it is
  likely that CPython have a bug that prevent consistent behavior for this.
