### PR TITLE
:bug: improve outgoing port reuse in same process execution flow (sync&async)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.11.910 (2024-11-08)
+=====================
+
+- Improved reliability of reusing a specific outgoing port. The feature is no longer experimental.
+
 2.11.909 (2024-11-07)
 =====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.11.909"
+__version__ = "2.11.910"

--- a/src/urllib3/contrib/resolver/_async/protocols.py
+++ b/src/urllib3/contrib/resolver/_async/protocols.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import socket
+import struct
 import typing
 from abc import ABCMeta, abstractmethod
 from datetime import datetime, timedelta, timezone
@@ -132,6 +133,13 @@ class AsyncBaseResolver(BaseResolver, metaclass=ABCMeta):
                             AttributeError,
                         ):  # Defensive: we can't do anything better than this.
                             pass
+
+                    try:
+                        sock.setsockopt(
+                            socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
+                        )
+                    except (OSError, AttributeError):
+                        pass
 
                 # If provided, set socket level options before connecting.
                 _set_socket_options(sock, socket_options)

--- a/src/urllib3/contrib/resolver/protocols.py
+++ b/src/urllib3/contrib/resolver/protocols.py
@@ -245,6 +245,13 @@ class BaseResolver(metaclass=ABCMeta):
                         ):  # Defensive: we can't do anything better than this.
                             pass
 
+                    try:
+                        sock.setsockopt(
+                            socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
+                        )
+                    except (OSError, AttributeError):
+                        pass
+
                     sock.bind(source_address)
 
                 # If provided, set socket level options before connecting.

--- a/src/urllib3/contrib/ssa/__init__.py
+++ b/src/urllib3/contrib/ssa/__init__.py
@@ -6,7 +6,6 @@ import socket
 import typing
 import warnings
 
-SHUT_RD = 0  # taken from the "_socket" module
 StandardTimeoutError = socket.timeout
 
 try:
@@ -126,7 +125,7 @@ class AsyncSocket:
 
             if hasattr(self._sock, "shutdown"):
                 try:
-                    self._sock.shutdown(SHUT_RD)
+                    self._sock.shutdown(socket.SHUT_RD)
                     shutdown_called = True
                 except TypeError:
                     uvloop_edge_case_bug = True
@@ -143,7 +142,7 @@ class AsyncSocket:
                             pass
                         else:
                             try:
-                                direct_sock.shutdown(SHUT_RD)
+                                direct_sock.shutdown(socket.SHUT_RD)
                                 shutdown_called = True
                             except OSError:
                                 warnings.warn(
@@ -174,7 +173,7 @@ class AsyncSocket:
                     and not _CPYTHON_SELECTOR_CLOSE_BUG_EXIST
                 ):
                     try:
-                        self._sock._sock.detach()
+                        self._sock._sock.close()
                     except (AttributeError, OSError):
                         pass
 
@@ -198,7 +197,7 @@ class AsyncSocket:
     async def wait_for_readiness(self) -> None:
         await self._established.wait()
 
-    def setsockopt(self, __level: int, __optname: int, __value: int) -> None:
+    def setsockopt(self, __level: int, __optname: int, __value: int | bytes) -> None:
         self._sock.setsockopt(__level, __optname, __value)
 
     def getsockopt(self, __level: int, __optname: int) -> int:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -369,7 +369,7 @@ def requires_traefik() -> None:
 
     try:
         sock = socket.create_connection(
-            (os.environ.get("TRAEFIK_HTTPBIN_IPV4", "127.0.0.1"), 8888), timeout=0.3
+            (os.environ.get("TRAEFIK_HTTPBIN_IPV4", "127.0.0.1"), 8888), timeout=1
         )
     except (ConnectionRefusedError, socket.gaierror, TimeoutError):
         _TRAEFIK_AVAILABLE = False

--- a/test/with_traefik/asynchronous/test_connection.py
+++ b/test/with_traefik/asynchronous/test_connection.py
@@ -206,9 +206,6 @@ class TestConnection(TraefikTestCase):
 
         await conn.close()
 
-    @pytest.mark.xfail(
-        reason="experimental support for reusable outgoing port", strict=False
-    )
     async def test_fast_reuse_outgoing_port(self) -> None:
         for _ in range(4):
             conn = AsyncHTTPSConnection(

--- a/test/with_traefik/test_connection.py
+++ b/test/with_traefik/test_connection.py
@@ -200,9 +200,6 @@ class TestConnection(TraefikTestCase):
 
         conn.close()
 
-    @pytest.mark.xfail(
-        reason="experimental support for reusable outgoing port", strict=False
-    )
     def test_fast_reuse_outgoing_port(self) -> None:
         for _ in range(4):
             conn = HTTPSConnection(


### PR DESCRIPTION
2.11.910 (2024-11-08)
=====================

- Improved reliability of reusing a specific outgoing port. The feature is no longer experimental.
