### PR TITLE
Release 2.12.909

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: "Traefik: Prerequisites - Colima (MacOS)"
         if: ${{ matrix.traefik-server && contains(matrix.os, 'mac') }}
-        uses: douglascamata/setup-docker-macos-action@4fe96839fcba8a2d746e020d00a89a37afbc7dc9
+        uses: douglascamata/setup-docker-macos-action@f2b307ddc57e8b9d3f9761f3cafa8883b2cdffd4
         with:
           colima-network-address: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
       - name: "Download artifact"
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
-          name: coverage-data*
+          pattern: coverage-data*
           merge-multiple: true
 
       - name: "Combine & check coverage"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,9 +167,9 @@ jobs:
           TRAEFIK_HTTPBIN_IPV4: ${{ contains(matrix.os, 'mac') && '192.168.65.2' || '127.0.0.1' }}
 
       - name: "Upload artifact"
-        uses: "actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce"
+        uses: "actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808"
         with:
-          name: coverage-data
+          name: coverage-data-${{ matrix.os }}-${{ matrix.nox-session }}-${{ matrix.python-version }}-${{ matrix.traefik-server }}
           path: ".coverage.*"
           if-no-files-found: error
 
@@ -190,9 +190,10 @@ jobs:
         run: "python -m pip install --upgrade coverage"
 
       - name: "Download artifact"
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
-          name: coverage-data
+          name: coverage-data*
+          merge-multiple: true
 
       - name: "Combine & check coverage"
         run: |
@@ -201,7 +202,7 @@ jobs:
           python -m coverage report --ignore-errors --show-missing --fail-under=86
 
       - name: "Upload report"
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
         with:
           name: coverage-report
           path: htmlcov

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: "3.x"
 
       - name: "Install dependencies"
-        run: python -m pip install build==0.8.0
+        run: python -m pip install build
 
       - name: "Build dists"
         run: |
@@ -38,7 +38,7 @@ jobs:
           cd dist && echo "::set-output name=hashes::$(sha256sum * | base64 -w0)"
 
       - name: "Upload dists"
-        uses: "actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce"
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
         with:
           name: "dist"
           path: "dist/"
@@ -51,7 +51,7 @@ jobs:
       actions: read
       contents: write
       id-token: write # Needed to access the workflow's OIDC identity.
-    uses: "slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0"
+    uses: "slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0"
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true
@@ -71,7 +71,7 @@ jobs:
 
     steps:
     - name: "Download dists"
-      uses: "actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a"
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:
         name: "dist"
         path: "dist/"
@@ -84,3 +84,5 @@ jobs:
 
     - name: "Publish dists to PyPI"
       uses: "pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70" # v1.12.3
+      with:
+        attestations: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@
   that mention 2.1 target in the 2.3 version). As such we immediately restore the methods. (#203)
 - Implemented our copy of ``HTTPResponse.read1`` heavily simplified as we do already support ``HTTPResponse.read(-1)``.
   Also mirrored in ``AsyncHTTPResponse.read1``.
-- Automatically grab ``qh3`` for X86 based processors.
+- Automatically grab ``qh3`` for X86 based processors (e.g. win32).
+- Fixed the aggressive exception in our native websocket implementation when a server responded positively to an upgrade
+  request without the required http header. Instead of ``RuntimeError``, now raises ``ProtocolError``.
 
 2.12.908 (2024-01-13)
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,9 +3,10 @@
 
 - Fixed compatibility with upstream urllib3 when third party program invoke deprecated ``HTTPResponse.getheader`` or
   ``HTTPResponse.getheaders``. Those methods were planned to be removed in 2.1 (they still have a pending deprecation
-  that mention 2.1 target in the 2.3 version). As such we immediately restore the methods.
+  that mention 2.1 target in the 2.3 version). As such we immediately restore the methods. (#203)
 - Implemented our copy of ``HTTPResponse.read1`` heavily simplified as we do already support ``HTTPResponse.read(-1)``.
   Also mirrored in ``AsyncHTTPResponse.read1``.
+- Automatically grab ``qh3`` for X86 based processors.
 
 2.12.908 (2024-01-13)
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@
   that mention 2.1 target in the 2.3 version). As such we immediately restore the methods. (#203)
 - Implemented our copy of ``HTTPResponse.read1`` heavily simplified as we do already support ``HTTPResponse.read(-1)``.
   Also mirrored in ``AsyncHTTPResponse.read1``.
-- Automatically grab ``qh3`` for X86 based processors (e.g. win32).
+- Automatically grab ``qh3`` for X86/i686 based processors (e.g. win32).
 - Fixed the aggressive exception in our native websocket implementation when a server responded positively to an upgrade
   request without the required http header. Instead of ``RuntimeError``, now raises ``ProtocolError``.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+2.12.909 (2024-01-20)
+=====================
+
+- Fixed compatibility with upstream urllib3 when third party program invoke deprecated ``HTTPResponse.getheader`` or
+  ``HTTPResponse.getheaders``. Those methods were planned to be removed in 2.1 (they still have a pending deprecation
+  that mention 2.1 target in the 2.3 version). As such we immediately restore the methods.
+- Implemented our copy of ``HTTPResponse.read1`` heavily simplified as we do already support ``HTTPResponse.read(-1)``.
+  Also mirrored in ``AsyncHTTPResponse.read1``.
+
 2.12.908 (2024-01-13)
 =====================
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -25,7 +25,7 @@ automatically available depending on the availability of the wheel on your platf
 
 This may require some external toolchain to be available (compilation).
 
-.. note:: HTTP/3 is automatically installed and ready-to-use if you fulfill theses requirements: Linux, Windows or MacOS using Python (or PyPy) 3.7 onward with one of the supported architecture (arm64/aarch64/s390x/x86_64/amd64/ppc64/ppc64le).
+.. note:: HTTP/3 is automatically installed and ready-to-use if you fulfill theses requirements: Linux, Windows or MacOS using Python (or PyPy) 3.7 onward with one of the supported architecture (aarch64/armv7l/s390x/x86_64/x86/i686/amd64/ppc64(le)).
 
 .. caution:: If the requirements aren't fulfilled for HTTP/3, your package manager won't pick qh3 for installation when installing urllib3-future and it will be silently disabled. We choose not to impose compilation and keep a safe pure Python fallback.
 

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -276,9 +276,11 @@ def _run_and_close_tornado(
     try:
         return asyncio.run(inner_fn())
     finally:
+        # AttributeError -> Python 3.14!
+        # todo: investigate...
         try:
             tornado_loop.close(all_fds=True)  # type: ignore[union-attr]
-        except (ValueError, OSError):
+        except (ValueError, OSError, AttributeError):
             pass  # can fail needlessly with "Invalid file descriptor". Ignore!
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 requires-python = ">=3.7"
 dynamic = ["version"]
 dependencies = [
-  "qh3>=1.2.0,<2.0.0; (platform_python_implementation != 'CPython' or python_full_version > '3.7.10') and (platform_system == 'Darwin' or platform_system == 'Windows' or platform_system == 'Linux') and (platform_machine == 'x86_64' or platform_machine == 's390x' or platform_machine == 'aarch64' or platform_machine == 'armv7l' or platform_machine == 'ppc64le' or platform_machine == 'ppc64' or platform_machine == 'AMD64' or platform_machine == 'arm64' or platform_machine == 'ARM64' or platform_machine == 'x86') and (platform_python_implementation == 'CPython' or (platform_python_implementation == 'PyPy' and python_version < '3.11'))",
+  "qh3>=1.2.0,<2.0.0; (platform_python_implementation != 'CPython' or python_full_version > '3.7.10') and (platform_system == 'Darwin' or platform_system == 'Windows' or platform_system == 'Linux') and (platform_machine == 'x86_64' or platform_machine == 's390x' or platform_machine == 'aarch64' or platform_machine == 'armv7l' or platform_machine == 'ppc64le' or platform_machine == 'ppc64' or platform_machine == 'AMD64' or platform_machine == 'arm64' or platform_machine == 'ARM64' or platform_machine == 'x86' or platform_machine == 'i686') and (platform_python_implementation == 'CPython' or (platform_python_implementation == 'PyPy' and python_version < '3.11'))",
   "h11>=0.11.0,<1.0.0",
   "jh2>=5.0.3,<6.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,9 +108,9 @@ log_level = "DEBUG"
 filterwarnings = [
     "error",
     '''ignore:.*iscoroutinefunction.*:DeprecationWarning''',
-    '''ignore:.*get_event_loop_policy.*:DeprecationWarning''',
-    '''ignore:.*set_event_loop_policy.*:DeprecationWarning''',
-    '''ignore:.*DefaultEventLoopPolicy.*:DeprecationWarning''',
+    '''ignore:.*get_event_loop.*:DeprecationWarning''',
+    '''ignore:.*set_event_loop.*:DeprecationWarning''',
+    '''ignore:.*EventLoopPolicy.*:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLS is deprecated:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLSv1 is deprecated:DeprecationWarning''',
     '''default:ssl\.TLSVersion\.TLSv1_1 is deprecated:DeprecationWarning''',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 requires-python = ">=3.7"
 dynamic = ["version"]
 dependencies = [
-  "qh3>=1.2.0,<2.0.0; (platform_python_implementation != 'CPython' or python_full_version > '3.7.10') and (platform_system == 'Darwin' or platform_system == 'Windows' or platform_system == 'Linux') and (platform_machine == 'x86_64' or platform_machine == 's390x' or platform_machine == 'aarch64' or platform_machine == 'armv7l' or platform_machine == 'ppc64le' or platform_machine == 'ppc64' or platform_machine == 'AMD64' or platform_machine == 'arm64' or platform_machine == 'ARM64') and (platform_python_implementation == 'CPython' or (platform_python_implementation == 'PyPy' and python_version < '3.11'))",
+  "qh3>=1.2.0,<2.0.0; (platform_python_implementation != 'CPython' or python_full_version > '3.7.10') and (platform_system == 'Darwin' or platform_system == 'Windows' or platform_system == 'Linux') and (platform_machine == 'x86_64' or platform_machine == 's390x' or platform_machine == 'aarch64' or platform_machine == 'armv7l' or platform_machine == 'ppc64le' or platform_machine == 'ppc64' or platform_machine == 'AMD64' or platform_machine == 'arm64' or platform_machine == 'ARM64' or platform_machine == 'x86') and (platform_python_implementation == 'CPython' or (platform_python_implementation == 'PyPy' and python_version < '3.11'))",
   "h11>=0.11.0,<1.0.0",
   "jh2>=5.0.3,<6.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ log_level = "DEBUG"
 filterwarnings = [
     "error",
     '''ignore:.*iscoroutinefunction.*:DeprecationWarning''',
+    '''ignore:.*get_event_loop_policy.*:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLS is deprecated:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLSv1 is deprecated:DeprecationWarning''',
     '''default:ssl\.TLSVersion\.TLSv1_1 is deprecated:DeprecationWarning''',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,8 @@ filterwarnings = [
     "error",
     '''ignore:.*iscoroutinefunction.*:DeprecationWarning''',
     '''ignore:.*get_event_loop_policy.*:DeprecationWarning''',
+    '''ignore:.*set_event_loop_policy.*:DeprecationWarning''',
+    '''ignore:.*DefaultEventLoopPolicy.*:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLS is deprecated:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLSv1 is deprecated:DeprecationWarning''',
     '''default:ssl\.TLSVersion\.TLSv1_1 is deprecated:DeprecationWarning''',

--- a/src/urllib3/_async/response.py
+++ b/src/urllib3/_async/response.py
@@ -364,6 +364,35 @@ class AsyncHTTPResponse(HTTPResponse):
 
         return data
 
+    async def read1(  # type: ignore[override]
+        self,
+        amt: int | None = None,
+        decode_content: bool | None = None,
+    ) -> bytes:
+        """
+        Similar to ``http.client.HTTPResponse.read1`` and documented
+        in :meth:`io.BufferedReader.read1`, but with an additional parameter:
+        ``decode_content``.
+
+        :param amt:
+            How much of the content to read.
+
+        :param decode_content:
+            If True, will attempt to decode the body based on the
+            'content-encoding' header.
+        """
+
+        data = await self.read(
+            amt=amt or -1,
+            decode_content=decode_content,
+        )
+
+        if amt is not None and len(data) > amt:
+            self._decoded_buffer.put(data)
+            return self._decoded_buffer.get(amt)
+
+        return data
+
     async def read(  # type: ignore[override]
         self,
         amt: int | None = None,

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.12.908"
+__version__ = "2.12.909"

--- a/src/urllib3/contrib/webextensions/_async/ws.py
+++ b/src/urllib3/contrib/webextensions/_async/ws.py
@@ -48,7 +48,7 @@ class AsyncWebSocketExtensionFromHTTP(AsyncExtensionFromHTTP):
         accept_token: str | None = response.headers.get("Sec-Websocket-Accept")
 
         if accept_token is None:
-            raise RuntimeError(
+            raise ProtocolError(
                 "The WebSocket HTTP extension requires 'Sec-Websocket-Accept' header in the server response but was not present."
             )
 
@@ -128,8 +128,6 @@ class AsyncWebSocketExtensionFromHTTP(AsyncExtensionFromHTTP):
         if self._response is not None:
             if self._police_officer is not None:
                 self._police_officer.forget(self._response)
-                if self._police_officer.busy:
-                    self._police_officer.release()
             else:
                 await self._response.close()
             self._response = None

--- a/src/urllib3/contrib/webextensions/ws.py
+++ b/src/urllib3/contrib/webextensions/ws.py
@@ -48,7 +48,7 @@ class WebSocketExtensionFromHTTP(ExtensionFromHTTP):
         accept_token: str | None = response.headers.get("Sec-Websocket-Accept")
 
         if accept_token is None:
-            raise RuntimeError(
+            raise ProtocolError(
                 "The WebSocket HTTP extension requires 'Sec-Websocket-Accept' header in the server response but was not present."
             )
 
@@ -128,8 +128,6 @@ class WebSocketExtensionFromHTTP(ExtensionFromHTTP):
         if self._response is not None:
             if self._police_officer is not None:
                 self._police_officer.forget(self._response)
-                if self._police_officer.busy:
-                    self._police_officer.release()
             else:
                 self._response.close()
             self._response = None


### PR DESCRIPTION
2.12.909 (2024-01-20)
=====================

- Fixed compatibility with upstream urllib3 when third party program invoke deprecated ``HTTPResponse.getheader`` or
  ``HTTPResponse.getheaders``. Those methods were planned to be removed in 2.1 (they still have a pending deprecation
  that mention 2.1 target in the 2.3 version). As such we immediately restore the methods. (#203)
- Implemented our copy of ``HTTPResponse.read1`` heavily simplified as we do already support ``HTTPResponse.read(-1)``.
  Also mirrored in ``AsyncHTTPResponse.read1``.
- Automatically grab ``qh3`` for X86 based processors (e.g. win32).
- Fixed the aggressive exception in our native websocket implementation when a server responded positively to an upgrade
  request without the required http header. Instead of ``RuntimeError``, now raises ``ProtocolError``.
