### PR TITLE
Release 2.12.900

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+2.12.900 (2024-11-28)
+=====================
+
+- Added built-in support for Server-Side-Event (or SSE) via a WebExtension.
+  It is as simple as doing ``pm.urlopen("GET", "sse://sse.dev/test")``. ``sse`` is using https under the hood by default.
+  To force SSE via plain HTTP, replace ``sse://`` by ``psse://``.
+  The ``extension`` attribute of produced response will be set, and you will be able to consume event promptly.
+  See the documentation to learn more.
+- Fixed unintentional regression using ``CONNECT`` verb manually outside of its standard usage.
+- Fixed using a WebExtension with ``urlopen(..., multiplexed=True)`` from a PoolManager instance.
+
 2.11.912 (2024-11-26)
 =====================
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <br><small>urllib3.future is as BoringSSL is to OpenSSL but to urllib3 (except support is available!)</small>
   <br><small>✨🍰 Enjoy HTTP like its 2024 🍰✨</small>
   <br><small>💰 Promotional offer, get everything and more for <del>40k</del> <b>0</b>$!</small>
-  <br><small>Wondering why and how this fork exist? Why urllib3 does not merge this, even partially? <a href="https://medium.com/@ahmed.tahri/revived-the-promise-made-six-years-ago-for-requests-3-37b440e6a064">Take a peek at this article!</a></small>
+  <br><small>Wondering why and how this fork exist? Why urllib3 is stuck? <a href="https://medium.com/@ahmed.tahri/revived-the-promise-made-six-years-ago-for-requests-3-37b440e6a064">Take a peek at this article!</a></small>
 </p>
 
 ⚡ urllib3.future is a powerful, *user-friendly* HTTP client for Python.<br>
@@ -37,6 +37,7 @@
 - Post-Quantum Security with QUIC.
 - Detailed connection inspection.
 - HTTP/2 with prior knowledge.
+- Server Side Event (SSE).
 - Multiplexed connection.
 - Mirrored Sync & Async.
 - Trailer Headers.

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -1607,3 +1607,33 @@ Setting it to ``None`` makes it disabled.
 .. note:: By default, it checks for incoming data and react to it every 5000ms.
 
 .. warning:: Disabling this will void the effect of our automated keepalive.
+
+Server Side Event
+-----------------
+
+.. note:: Upgrade urllib3-future to 2.12+ or later to benefit from this.
+
+You can start leveraging SSE through HTTP/1, HTTP/2 or HTTP/3 with a mere line of code!
+Everything is handled by us, you don't have to worry about protocols internal. Do as you
+did simple http request.
+
+.. code-block:: python
+
+    import urllib3
+
+    if __name__ == "__main__":
+
+        with urllib3.PoolManager() as pm:
+            r = pm.urlopen("GET", "sse://httpbingo.org/sse?delay=1s&duration=5s&count=10")
+
+            while r.extension.closed is False:
+                event = r.extension.next_payload()  # here, next_payload() returns an ServerSentEvent object.
+                print(event)
+                print(event.json())
+
+            print(r.trailers)  # some server can give you some stats post ending the stream of events, you'll find them here.
+
+.. warning:: By default ``sse://`` is bound to ``https://``. Use ``psse://`` to connect using plain http instead.
+
+In opposition to WebSocket, the method ``next_payload()`` output an object. The event fully parsed.
+If you wanted to get the raw event, untouched, as unicode string, add the kwarg ``raw=True`` into the method ``next_payload()``.

--- a/noxfile.py
+++ b/noxfile.py
@@ -242,10 +242,16 @@ def tests_impl(
             "python",
             *(("-bb",) if byte_string_comparisons else ()),
             "-m",
-            "coverage",
-            "run",
-            "--parallel-mode",
-            "-m",
+            *(
+                (
+                    "coverage",
+                    "run",
+                    "--parallel-mode",
+                    "-m",
+                )
+                if tracemalloc_enable is False
+                else ()
+            ),
             "pytest",
             "-v",
             "-ra",

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -1073,7 +1073,8 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
 
         if extension is not None:
             if response.status == 101 or (
-                200 <= response.status < 300 and method == "CONNECT"
+                200 <= response.status < 300
+                and (method == "CONNECT" or extension is not None)
             ):
                 if extension is None:
                     extension = load_extension(None)()
@@ -1372,7 +1373,8 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
         response._pool = self
 
         if response.status == 101 or (
-            200 <= response.status < 300 and method == "CONNECT"
+            200 <= response.status < 300
+            and (method == "CONNECT" or extension is not None)
         ):
             if extension is None:
                 extension = load_extension(None)()

--- a/src/urllib3/_async/poolmanager.py
+++ b/src/urllib3/_async/poolmanager.py
@@ -623,9 +623,10 @@ class AsyncPoolManager(AsyncRequestMethods):
 
         extension = from_promise.get_parameter("extension")
 
-        if extension is not None:
+        if extension is not None and response.extension is None:
             if response.status == 101 or (
-                200 <= response.status < 300 and method == "CONNECT"
+                200 <= response.status < 300
+                and (method == "CONNECT" or extension is not None)
             ):
                 if extension is None:
                     extension = load_extension(None)()
@@ -707,6 +708,7 @@ class AsyncPoolManager(AsyncRequestMethods):
         if u.scheme is not None and u.scheme.lower() not in ("http", "https"):
             extension = load_extension(*parse_extension(u.scheme))
             kw["extension"] = extension()
+            kw.update(kw["extension"].urlopen_kwargs)
 
         kw["assert_same_host"] = False
         kw["redirect"] = False

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.11.912"
+__version__ = "2.12.900"

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1069,7 +1069,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         if extension is not None:
             if response.status == 101 or (
-                200 <= response.status < 300 and method == "CONNECT"
+                200 <= response.status < 300
+                and (method == "CONNECT" or extension is not None)
             ):
                 if extension is None:
                     extension = load_extension(None)()
@@ -1355,7 +1356,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         response._pool = self
 
         if response.status == 101 or (
-            200 <= response.status < 300 and method == "CONNECT"
+            200 <= response.status < 300
+            and (method == "CONNECT" or extension is not None)
         ):
             if extension is None:
                 extension = load_extension(None)()

--- a/src/urllib3/contrib/hface/protocols/http1/_h11.py
+++ b/src/urllib3/contrib/hface/protocols/http1/_h11.py
@@ -77,7 +77,7 @@ def headers_to_request(headers: HeadersType) -> h11.Event:
     if authority is None:
         raise ValueError("Missing request header: :authority")
 
-    if method == b"CONNECT":
+    if method == b"CONNECT" and path is None:
         # CONNECT requests are a special case.
         target = authority
     else:

--- a/src/urllib3/contrib/webextensions/__init__.py
+++ b/src/urllib3/contrib/webextensions/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .protocol import ExtensionFromHTTP
 from .raw import RawExtensionFromHTTP
+from .sse import ServerSideEventExtensionFromHTTP
 
 try:
     from .ws import WebSocketExtensionFromHTTP, WebSocketExtensionFromMultiplexedHTTP
@@ -35,5 +36,6 @@ __all__ = (
     "RawExtensionFromHTTP",
     "WebSocketExtensionFromHTTP",
     "WebSocketExtensionFromMultiplexedHTTP",
+    "ServerSideEventExtensionFromHTTP",
     "load_extension",
 )

--- a/src/urllib3/contrib/webextensions/_async/__init__.py
+++ b/src/urllib3/contrib/webextensions/_async/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .protocol import AsyncExtensionFromHTTP
 from .raw import AsyncRawExtensionFromHTTP
+from .sse import AsyncServerSideEventExtensionFromHTTP
 
 try:
     from .ws import (
@@ -38,5 +39,6 @@ __all__ = (
     "AsyncRawExtensionFromHTTP",
     "AsyncWebSocketExtensionFromHTTP",
     "AsyncWebSocketExtensionFromMultiplexedHTTP",
+    "AsyncServerSideEventExtensionFromHTTP",
     "load_extension",
 )

--- a/src/urllib3/contrib/webextensions/_async/protocol.py
+++ b/src/urllib3/contrib/webextensions/_async/protocol.py
@@ -120,6 +120,10 @@ class AsyncExtensionFromHTTP(metaclass=ABCMeta):
                 if self._response:
                     await self.close()
 
+    @property
+    def urlopen_kwargs(self) -> dict[str, typing.Any]:
+        return {}
+
     async def start(self, response: AsyncHTTPResponse) -> None:
         """The HTTP server gave us the go-to start negotiating another protocol."""
         if response._fp is None or not hasattr(response._fp, "_dsa"):

--- a/src/urllib3/contrib/webextensions/_async/sse.py
+++ b/src/urllib3/contrib/webextensions/_async/sse.py
@@ -11,7 +11,6 @@ from .protocol import AsyncExtensionFromHTTP
 
 
 class AsyncServerSideEventExtensionFromHTTP(AsyncExtensionFromHTTP):
-
     def __init__(self) -> None:
         super().__init__()
 
@@ -57,7 +56,9 @@ class AsyncServerSideEventExtensionFromHTTP(AsyncExtensionFromHTTP):
         ...
 
     @typing.overload
-    async def next_payload(self, *, raw: typing.Literal[False] = False) -> ServerSentEvent | None:
+    async def next_payload(
+        self, *, raw: typing.Literal[False] = False
+    ) -> ServerSentEvent | None:
         ...
 
     async def next_payload(self, *, raw: bool = False) -> ServerSentEvent | str | None:
@@ -105,9 +106,7 @@ class AsyncServerSideEventExtensionFromHTTP(AsyncExtensionFromHTTP):
         if "id" not in kwargs and self._last_event_id is not None:
             kwargs["id"] = self._last_event_id
 
-        event = ServerSentEvent(
-            **kwargs
-        )
+        event = ServerSentEvent(**kwargs)
 
         if event.id:
             self._last_event_id = event.id

--- a/src/urllib3/contrib/webextensions/_async/sse.py
+++ b/src/urllib3/contrib/webextensions/_async/sse.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from ...._async.response import AsyncHTTPResponse
+
+from ....backend import HttpVersion
+from ..sse import ServerSentEvent
+from .protocol import AsyncExtensionFromHTTP
+
+
+class AsyncServerSideEventExtensionFromHTTP(AsyncExtensionFromHTTP):
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._last_event_id: str | None = None
+        self._buffer: str = ""
+        self._stream: typing.AsyncGenerator[bytes, None] | None = None
+
+    @staticmethod
+    def supported_svn() -> set[HttpVersion]:
+        return {HttpVersion.h11, HttpVersion.h2, HttpVersion.h3}
+
+    @staticmethod
+    def implementation() -> str:
+        return "native"
+
+    @property
+    def urlopen_kwargs(self) -> dict[str, typing.Any]:
+        return {"preload_content": False}
+
+    async def close(self) -> None:
+        if self._stream is not None and self._response is not None:
+            await self._stream.aclose()
+            if self._response._fp is not None and hasattr(self._response._fp, "abort"):
+                await self._response._fp.abort()
+            self._stream = None
+            self._response = None
+            self._police_officer = None
+
+    @property
+    def closed(self) -> bool:
+        return self._stream is None
+
+    async def start(self, response: AsyncHTTPResponse) -> None:
+        await super().start(response)
+
+        self._stream = response.stream(-1, decode_content=True)
+
+    def headers(self, http_version: HttpVersion) -> dict[str, str]:
+        return {"accept": "text/event-stream", "cache-control": "no-store"}
+
+    @typing.overload
+    async def next_payload(self, *, raw: typing.Literal[True] = True) -> str | None:
+        ...
+
+    @typing.overload
+    async def next_payload(self, *, raw: typing.Literal[False] = False) -> ServerSentEvent | None:
+        ...
+
+    async def next_payload(self, *, raw: bool = False) -> ServerSentEvent | str | None:
+        """Unpack the next received message/payload from remote."""
+        if self._response is None or self._stream is None:
+            raise OSError("The HTTP extension is closed or uninitialized")
+
+        try:
+            raw_payload: str = (await self._stream.__anext__()).decode("utf-8")
+        except StopAsyncIteration:
+            await self._stream.aclose()
+            self._stream = None
+            return None
+
+        if self._buffer:
+            raw_payload = self._buffer + raw_payload
+            self._buffer = ""
+
+        kwargs: dict[str, typing.Any] = {}
+        eot = False
+
+        for line in raw_payload.splitlines():
+            if not line:
+                eot = True
+                break
+            key, _, value = line.partition(":")
+            if key not in {"event", "data", "retry", "id"}:
+                continue
+            if value.startswith(" "):
+                value = value[1:]
+            if key == "id":
+                if "\u0000" in value:
+                    continue
+            if key == "retry":
+                try:
+                    value = int(value)  # type: ignore[assignment]
+                except (ValueError, TypeError):
+                    continue
+            kwargs[key] = value
+
+        if eot is False:
+            self._buffer = raw_payload
+            return await self.next_payload(raw=raw)  # type: ignore[call-overload,no-any-return]
+
+        if "id" not in kwargs and self._last_event_id is not None:
+            kwargs["id"] = self._last_event_id
+
+        event = ServerSentEvent(
+            **kwargs
+        )
+
+        if event.id:
+            self._last_event_id = event.id
+
+        if raw is True:
+            return raw_payload
+
+        return event
+
+    async def send_payload(self, buf: str | bytes) -> None:
+        """Dispatch a buffer to remote."""
+        raise NotImplementedError("SSE is only one-way. Sending is forbidden.")
+
+    @staticmethod
+    def supported_schemes() -> set[str]:
+        return {"sse", "psse"}
+
+    @staticmethod
+    def scheme_to_http_scheme(scheme: str) -> str:
+        return {"sse": "https", "psse": "http"}[scheme]

--- a/src/urllib3/contrib/webextensions/protocol.py
+++ b/src/urllib3/contrib/webextensions/protocol.py
@@ -120,6 +120,11 @@ class ExtensionFromHTTP(metaclass=ABCMeta):
                 if self._response:
                     self.close()
 
+    @property
+    def urlopen_kwargs(self) -> dict[str, typing.Any]:
+        """Return prerequisites. Must be passed as additional parameters to urlopen."""
+        return {}
+
     def start(self, response: HTTPResponse) -> None:
         """The HTTP server gave us the go-to start negotiating another protocol."""
         if response._fp is None or not hasattr(response._fp, "_dsa"):

--- a/src/urllib3/contrib/webextensions/sse.py
+++ b/src/urllib3/contrib/webextensions/sse.py
@@ -11,7 +11,6 @@ from ...backend import HttpVersion
 from .protocol import ExtensionFromHTTP
 
 
-
 class ServerSentEvent:
     def __init__(
         self,
@@ -65,7 +64,6 @@ class ServerSentEvent:
 
 
 class ServerSideEventExtensionFromHTTP(ExtensionFromHTTP):
-
     def __init__(self) -> None:
         super().__init__()
 
@@ -112,7 +110,9 @@ class ServerSideEventExtensionFromHTTP(ExtensionFromHTTP):
         ...
 
     @typing.overload
-    def next_payload(self, *, raw: typing.Literal[False] = False) -> ServerSentEvent | None:
+    def next_payload(
+        self, *, raw: typing.Literal[False] = False
+    ) -> ServerSentEvent | None:
         ...
 
     def next_payload(self, *, raw: bool = False) -> ServerSentEvent | str | None:
@@ -159,9 +159,7 @@ class ServerSideEventExtensionFromHTTP(ExtensionFromHTTP):
             if "id" not in kwargs and self._last_event_id is not None:
                 kwargs["id"] = self._last_event_id
 
-            event = ServerSentEvent(
-                **kwargs
-            )
+            event = ServerSentEvent(**kwargs)
 
             if event.id:
                 self._last_event_id = event.id

--- a/src/urllib3/contrib/webextensions/sse.py
+++ b/src/urllib3/contrib/webextensions/sse.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+import typing
+from threading import RLock
+
+if typing.TYPE_CHECKING:
+    from ...response import HTTPResponse
+
+from ...backend import HttpVersion
+from .protocol import ExtensionFromHTTP
+
+
+
+class ServerSentEvent:
+    def __init__(
+        self,
+        event: str | None = None,
+        data: str | None = None,
+        id: str | None = None,
+        retry: int | None = None,
+    ) -> None:
+        if not event:
+            event = "message"
+
+        if data is None:
+            data = ""
+
+        if id is None:
+            id = ""
+
+        self._event = event
+        self._data = data
+        self._id = id
+        self._retry = retry
+
+    @property
+    def event(self) -> str:
+        return self._event
+
+    @property
+    def data(self) -> str:
+        return self._data
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def retry(self) -> int | None:
+        return self._retry
+
+    def json(self) -> typing.Any:
+        return json.loads(self.data)
+
+    def __repr__(self) -> str:
+        pieces = [f"event={self.event!r}"]
+        if self.data != "":
+            pieces.append(f"data={self.data!r}")
+        if self.id != "":
+            pieces.append(f"id={self.id!r}")
+        if self.retry is not None:
+            pieces.append(f"retry={self.retry!r}")
+        return f"ServerSentEvent({', '.join(pieces)})"
+
+
+class ServerSideEventExtensionFromHTTP(ExtensionFromHTTP):
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._last_event_id: str | None = None
+        self._buffer: str = ""
+        self._lock = RLock()
+        self._stream: typing.Generator[bytes, None, None] | None = None
+
+    @staticmethod
+    def supported_svn() -> set[HttpVersion]:
+        return {HttpVersion.h11, HttpVersion.h2, HttpVersion.h3}
+
+    @staticmethod
+    def implementation() -> str:
+        return "native"
+
+    @property
+    def urlopen_kwargs(self) -> dict[str, typing.Any]:
+        return {"preload_content": False}
+
+    @property
+    def closed(self) -> bool:
+        return self._stream is None
+
+    def close(self) -> None:
+        if self._stream is not None and self._response is not None:
+            self._stream.close()
+            if self._response._fp is not None and hasattr(self._response._fp, "abort"):
+                self._response._fp.abort()
+            self._stream = None
+            self._response = None
+            self._police_officer = None
+
+    def start(self, response: HTTPResponse) -> None:
+        super().start(response)
+
+        self._stream = response.stream(-1, decode_content=True)
+
+    def headers(self, http_version: HttpVersion) -> dict[str, str]:
+        return {"accept": "text/event-stream", "cache-control": "no-store"}
+
+    @typing.overload
+    def next_payload(self, *, raw: typing.Literal[True] = True) -> str | None:
+        ...
+
+    @typing.overload
+    def next_payload(self, *, raw: typing.Literal[False] = False) -> ServerSentEvent | None:
+        ...
+
+    def next_payload(self, *, raw: bool = False) -> ServerSentEvent | str | None:
+        """Unpack the next received message/payload from remote."""
+        if self._response is None or self._stream is None:
+            raise OSError("The HTTP extension is closed or uninitialized")
+        with self._lock:
+            try:
+                raw_payload: str = next(self._stream).decode("utf-8")
+            except StopIteration:
+                self._stream = None
+                return None
+
+            if self._buffer:
+                raw_payload = self._buffer + raw_payload
+                self._buffer = ""
+
+            kwargs: dict[str, typing.Any] = {}
+            eot = False
+
+            for line in raw_payload.splitlines():
+                if not line:
+                    eot = True
+                    break
+                key, _, value = line.partition(":")
+                if key not in {"event", "data", "retry", "id"}:
+                    continue
+                if value.startswith(" "):
+                    value = value[1:]
+                if key == "id":
+                    if "\u0000" in value:
+                        continue
+                if key == "retry":
+                    try:
+                        value = int(value)  # type: ignore[assignment]
+                    except (ValueError, TypeError):
+                        continue
+                kwargs[key] = value
+
+            if eot is False:
+                self._buffer = raw_payload
+                return self.next_payload(raw=raw)  # type: ignore[call-overload,no-any-return]
+
+            if "id" not in kwargs and self._last_event_id is not None:
+                kwargs["id"] = self._last_event_id
+
+            event = ServerSentEvent(
+                **kwargs
+            )
+
+            if event.id:
+                self._last_event_id = event.id
+
+            if raw is True:
+                return raw_payload
+
+            return event
+
+    def send_payload(self, buf: str | bytes) -> None:
+        """Dispatch a buffer to remote."""
+        raise NotImplementedError("SSE is only one-way. Sending is forbidden.")
+
+    @staticmethod
+    def supported_schemes() -> set[str]:
+        return {"sse", "psse"}
+
+    @staticmethod
+    def scheme_to_http_scheme(scheme: str) -> str:
+        return {"sse": "https", "psse": "http"}[scheme]

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -755,9 +755,11 @@ class PoolManager(RequestMethods):
 
         extension = from_promise.get_parameter("extension")
 
-        if extension is not None:
+        # Pool may have already set&start extension.
+        if extension is not None and response.extension is None:
             if response.status == 101 or (
-                200 <= response.status < 300 and method == "CONNECT"
+                200 <= response.status < 300
+                and (method == "CONNECT" or extension is not None)
             ):
                 if extension is None:
                     extension = load_extension(None)()
@@ -839,6 +841,7 @@ class PoolManager(RequestMethods):
         if u.scheme is not None and u.scheme.lower() not in ("http", "https"):
             extension = load_extension(*parse_extension(u.scheme))
             kw["extension"] = extension()
+            kw.update(kw["extension"].urlopen_kwargs)
 
         kw["assert_same_host"] = False
         kw["redirect"] = False

--- a/test/with_traefik/asynchronous/test_connection.py
+++ b/test/with_traefik/asynchronous/test_connection.py
@@ -213,7 +213,7 @@ class TestConnection(TraefikTestCase):
                 self.https_port,
                 ca_certs=self.ca_authority,
                 resolver=self.test_async_resolver.new(),
-                source_address=("0.0.0.0", 8745),
+                source_address=("0.0.0.0", 8789),
             )
 
             await conn.connect()

--- a/test/with_traefik/asynchronous/test_webextensions.py
+++ b/test/with_traefik/asynchronous/test_webextensions.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import asyncio
+import time
+
 import pytest
 
 from urllib3 import AsyncPoolManager, HttpVersion, Timeout
+from urllib3.backend.hface import _HAS_HTTP3_SUPPORT
 from urllib3.contrib.webextensions._async import (
     AsyncRawExtensionFromHTTP,
+    AsyncServerSideEventExtensionFromHTTP,
     AsyncWebSocketExtensionFromHTTP,
 )
 from urllib3.exceptions import ReadTimeoutError
@@ -246,6 +251,7 @@ class TestWebExtensions(TraefikTestCase):
             resolver=self.test_async_resolver,
             ca_certs=self.ca_authority,
             timeout=Timeout(read=1),
+            retries=False,
         ) as pm:
             resp = await pm.urlopen("GET", target_url + "/websocket/echo")
 
@@ -267,3 +273,224 @@ class TestWebExtensions(TraefikTestCase):
                 await resp.extension.next_payload()
 
             await resp.extension.close()
+
+    @pytest.mark.parametrize(
+        "target_protocol, target_http",
+        [
+            ("sse", 11),
+            ("sse", 20),
+            ("sse", 30),
+            ("psse", 11),
+            ("psse", 20),
+        ],
+    )
+    async def test_server_side_event(
+        self, target_protocol: str, target_http: int
+    ) -> None:
+        target_url = self.https_url if target_protocol == "sse" else self.http_url
+        target_url = (
+            target_url.replace("https://", "sse://")
+            if target_protocol == "sse"
+            else target_url.replace("http://", "psse://")
+        )
+
+        disabled_svn = set()
+
+        if target_http == 11:
+            disabled_svn.add(HttpVersion.h2)
+            disabled_svn.add(HttpVersion.h3)
+        elif target_http == 20:
+            disabled_svn.add(HttpVersion.h11)
+            disabled_svn.add(HttpVersion.h3)
+        elif target_http == 30:
+            disabled_svn.add(HttpVersion.h11)
+            disabled_svn.add(HttpVersion.h2)
+
+        async with AsyncPoolManager(
+            resolver=self.test_async_resolver,
+            ca_certs=self.ca_authority,
+            disabled_svn=disabled_svn,
+        ) as pm:
+            resp = await pm.urlopen("GET", target_url + "/sse?delay=1s&count=5")
+
+            # The response ends with a "200 OK"!
+            assert resp.status == 200
+
+            # The HTTP extension should be automatically loaded!
+            assert resp.extension is not None
+
+            assert resp.version == target_http
+
+            assert isinstance(resp.extension, AsyncServerSideEventExtensionFromHTTP)
+
+            events = []
+
+            while resp.extension.closed is False:
+                ev = await resp.extension.next_payload()
+                print(ev)
+                if ev is not None:
+                    events.append(ev)
+
+            assert len(events) == 5
+
+            assert resp.extension.closed is True
+
+            for event in events:
+                assert event.json()  # type: ignore
+                assert "timestamp" in event.json()  # type: ignore
+
+            assert resp.trailers
+            assert "server-timing" in resp.trailers
+
+    @pytest.mark.parametrize(
+        "target_protocol, target_http",
+        [
+            ("sse", 11),
+            ("sse", 20),
+            ("sse", 30),
+            ("psse", 11),
+            ("psse", 20),
+        ],
+    )
+    async def test_server_side_event_abort(
+        self, target_protocol: str, target_http: int
+    ) -> None:
+        target_url = self.https_url if target_protocol == "sse" else self.http_url
+        target_url = (
+            target_url.replace("https://", "sse://")
+            if target_protocol == "sse"
+            else target_url.replace("http://", "psse://")
+        )
+
+        disabled_svn = set()
+
+        if target_http == 11:
+            disabled_svn.add(HttpVersion.h2)
+            disabled_svn.add(HttpVersion.h3)
+        elif target_http == 20:
+            disabled_svn.add(HttpVersion.h11)
+            disabled_svn.add(HttpVersion.h3)
+        elif target_http == 30:
+            disabled_svn.add(HttpVersion.h11)
+            disabled_svn.add(HttpVersion.h2)
+
+        async with AsyncPoolManager(
+            resolver=self.test_async_resolver,
+            ca_certs=self.ca_authority,
+            disabled_svn=disabled_svn,
+        ) as pm:
+            resp = await pm.urlopen("GET", target_url + "/sse?delay=1s&count=5")
+
+            # The response ends with a "200 OK"!
+            assert resp.status == 200
+
+            # The HTTP extension should be automatically loaded!
+            assert resp.extension is not None
+
+            assert isinstance(resp.extension, AsyncServerSideEventExtensionFromHTTP)
+
+            events = []
+
+            while resp.extension.closed is False:
+                events.append(await resp.extension.next_payload())
+
+                if len(events) == 2:
+                    await resp.extension.close()
+
+            assert len(events) == 2
+
+            assert resp.extension.closed is True
+
+            for event in events:
+                assert event.json()  # type: ignore
+                assert "timestamp" in event.json()  # type: ignore
+
+            assert not resp.trailers
+
+    @pytest.mark.parametrize(
+        "target_protocol, target_http",
+        [
+            ("sse", 20),
+            ("sse", 30),
+            ("psse", 20),
+        ],
+    )
+    async def test_server_side_event_multiplexed(
+        self, target_protocol: str, target_http: int
+    ) -> None:
+        target_url = self.https_url if target_protocol == "sse" else self.http_url
+        target_url = (
+            target_url.replace("https://", "sse://")
+            if target_protocol == "sse"
+            else target_url.replace("http://", "psse://")
+        )
+
+        disabled_svn = set()
+
+        if target_http == 30 and _HAS_HTTP3_SUPPORT() is False:
+            pytest.skip("Test requires http3 support")
+
+        if target_http == 20:
+            disabled_svn.add(HttpVersion.h11)
+            disabled_svn.add(HttpVersion.h3)
+        elif target_http == 30:
+            disabled_svn.add(HttpVersion.h11)
+            disabled_svn.add(HttpVersion.h2)
+
+        async with AsyncPoolManager(
+            resolver=self.test_async_resolver,
+            ca_certs=self.ca_authority,
+            disabled_svn=disabled_svn,
+        ) as pm:
+            before = time.time()
+
+            await asyncio.gather(
+                *[
+                    pm.urlopen(
+                        "GET", target_url + "/sse?delay=1s&count=5", multiplexed=True
+                    ),
+                    pm.urlopen(
+                        "GET", target_url + "/sse?delay=1s&count=5", multiplexed=True
+                    ),
+                    pm.urlopen(
+                        "GET", target_url + "/sse?delay=1s&count=5", multiplexed=True
+                    ),
+                ]
+            )
+
+            responses = await asyncio.gather(
+                *[pm.get_response(), pm.get_response(), pm.get_response()]
+            )
+
+            assert pm.pools.rsize() == 1
+
+            for resp in responses:
+                assert resp is not None
+                # The response ends with a "200 OK"!
+                assert resp.status == 200
+
+                # The HTTP extension should be automatically loaded!
+                assert resp.extension is not None
+
+                assert resp.version == target_http
+
+                assert isinstance(resp.extension, AsyncServerSideEventExtensionFromHTTP)
+
+            events = []
+
+            while any(e.extension.closed is False for e in responses):  # type: ignore
+                for resp in responses:
+                    assert resp is not None
+                    if resp.extension.closed:  # type: ignore
+                        continue
+                    ev = await resp.extension.next_payload()  # type: ignore
+                    if ev is not None:
+                        events.append(ev)
+
+            assert len(events) == 5 * 3
+
+            for event in events:
+                assert event.json()  # type: ignore
+                assert "timestamp" in event.json()  # type: ignore
+
+            assert time.time() - before <= 10.0

--- a/test/with_traefik/asynchronous/test_webextensions.py
+++ b/test/with_traefik/asynchronous/test_webextensions.py
@@ -294,6 +294,9 @@ class TestWebExtensions(TraefikTestCase):
             else target_url.replace("http://", "psse://")
         )
 
+        if target_http == 30 and _HAS_HTTP3_SUPPORT() is False:
+            pytest.skip("Test requires http3 support")
+
         disabled_svn = set()
 
         if target_http == 11:
@@ -361,6 +364,9 @@ class TestWebExtensions(TraefikTestCase):
             if target_protocol == "sse"
             else target_url.replace("http://", "psse://")
         )
+
+        if target_http == 30 and _HAS_HTTP3_SUPPORT() is False:
+            pytest.skip("Test requires http3 support")
 
         disabled_svn = set()
 


### PR DESCRIPTION
2.12.900 (2024-11-28)
=====================

- Added built-in support for Server-Side-Event (or SSE) via a WebExtension.
  It is as simple as doing ``pm.urlopen("GET", "sse://sse.dev/test")``. ``sse`` is using https under the hood by default.
  To force SSE via plain HTTP, replace ``sse://`` by ``psse://``.
  The ``extension`` attribute of produced response will be set, and you will be able to consume event promptly.
  See the documentation to learn more.
- Fixed unintentional regression using ``CONNECT`` verb manually outside of its standard usage.
- Fixed using a WebExtension with ``urlopen(..., multiplexed=True)`` from a PoolManager instance.
