### PR TITLE
Release 2.12.913

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,6 @@
 - Added useful repr for ``PoolManager``, ``ConnectionPool`` and ``TrafficPolice`` (async counterpart included).
 - Fixed ``KeyError`` upon parsing X509 certificate pulled from the QUIC layer when the certificate contain an unexpected
   rfc4514 attribute. (https://github.com/jawah/urllib3.future/issues/217)
-- Fixed a rare error when passing an url as ``bytes`` instead of ``str`` (support for legacy programs).
 
 2.12.912 (2024-02-07)
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,10 @@
-2.12.913 (2024-02-10)
+2.12.913 (2024-03-21)
 =====================
 
 - Added useful repr for ``PoolManager``, ``ConnectionPool`` and ``TrafficPolice`` (async counterpart included).
+- Fixed ``KeyError`` upon parsing X509 certificate pulled from the QUIC layer when the certificate contain an unexpected
+  rfc4514 attribute. (https://github.com/jawah/urllib3.future/issues/217)
+- Fixed a rare error when passing an url as ``bytes`` instead of ``str`` (support for legacy programs).
 
 2.12.912 (2024-02-07)
 =====================

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.12.912"
+__version__ = "2.12.913"

--- a/src/urllib3/contrib/hface/protocols/http3/_qh3.py
+++ b/src/urllib3/contrib/hface/protocols/http3/_qh3.py
@@ -371,9 +371,12 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
             "C": "countryName",
             "STREET": "streetAddress",
             "DC": "domainComponent",
+            "E": "email",
         }
 
         for raw_oid, rfc4514_attribute_name, value in x509_certificate.subject:
+            if rfc4514_attribute_name not in _short_name_assoc:
+                continue
             issuer_info["subject"].append(  # type: ignore[attr-defined]
                 (
                     (
@@ -384,6 +387,8 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
             )
 
         for raw_oid, rfc4514_attribute_name, value in x509_certificate.issuer:
+            if rfc4514_attribute_name not in _short_name_assoc:
+                continue
             issuer_info["issuer"].append(  # type: ignore[attr-defined]
                 (
                     (
@@ -440,9 +445,12 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
             "C": "countryName",
             "STREET": "streetAddress",
             "DC": "domainComponent",
+            "E": "email",
         }
 
         for raw_oid, rfc4514_attribute_name, value in x509_certificate.subject:
+            if rfc4514_attribute_name not in _short_name_assoc:
+                continue
             peer_info["subject"].append(  # type: ignore[attr-defined]
                 (
                     (
@@ -453,6 +461,8 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
             )
 
         for raw_oid, rfc4514_attribute_name, value in x509_certificate.issuer:
+            if rfc4514_attribute_name not in _short_name_assoc:
+                continue
             peer_info["issuer"].append(  # type: ignore[attr-defined]
                 (
                     (

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -423,10 +423,6 @@ def parse_url(url: str) -> Url:
         # Empty
         return Url()
 
-    # some legacy app may pass down a bytes url[...]
-    if isinstance(url, bytes):
-        url = url.decode()
-
     source_url = url
     if not _SCHEME_RE.search(url):
         url = "//" + url

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -423,6 +423,10 @@ def parse_url(url: str) -> Url:
         # Empty
         return Url()
 
+    # some legacy app may pass down a bytes url[...]
+    if isinstance(url, bytes):
+        url = url.decode()
+
     source_url = url
     if not _SCHEME_RE.search(url):
         url = "//" + url


### PR DESCRIPTION
2.12.913 (2024-03-21)
=====================

- Added useful repr for ``PoolManager``, ``ConnectionPool`` and ``TrafficPolice`` (async counterpart included).
- Fixed ``KeyError`` upon parsing X509 certificate pulled from the QUIC layer when the certificate contain an unexpected
  rfc4514 attribute. (https://github.com/jawah/urllib3.future/issues/217)
