### PR TITLE
Release 2.12.904

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
         run: |
           python -m coverage combine
           python -m coverage html --skip-covered --skip-empty
-          python -m coverage report --ignore-errors --show-missing --fail-under=80
+          python -m coverage report --ignore-errors --show-missing --fail-under=86
 
       - name: "Upload report"
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@
 /build
 /docs/_build
 coverage.xml
-traefik/httpbin.local.key
 traefik/httpbin.local.pem
+traefik/httpbin.local.pem.key
 rootCA.pem

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,22 @@
+2.12.904 (2024-12-22)
+=====================
+
+- Fixed an issue when trying to force load Websocket over HTTP/2 or HTTP/3.
+- Ensured WebSocket via HTTP/2 with improved CI pipeline featuring haproxy as the reverse proxy.
+- Fixed ``RuntimeError`` when forcing HTTP/3 by disabling both HTTP/1, and HTTP/2 and the remote is unable to negotiate HTTP/3.
+  This issue occurred because of our automatic downgrade procedure introduced in our 2.10.x series. The downgrade ends in panic
+  due to unavailable lower protocols. This only improve the UX by not downgrading and letting the original error out.
+  See https://github.com/jawah/niquests/issues/189 for original user report.
+- Fixed negotiated extensions for WebSocket being ignored (e.g. per-deflate message).
+- Backported ``HTTPResponse.shutdown()`` and nullified it. The fix they attempt to ship only concern
+  them, we are already safe (based on issue reproduction). See https://github.com/urllib3/urllib3/issues/2868
+- Backported ``proxy_is_tunneling`` property to ``HTTPConnection`` and ``HTTPSConnection``.
+  See https://github.com/urllib3/urllib3/pull/3459
+- Backported ``HTTPSConnection.is_verified`` to False when using a forwarding proxy.
+  See https://github.com/urllib3/urllib3/pull/3283
+- Backported pickling support to ``NewConnectionError`` and ``NameResolutionError``.
+  See https://github.com/urllib3/urllib3/pull/3480
+
 2.12.903 (2024-12-09)
 =====================
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,8 +7,8 @@ pytest-timeout>=2.3.1,<3
 trustme>=0.9.0,<2
 # We have to install at most cryptography 39.0.2 for PyPy<7.3.10
 # versions of Python 3.7, 3.8, and 3.9.
-cryptography==39.0.2; implementation_name=="pypy" and implementation_version<"7.3.10"
-cryptography==42.0.5; implementation_name!="pypy" or implementation_version>="7.3.10"
+cryptography==39.0.2; implementation_name=="pypy" and implementation_version<="7.3.11"
+cryptography==42.0.5; implementation_name!="pypy" or implementation_version>"7.3.11"
 backports.zoneinfo==0.2.1; python_version<"3.9"
 tzdata==2024.2; python_version<"3.8"
 towncrier==21.9.0

--- a/docker-compose.win.yaml
+++ b/docker-compose.win.yaml
@@ -2,6 +2,9 @@ services:
   proxy:
     image: traefik:v3.2-windowsservercore-ltsc2022
     restart: unless-stopped
+    depends_on:
+      httpbin:
+        condition: service_started
     healthcheck:
       test: [ "CMD", "traefik" ,"healthcheck", "--ping" ]
       interval: 10s
@@ -72,9 +75,6 @@ services:
       context: ./go-httpbin
       dockerfile: patched.Dockerfile
     restart: unless-stopped
-    depends_on:
-      proxy:
-        condition: service_healthy
     labels:
       - traefik.enable=true
       - traefik.http.routers.httpbin-http.rule=Host(`httpbin.local`) || Host(`alt.httpbin.local`)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,9 @@ services:
   proxy:
     image: traefik:v3.2
     restart: unless-stopped
+    depends_on:
+      httpbin:
+        condition: service_started
     healthcheck:
       test: [ "CMD", "traefik" ,"healthcheck", "--ping" ]
       interval: 10s
@@ -67,9 +70,6 @@ services:
   httpbin:
     image: mccutchen/go-httpbin:v2.15.0
     restart: unless-stopped
-    depends_on:
-      proxy:
-        condition: service_healthy
     labels:
       - traefik.enable=true
       - traefik.http.routers.httpbin-http.rule=Host(`httpbin.local`) || Host(`alt.httpbin.local`)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,6 +67,24 @@ services:
       # Sadly unsupported for HTTP/3!
       - --entrypoints.alt-https.transport.keepAliveMaxTime=5s
 
+  # haproxy is one of the very few
+  # capable of handling RFC8441 natively.
+  # todo: wait for Traefik to implement RFC8441, Caddy is almost ready (v2.9).
+  #       golang stdlib is ready for it.
+  haproxy:
+    image: haproxy:3.1-alpine
+    restart: unless-stopped
+    depends_on:
+      httpbin:
+        condition: service_started
+    ports:
+      - target: 443
+        published: 9443
+        protocol: tcp
+        mode: host
+    volumes:
+      - ./traefik:/usr/local/etc/haproxy
+
   httpbin:
     image: mccutchen/go-httpbin:v2.15.0
     restart: unless-stopped

--- a/noxfile.py
+++ b/noxfile.py
@@ -95,10 +95,10 @@ def traefik_boot(
 
         shutil.move("./traefik/server.pem", "./traefik/httpbin.local.pem")
 
-        if os.path.exists("./traefik/httpbin.local.key"):
-            os.unlink("./traefik/httpbin.local.key")
+        if os.path.exists("./traefik/httpbin.local.pem.key"):
+            os.unlink("./traefik/httpbin.local.pem.key")
 
-        shutil.move("./traefik/server.key", "./traefik/httpbin.local.key")
+        shutil.move("./traefik/server.key", "./traefik/httpbin.local.pem.key")
 
         if os.path.exists("./rootCA.pem"):
             os.unlink("./rootCA.pem")

--- a/noxfile.py
+++ b/noxfile.py
@@ -324,7 +324,6 @@ def downstream_botocore(session: nox.Session) -> None:
     session.run("python", "scripts/ci/install")
 
     session.cd(root)
-    session.install("setuptools<71")
 
     session.install(".", silent=False)
     session.cd(f"{tmp_dir}/botocore")

--- a/noxfile.py
+++ b/noxfile.py
@@ -55,26 +55,10 @@ def traefik_boot(
     if not os.path.exists("./traefik/httpbin.local.pem"):
         session.log("Prepare fake certificates for our Traefik server...")
 
-        addon_proc = subprocess.Popen(
-            [
-                "python",
-                "-m",
-                "pip",
-                "install",
-                "cffi==1.17.0rc1; python_version > '3.12'",
-                "trustme",
-            ]
-        )
+        session.install("trustme")
 
-        addon_proc.wait()
-
-        if addon_proc.returncode != 0:
-            yield
-            session.warn("Unable to install trustme outside of the nox Session")
-            return
-
-        trustme_proc = subprocess.Popen(
-            [
+        session.run(
+            *[
                 "python",
                 "-m",
                 "trustme",
@@ -85,13 +69,6 @@ def traefik_boot(
                 "./traefik",
             ]
         )
-
-        trustme_proc.wait()
-
-        if trustme_proc.returncode != 0:
-            session.warn("Unable to issue required certificates for our Traefik stack")
-            yield
-            return
 
         shutil.move("./traefik/server.pem", "./traefik/httpbin.local.pem")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -155,6 +155,7 @@ def traefik_boot(
                 RemoteDisconnected,
                 TimeoutError,
                 SocketTimeout,
+                ConnectionError,
             ) as e:
                 i += 1
                 time.sleep(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ include = [
   "/docker-compose.win.yaml",
   "/traefik/certificate.toml",
   "/traefik/patched.Dockerfile",
+  "/traefik/haproxy.cfg",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -2350,7 +2350,7 @@ class AsyncHTTPSConnectionPool(AsyncHTTPConnectionPool):
         if conn.is_closed:
             await conn.connect()
 
-        if not conn.is_verified:
+        if not conn.is_verified and not conn.proxy_is_verified:
             warnings.warn(
                 (
                     f"Unverified HTTPS request is being made to host '{conn.host}'. "

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.12.903"
+__version__ = "2.12.904"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -595,10 +595,16 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                 # this avoid the close() to attempt re-use the (dead) sock
                 self._protocol = None
 
-                raise MustDowngradeError(
-                    f"The server yielded its support for {self._svn} through the Alt-Svc header while unable to do so. "
-                    f"To remediate that issue, either disable {self._svn} or reach out to the server admin."
-                ) from e
+                # we don't want to force downgrade if the user specifically said
+                # to kill support for all other supported protocols!
+                if (
+                    HttpVersion.h11 not in self.disabled_svn
+                    or HttpVersion.h2 not in self.disabled_svn
+                ):
+                    raise MustDowngradeError(
+                        f"The server yielded its support for {self._svn} through the Alt-Svc header while unable to do so. "
+                        f"To remediate that issue, either disable {self._svn} or reach out to the server admin."
+                    ) from e
             raise
 
         self._connected_at = time.monotonic()
@@ -965,9 +971,10 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                     if (self._svn == HttpVersion.h2 and event.error_code == 0xD) or (
                         self._svn == HttpVersion.h3 and event.error_code == 0x0110
                     ):
-                        raise MustDowngradeError(
-                            f"The remote server is unable to serve this resource over {self._svn}"
-                        )
+                        if HttpVersion.h11 not in self.disabled_svn:
+                            raise MustDowngradeError(
+                                f"The remote server is unable to serve this resource over {self._svn}"
+                            )
 
                     raise ProtocolError(
                         f"Stream {event.stream_id} was reset by remote peer. Reason: {hex(event.error_code)}."

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -138,6 +138,7 @@ class HfaceBackend(BaseBackend):
         self.__remaining_body_length: int | None = None
         self.__authority_bit_set: bool = False
         self.__legacy_host_entry: bytes | None = None
+        self.__protocol_bit_set: bool = False
 
         # h3 specifics
         self.__custom_tls_settings: QuicTLSConfig | None = None
@@ -1101,6 +1102,7 @@ class HfaceBackend(BaseBackend):
         self.__remaining_body_length = None
         self.__legacy_host_entry = None
         self.__authority_bit_set = False
+        self.__protocol_bit_set = False
 
         self._start_last_request = datetime.now(tz=timezone.utc)
 
@@ -1181,6 +1183,8 @@ class HfaceBackend(BaseBackend):
             )
 
             if encoded_header.startswith(b":"):
+                if encoded_header == b":protocol":
+                    self.__protocol_bit_set = True
                 item_to_remove = None
 
                 for _k, _v in self.__headers:
@@ -1227,7 +1231,9 @@ class HfaceBackend(BaseBackend):
         # only h2 and h3 support streams, it is faked/simulated for h1.
         self._stream_id = self._protocol.get_available_stream_id()
         # unless anything hint the opposite, the request head frame is the end stream
-        should_end_stream: bool = expect_body_afterward is False
+        should_end_stream: bool = (
+            expect_body_afterward is False and self.__protocol_bit_set is False
+        )
 
         # handle cases where 'Host' header is set manually
         if self.__legacy_host_entry is not None:
@@ -1280,7 +1286,7 @@ class HfaceBackend(BaseBackend):
         else:
             self._last_used_at = time.monotonic()
 
-        if should_end_stream:
+        if expect_body_afterward is False:
             if self._start_last_request and self.conn_info:
                 self.conn_info.request_sent_latency = (
                     datetime.now(tz=timezone.utc) - self._start_last_request

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -300,6 +300,20 @@ class HTTPConnection(HfaceBackend):
     def has_connected_to_proxy(self) -> bool:
         return self._has_connected_to_proxy
 
+    @property
+    def proxy_is_forwarding(self) -> bool:
+        """
+        Return True if a forwarding proxy is configured, else return False
+        """
+        return bool(self.proxy) and self._tunnel_host is None
+
+    @property
+    def proxy_is_tunneling(self) -> bool:
+        """
+        Return True if a tunneling proxy is configured, else return False
+        """
+        return self._tunnel_host is not None
+
     def close(self) -> None:
         try:
             super().close()
@@ -766,7 +780,7 @@ class HTTPSConnection(HTTPConnection):
                     alpn_protocols.append("h2")
 
             # Do we need to establish a tunnel?
-            if self._tunnel_host is not None:
+            if self.proxy_is_tunneling:
                 # We're tunneling to an HTTPS origin so need to do TLS-in-TLS.
                 if self._tunnel_scheme == "https":
                     self.sock = sock = self._connect_tls_proxy(
@@ -781,7 +795,7 @@ class HTTPSConnection(HTTPConnection):
 
                 self._tunnel()
                 # Override the host with the one we're requesting data from.
-                server_hostname = self._tunnel_host
+                server_hostname = self._tunnel_host  # type: ignore[assignment]
 
             if self.server_hostname is not None:
                 server_hostname = self.server_hostname
@@ -808,7 +822,14 @@ class HTTPSConnection(HTTPConnection):
                 key_data=self.key_data,
             )
             self.sock = sock_and_verified.socket  # type: ignore[assignment]
-            self.is_verified = sock_and_verified.is_verified
+
+            # Forwarding proxies can never have a verified target since
+            # the proxy is the one doing the verification. Should instead
+            # use a CONNECT tunnel in order to verify the target.
+            # See: https://github.com/urllib3/urllib3/issues/3267.
+            self.is_verified = (
+                sock_and_verified.is_verified and not self.proxy_is_forwarding
+            )
 
         self._post_conn()
 

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -2284,7 +2284,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         if conn.is_closed:
             conn.connect()
 
-        if not conn.is_verified:
+        if not conn.is_verified and not conn.proxy_is_verified:
             warnings.warn(
                 (
                     f"Unverified HTTPS request is being made to host '{conn.host}'. "

--- a/src/urllib3/contrib/webextensions/__init__.py
+++ b/src/urllib3/contrib/webextensions/__init__.py
@@ -10,6 +10,20 @@ except ImportError:
     WebSocketExtensionFromHTTP = None  # type: ignore[misc, assignment]
     WebSocketExtensionFromMultiplexedHTTP = None  # type: ignore[misc, assignment]
 
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def recursive_subclasses(cls: type[T]) -> list[type[T]]:
+    all_subclasses = []
+
+    for subclass in cls.__subclasses__():
+        all_subclasses.append(subclass)
+        all_subclasses.extend(recursive_subclasses(subclass))
+
+    return all_subclasses
+
 
 def load_extension(
     scheme: str | None, implementation: str | None = None
@@ -17,7 +31,12 @@ def load_extension(
     if scheme is None:
         return RawExtensionFromHTTP
 
-    for extension in ExtensionFromHTTP.__subclasses__():
+    scheme = scheme.lower()
+
+    if implementation:
+        implementation = implementation.lower()
+
+    for extension in recursive_subclasses(ExtensionFromHTTP):
         if scheme in extension.supported_schemes():
             if (
                 implementation is not None

--- a/src/urllib3/contrib/webextensions/_async/__init__.py
+++ b/src/urllib3/contrib/webextensions/_async/__init__.py
@@ -13,6 +13,8 @@ except ImportError:
     AsyncWebSocketExtensionFromHTTP = None  # type: ignore[misc, assignment]
     AsyncWebSocketExtensionFromMultiplexedHTTP = None  # type: ignore[misc, assignment]
 
+from .. import recursive_subclasses
+
 
 def load_extension(
     scheme: str | None, implementation: str | None = None
@@ -20,7 +22,12 @@ def load_extension(
     if scheme is None:
         return AsyncRawExtensionFromHTTP
 
-    for extension in AsyncExtensionFromHTTP.__subclasses__():
+    scheme = scheme.lower()
+
+    if implementation:
+        implementation = implementation.lower()
+
+    for extension in recursive_subclasses(AsyncExtensionFromHTTP):
         if scheme in extension.supported_schemes():
             if (
                 implementation is not None

--- a/src/urllib3/contrib/webextensions/_async/ws.py
+++ b/src/urllib3/contrib/webextensions/_async/ws.py
@@ -52,7 +52,16 @@ class AsyncWebSocketExtensionFromHTTP(AsyncExtensionFromHTTP):
                 "The WebSocket HTTP extension requires 'Sec-Websocket-Accept' header in the server response but was not present."
             )
 
-        fake_http_response += accept_token.encode() + b"\r\n\r\n"
+        fake_http_response += accept_token.encode() + b"\r\n"
+
+        if "sec-websocket-extensions" in response.headers:
+            fake_http_response += (
+                b"Sec-Websocket-Extensions: "
+                + response.headers.get("sec-websocket-extensions").encode()  # type: ignore[union-attr]
+                + b"\r\n"
+            )
+
+        fake_http_response += b"\r\n"
 
         try:
             self._protocol.receive_data(fake_http_response)

--- a/src/urllib3/contrib/webextensions/ws.py
+++ b/src/urllib3/contrib/webextensions/ws.py
@@ -52,7 +52,16 @@ class WebSocketExtensionFromHTTP(ExtensionFromHTTP):
                 "The WebSocket HTTP extension requires 'Sec-Websocket-Accept' header in the server response but was not present."
             )
 
-        fake_http_response += accept_token.encode() + b"\r\n\r\n"
+        fake_http_response += accept_token.encode() + b"\r\n"
+
+        if "sec-websocket-extensions" in response.headers:
+            fake_http_response += (
+                b"Sec-Websocket-Extensions: "
+                + response.headers.get("sec-websocket-extensions").encode()  # type: ignore[union-attr]
+                + b"\r\n"
+            )
+
+        fake_http_response += b"\r\n"
 
         try:
             self._protocol.receive_data(fake_http_response)
@@ -233,7 +242,7 @@ class WebSocketExtensionFromMultiplexedHTTP(WebSocketExtensionFromHTTP):
 
     @staticmethod
     def implementation() -> str:
-        return "rfc8441"
+        return "rfc8441"  # also known as rfc9220 (http3)
 
     @staticmethod
     def supported_svn() -> set[HttpVersion]:

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -167,6 +167,10 @@ class NewConnectionError(ConnectTimeoutError, HTTPError):
         self.conn = conn
         super().__init__(f"{conn}: {message}")
 
+    def __reduce__(self) -> _TYPE_REDUCE_RESULT:
+        # For pickling purposes.
+        return self.__class__, (None, None)
+
 
 class NameResolutionError(NewConnectionError):
     """Raised when host name resolution fails."""
@@ -182,6 +186,10 @@ class NameResolutionError(NewConnectionError):
     ):
         message = f"Failed to resolve '{host}' ({reason})"
         super().__init__(conn, message)
+
+    def __reduce__(self) -> _TYPE_REDUCE_RESULT:
+        # For pickling purposes.
+        return self.__class__, (None, None, None)
 
 
 class EmptyPoolError(PoolError):

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -1057,6 +1057,14 @@ class HTTPResponse(io.IOBase):
         if buffer:
             yield b"".join(buffer)
 
+    def shutdown(self) -> None:
+        """urllib3 implemented this method in version 2.3 to palliate for a
+        thread safety issue[...] using another thread safety issue[...]
+        fortunately, we don't need that hack with urllib3-future thanks to
+        our extensive safety with TrafficPolice. You may safely remove that
+        call."""
+        pass
+
 
 # Kept for BC-purposes.
 BaseHTTPResponse = HTTPResponse

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import pickle
+import socket
 from email.errors import MessageDefect
 from test import DUMMY_POOL
 
 import pytest
 
+from urllib3.connection import HTTPConnection
 from urllib3.connectionpool import HTTPConnectionPool
 from urllib3.exceptions import (
     ClosedPoolError,
@@ -16,6 +18,8 @@ from urllib3.exceptions import (
     HTTPError,
     LocationParseError,
     MaxRetryError,
+    NameResolutionError,
+    NewConnectionError,
     ReadTimeoutError,
 )
 
@@ -36,6 +40,8 @@ class TestPickle:
             EmptyPoolError(HTTPConnectionPool("localhost"), ""),
             HostChangedError(HTTPConnectionPool("localhost"), "/", 0),
             ReadTimeoutError(HTTPConnectionPool("localhost"), "/", ""),
+            NewConnectionError(HTTPConnection("localhost"), ""),
+            NameResolutionError("", HTTPConnection("localhost"), socket.gaierror()),
         ],
     )
     def test_exceptions(self, exception: Exception) -> None:

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -38,6 +38,16 @@ from urllib3.util.timeout import Timeout
 from .. import TARPIT_HOST, requires_network
 
 
+def assert_is_verified(pm: ProxyManager, *, proxy: bool, target: bool) -> None:
+    pool = list(pm.pools._container.values())[-1]  # retrieve last pool entry
+    connection = (
+        list(pool.pool._container.values())[-1] if pool.pool is not None else None
+    )  # retrieve last connection entry
+    assert connection is not None
+    assert connection.proxy_is_verified is proxy
+    assert connection.is_verified is target
+
+
 class TestHTTPProxyManager(HTTPDummyProxyTestCase):
     @classmethod
     def setup_class(cls) -> None:
@@ -76,6 +86,31 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
             r = https.request("GET", f"{self.http_url}/")
             assert r.status == 200
+
+    def test_is_verified_http_proxy_to_http_target(self) -> None:
+        with proxy_from_url(self.proxy_url, ca_certs=DEFAULT_CA) as http:
+            r = http.request("GET", f"{self.http_url}/")
+            assert r.status == 200
+            assert_is_verified(http, proxy=False, target=False)
+
+    def test_is_verified_http_proxy_to_https_target(self) -> None:
+        with proxy_from_url(self.proxy_url, ca_certs=DEFAULT_CA) as http:
+            r = http.request("GET", f"{self.https_url}/")
+            assert r.status == 200
+            assert_is_verified(http, proxy=False, target=True)
+
+    @pytest.mark.xfail(reason="see https://github.com/urllib3/urllib3/issues/3267")
+    def test_is_verified_https_proxy_to_http_target(self) -> None:
+        with proxy_from_url(self.https_proxy_url, ca_certs=DEFAULT_CA) as https:
+            r = https.request("GET", f"{self.http_url}/")
+            assert r.status == 200
+            assert_is_verified(https, proxy=True, target=False)
+
+    def test_is_verified_https_proxy_to_https_target(self) -> None:
+        with proxy_from_url(self.https_proxy_url, ca_certs=DEFAULT_CA) as https:
+            r = https.request("GET", f"{self.https_url}/")
+            assert r.status == 200
+            assert_is_verified(https, proxy=True, target=True)
 
     def test_https_proxy_with_proxy_ssl_context(self) -> None:
         proxy_ssl_context = create_urllib3_context()

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -99,7 +99,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             assert r.status == 200
             assert_is_verified(http, proxy=False, target=True)
 
-    @pytest.mark.xfail(reason="see https://github.com/urllib3/urllib3/issues/3267")
     def test_is_verified_https_proxy_to_http_target(self) -> None:
         with proxy_from_url(self.https_proxy_url, ca_certs=DEFAULT_CA) as https:
             r = https.request("GET", f"{self.http_url}/")

--- a/test/with_traefik/__init__.py
+++ b/test/with_traefik/__init__.py
@@ -28,18 +28,22 @@ class TraefikTestCase:
     http_alt_port: int = 9999
     https_alt_port: int = 8754
 
+    https_haproxy_port: int = 9443
+
     http_url: str = f"http://{host}:{http_port}"
     https_url: str = f"https://{host}:{https_port}"
 
     http_alt_url: str = f"http://{host}:{http_alt_port}"
     https_alt_url: str = f"https://{host}:{https_alt_port}"
 
-    test_resolver: ResolverDescription = ResolverDescription.from_url(
-        f"in-memory://default?hosts={host}:{TRAEFIK_HTTPBIN_IPV4}&hosts={alt_host}:{TRAEFIK_HTTPBIN_IPV4}"
-    )
+    https_haproxy_url: str = f"https://{host}:{https_haproxy_port}"
+
+    test_resolver_raw: str = f"in-memory://default?hosts={host}:{TRAEFIK_HTTPBIN_IPV4}&hosts={alt_host}:{TRAEFIK_HTTPBIN_IPV4}"
+
+    test_resolver: ResolverDescription = ResolverDescription.from_url(test_resolver_raw)
 
     test_async_resolver: AsyncResolverDescription = AsyncResolverDescription.from_url(
-        f"in-memory://default?hosts={host}:{TRAEFIK_HTTPBIN_IPV4}&hosts={alt_host}:{TRAEFIK_HTTPBIN_IPV4}"
+        test_resolver_raw
     )
 
     ca_authority: str | None = None

--- a/test/with_traefik/asynchronous/test_connectionpool_multiplexed.py
+++ b/test/with_traefik/asynchronous/test_connectionpool_multiplexed.py
@@ -19,7 +19,7 @@ class TestConnectionPoolMultiplexed(TraefikTestCase):
             self.host,
             self.https_port,
             ca_certs=self.ca_authority,
-            resolver=self.test_async_resolver,
+            resolver=[self.test_async_resolver],
         ) as pool:
             promises = []
 

--- a/test/with_traefik/asynchronous/test_connectionpool_multiplexed.py
+++ b/test/with_traefik/asynchronous/test_connectionpool_multiplexed.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from asyncio import sleep
+from random import randint
 from test import notMacOS
 from time import time
 
@@ -234,6 +236,10 @@ class TestConnectionPoolMultiplexed(TraefikTestCase):
             promises = []
 
             for _ in range(32):
+                # we need this to avoid killing the "failure_rate" respect
+                # in manual multiplexed mode. it's too fast, and the rate isn't respected
+                # as it should.
+                await sleep(randint(100, 350) / 1000.0)
                 promises.append(
                     await pool.urlopen(
                         "GET",

--- a/test/with_traefik/asynchronous/test_poolmanager_multiplexed.py
+++ b/test/with_traefik/asynchronous/test_poolmanager_multiplexed.py
@@ -17,7 +17,7 @@ class TestPoolManagerMultiplexed(TraefikTestCase):
     async def test_multiplexing_fastest_to_slowest(self) -> None:
         async with AsyncPoolManager(
             ca_certs=self.ca_authority,
-            resolver=self.test_async_resolver,
+            resolver=self.test_resolver_raw,
         ) as pool:
             promises = []
 
@@ -214,7 +214,7 @@ class TestPoolManagerMultiplexed(TraefikTestCase):
     async def test_retries_in_multiplexed_mode(self) -> None:
         async with AsyncPoolManager(
             ca_certs=self.ca_authority,
-            resolver=self.test_async_resolver,
+            resolver=[self.test_resolver_raw],
         ) as pool:
             retry = Retry(
                 16, status_forcelist=[500], backoff_factor=0.05, raise_on_redirect=True

--- a/test/with_traefik/asynchronous/test_poolmanager_multiplexed.py
+++ b/test/with_traefik/asynchronous/test_poolmanager_multiplexed.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from asyncio import sleep
+from random import randint
 from test import notMacOS
 from time import time
 
@@ -233,6 +235,10 @@ class TestPoolManagerMultiplexed(TraefikTestCase):
             promises = []
 
             for _ in range(32):
+                # we need this to avoid killing the "failure_rate" respect
+                # in manual multiplexed mode. it's too fast, and the rate isn't respected
+                # as it should.
+                await sleep(randint(100, 350) / 1000.0)
                 promises.append(
                     await pool.urlopen(
                         "GET",

--- a/test/with_traefik/asynchronous/test_stream.py
+++ b/test/with_traefik/asynchronous/test_stream.py
@@ -32,7 +32,7 @@ class TestStreamResponse(TraefikTestCase):
             self.host,
             self.https_port,
             ca_certs=self.ca_authority,
-            resolver=self.test_async_resolver,
+            resolver=self.test_async_resolver.new(),
         ) as p:
             for i in range(3):
                 resp = await p.request("GET", "/get", preload_content=False)
@@ -76,7 +76,7 @@ class TestStreamResponse(TraefikTestCase):
             self.host,
             self.https_port,
             ca_certs=self.ca_authority,
-            resolver=self.test_async_resolver,
+            resolver=[self.test_async_resolver],
         ) as p:
             resp = await p.request("GET", "/get", preload_content=False)
             assert resp.status == 200

--- a/test/with_traefik/asynchronous/test_svn.py
+++ b/test/with_traefik/asynchronous/test_svn.py
@@ -156,6 +156,25 @@ class TestSvnCapability(TraefikTestCase):
                 )
 
     @pytest.mark.usefixtures("requires_http3")
+    async def test_dont_downgrade_avoid_runtime_error(self) -> None:
+        async with AsyncHTTPSConnectionPool(
+            self.host,
+            self.https_alt_port,
+            timeout=1,
+            retries=False,
+            ca_certs=self.ca_authority,
+            resolver=self.test_resolver,
+            disabled_svn={HttpVersion.h11, HttpVersion.h2},
+        ) as p:
+            try:
+                await p.request(
+                    "GET",
+                    "/get",
+                )
+            except Exception as e:
+                assert not isinstance(e, RuntimeError)
+
+    @pytest.mark.usefixtures("requires_http3")
     async def test_misleading_upgrade_h3(self) -> None:
         dumb_cache: dict[tuple[str, int], tuple[str, int] | None] = dict()
 

--- a/test/with_traefik/asynchronous/test_svn.py
+++ b/test/with_traefik/asynchronous/test_svn.py
@@ -163,7 +163,7 @@ class TestSvnCapability(TraefikTestCase):
             timeout=1,
             retries=False,
             ca_certs=self.ca_authority,
-            resolver=self.test_resolver,
+            resolver=self.test_async_resolver,
             disabled_svn={HttpVersion.h11, HttpVersion.h2},
         ) as p:
             try:

--- a/test/with_traefik/test_connectionpool_multiplexed.py
+++ b/test/with_traefik/test_connectionpool_multiplexed.py
@@ -18,7 +18,7 @@ class TestConnectionPoolMultiplexed(TraefikTestCase):
             self.host,
             self.https_port,
             ca_certs=self.ca_authority,
-            resolver=self.test_resolver,
+            resolver=[self.test_resolver],
         ) as pool:
             promises = []
 
@@ -180,7 +180,7 @@ class TestConnectionPoolMultiplexed(TraefikTestCase):
             self.host,
             self.https_port,
             ca_certs=self.ca_authority,
-            resolver=self.test_resolver,
+            resolver=self.test_resolver_raw,
         ) as pool:
             retry = Retry(redirect=max_retries) if max_retries is not None else None
             promise = pool.urlopen(
@@ -213,7 +213,7 @@ class TestConnectionPoolMultiplexed(TraefikTestCase):
             self.host,
             self.https_port,
             ca_certs=self.ca_authority,
-            resolver=self.test_resolver,
+            resolver=[self.test_resolver_raw],
         ) as pool:
             retry = Retry(
                 16, status_forcelist=[500], backoff_factor=0.05, raise_on_redirect=True

--- a/test/with_traefik/test_connectionpool_multiplexed.py
+++ b/test/with_traefik/test_connectionpool_multiplexed.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from random import randint
 from test import notMacOS
-from time import time
+from time import sleep, time
 
 import pytest
 
@@ -232,6 +233,10 @@ class TestConnectionPoolMultiplexed(TraefikTestCase):
             promises = []
 
             for _ in range(32):
+                # we need this to avoid killing the "failure_rate" respect
+                # in manual multiplexed mode. it's too fast, and the rate isn't respected
+                # as it should.
+                sleep(randint(100, 350) / 1000.0)
                 promises.append(
                     pool.urlopen(
                         "GET",

--- a/test/with_traefik/test_poolmanager_multiplexed.py
+++ b/test/with_traefik/test_poolmanager_multiplexed.py
@@ -16,7 +16,7 @@ class TestPoolManagerMultiplexed(TraefikTestCase):
     def test_multiplexing_fastest_to_slowest(self) -> None:
         with PoolManager(
             ca_certs=self.ca_authority,
-            resolver=self.test_resolver,
+            resolver=self.test_resolver.new(),
         ) as pool:
             promises = []
 
@@ -100,7 +100,7 @@ class TestPoolManagerMultiplexed(TraefikTestCase):
     def test_multiplexing_stream_saturation(self) -> None:
         with PoolManager(
             ca_certs=self.ca_authority,
-            resolver=self.test_resolver,
+            resolver=[self.test_resolver],
         ) as pool:
             promises = []
 

--- a/test/with_traefik/test_poolmanager_multiplexed.py
+++ b/test/with_traefik/test_poolmanager_multiplexed.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from random import randint
 from test import notMacOS
-from time import time
+from time import sleep, time
 
 import pytest
 
@@ -232,6 +233,10 @@ class TestPoolManagerMultiplexed(TraefikTestCase):
             promises = []
 
             for _ in range(32):
+                # we need this to avoid killing the "failure_rate" respect
+                # in manual multiplexed mode. it's too fast, and the rate isn't respected
+                # as it should.
+                sleep(randint(100, 350) / 1000.0)
                 promises.append(
                     pool.urlopen(
                         "GET",

--- a/test/with_traefik/test_stream.py
+++ b/test/with_traefik/test_stream.py
@@ -31,7 +31,7 @@ class TestStreamResponse(TraefikTestCase):
             self.host,
             self.https_port,
             ca_certs=self.ca_authority,
-            resolver=self.test_resolver,
+            resolver=[self.test_resolver_raw],
         ) as p:
             for i in range(3):
                 resp = p.request("GET", "/get", preload_content=False)

--- a/test/with_traefik/test_svn.py
+++ b/test/with_traefik/test_svn.py
@@ -149,6 +149,25 @@ class TestSvnCapability(TraefikTestCase):
                     == 'h3-25=":443"; ma=3600, h2=":443"; ma=3600'
                 )
 
+    @pytest.mark.usefixtures("requires_http3")
+    def test_dont_downgrade_avoid_runtime_error(self) -> None:
+        with HTTPSConnectionPool(
+            self.host,
+            self.https_alt_port,
+            timeout=1,
+            retries=False,
+            ca_certs=self.ca_authority,
+            resolver=self.test_resolver,
+            disabled_svn={HttpVersion.h11, HttpVersion.h2},
+        ) as p:
+            try:
+                p.request(
+                    "GET",
+                    "/get",
+                )
+            except Exception as e:
+                assert not isinstance(e, RuntimeError)
+
     def test_illegal_upgrade_h3(self) -> None:
         with HTTPSConnectionPool(
             self.host,

--- a/traefik/certificate.toml
+++ b/traefik/certificate.toml
@@ -1,3 +1,3 @@
 [[tls.certificates]]
   certFile = "/certs/httpbin.local.pem"
-  keyFile = "/certs/httpbin.local.key"
+  keyFile = "/certs/httpbin.local.pem.key"

--- a/traefik/haproxy.cfg
+++ b/traefik/haproxy.cfg
@@ -1,0 +1,19 @@
+global
+    log stdout format raw daemon debug
+
+defaults
+    timeout connect 5s
+    timeout client 1m
+    timeout server 1m
+
+frontend http
+    bind :443 ssl crt /usr/local/etc/haproxy/httpbin.local.pem
+    default_backend httpbin
+    log global
+    log-format "${HAPROXY_HTTP_LOG_FMT} hdrs:%{+Q}[var(txn.req_hdrs)]"
+    mode http
+
+backend httpbin
+    mode http
+    log global
+    server s1 httpbin:8080


### PR DESCRIPTION
2.12.904 (2024-12-22)
=====================

- Fixed an issue when trying to force load Websocket over HTTP/2 or HTTP/3.
- Ensured WebSocket via HTTP/2 with improved CI pipeline featuring haproxy as the reverse proxy.
- Fixed ``RuntimeError`` when forcing HTTP/3 by disabling both HTTP/1, and HTTP/2 and the remote is unable to negotiate HTTP/3.
  This issue occurred because of our automatic downgrade procedure introduced in our 2.10.x series. The downgrade ends in panic
  due to unavailable lower protocols. This only improve the UX by not downgrading and letting the original error out.
  See https://github.com/jawah/niquests/issues/189 for original user report.
- Fixed negotiated extensions for WebSocket being ignored (e.g. per-deflate message).
- Backported ``HTTPResponse.shutdown()`` and nullified it. The fix they attempt to ship only concern
  them, we are already safe (based on issue reproduction). See https://github.com/urllib3/urllib3/issues/2868
- Backported ``proxy_is_tunneling`` property to ``HTTPConnection`` and ``HTTPSConnection``.
  See https://github.com/urllib3/urllib3/pull/3459
- Backported ``HTTPSConnection.is_verified`` to False when using a forwarding proxy.
  See https://github.com/urllib3/urllib3/pull/3283
- Backported pickling support to ``NewConnectionError`` and ``NameResolutionError``.
  See https://github.com/urllib3/urllib3/pull/3480
