### PR TITLE
add `__repr__` method for AsyncHTTPConnectionPool & other related classes

### DIFF
--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -436,6 +436,9 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
             self._keepalive_idle_window = MINIMAL_KEEPALIVE_IDLE_WINDOW
         self._background_monitoring: asyncio.Task | None = None  # type: ignore[type-arg]
 
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} host={self.host!r} port={self.port} timeout={self.timeout}>"
+
     @property
     def is_idle(self) -> bool:
         return self.pool is None or self.pool.bag_only_idle

--- a/src/urllib3/_async/poolmanager.py
+++ b/src/urllib3/_async/poolmanager.py
@@ -174,6 +174,9 @@ class AsyncPoolManager(AsyncRequestMethods):
             else resolver
         )
 
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} num_pools={self._num_pools}>"
+
     async def __aenter__(self: _SelfT) -> _SelfT:
         return self
 

--- a/src/urllib3/util/_async/traffic_police.py
+++ b/src/urllib3/util/_async/traffic_police.py
@@ -79,6 +79,9 @@ class AsyncTrafficPolice(typing.Generic[T]):
             contextvars.ContextVar("cursor", default=None)
         )
 
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} max_size={self.maxsize} concurrency={self.concurrency}>"
+
     @property
     def _cursor(self) -> ActiveCursor[T] | None:
         try:


### PR DESCRIPTION


<!---
Hello!

If this is your first PR to urllib3.future please review the Contributing Guide:
https://urllib3future.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

Hello,

I have opened this draft PR as per our discussion in #194 
I am not well versed with this codebase but I did attempt to understand and navigate around the codebase to see what I need to cover for this PR and made the necessary changes upto my understanding. I probably missed something. 😄 

I have only currently made changes for async public classes.
However, in the linked issue, you said we will need to cover sync counter parts as well, but I'm unsure which ones exactly to cover. So, please guide me on that and I will do the required.

I have run `nox -rs format` and `nox -rs lint` commands on my proposed changes before submitting this PR as per the contrinuting guidelines. Please let me know if I missed anything.