### PR TITLE
Release 2.12.914

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+2.12.914 (2024-03-30)
+=====================
+
+- Fixed a rare thread safety issue when the size of PoolManager is inferior to the thread count. An edge case permitted
+  the creation of two ``ConnectionPool`` for the same ``PoolKey``.
+- Changed the default behavior of threads management to not raise an exception if the thread count is greater than
+  the pool size. Making it that way better align with upstream, our initial decision revealed itself to cause
+  confusions for some of our users. No longer will urllib3-future raise ``OverwhelmedTraffic`` in default configuration.
+- Fixed an error when ``happy_eyeballs=True`` is set with more tasks or threads than the pool size.
+
 2.12.913 (2024-03-21)
 =====================
 

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -477,192 +477,200 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
 
         conn = None
 
-        # this path is applicable if resolver yield at least two records.
-        # if A/AAAA records only (non-dual stack) -> spawn 4 (default) tasks with each record
-        # if A/AAAA records mixed (dual stack)    -> spawn 4 (default) tasks following this pattern (IPv6, IPv4, IPv6, IPv4)
-        # if single record A or AAAA -> ignore
-        # Don't mind about HTTP/2 or 3 in here, we're unencrypted here!
-        if self.happy_eyeballs:
-            log.debug(
-                "Attempting Happy-Eyeball %s:%s",
-                self.host,
-                self.port or "443",
-            )
-
-            if heb_timeout is None:
-                heb_timeout = self.timeout
-
-            override_timeout = (
-                heb_timeout.connect_timeout
-                if heb_timeout.connect_timeout is not None
-                and isinstance(heb_timeout.connect_timeout, (float, int))
-                else None
-            )
-
-            dt_pre_resolve = datetime.now(tz=timezone.utc)
-
-            if override_timeout is not None:
-                try:
-                    async with timeout(override_timeout):
-                        ip_addresses = await self._resolver.getaddrinfo(
-                            self.host,
-                            self.port,
-                            socket.AF_UNSPEC
-                            if "socket_family" not in self.conn_kw
-                            else self.conn_kw["socket_family"],
-                            socket.SOCK_STREAM,
-                            quic_upgrade_via_dns_rr=False,
-                        )
-                except TimeoutError:
-                    new_err = socket.gaierror(
-                        f"unable to resolve '{self.host}' within {override_timeout}s"
-                    )
-                    raise NameResolutionError(self.host, self, new_err)
-            else:
-                ip_addresses = await self._resolver.getaddrinfo(
-                    self.host,
-                    self.port,
-                    socket.AF_UNSPEC
-                    if "socket_family" not in self.conn_kw
-                    else self.conn_kw["socket_family"],
-                    socket.SOCK_STREAM,
-                    quic_upgrade_via_dns_rr=False,
-                )
-
-            delta_post_resolve = datetime.now(tz=timezone.utc) - dt_pre_resolve
-
-            if len(ip_addresses) > 1:
-                ipv6_addresses = []
-                ipv4_addresses = []
-
-                for ip_address in ip_addresses:
-                    if ip_address[0] == socket.AF_INET6:
-                        ipv6_addresses.append(ip_address)
-                    else:
-                        ipv4_addresses.append(ip_address)
-
-                if ipv4_addresses and ipv6_addresses:
-                    log.debug(
-                        "Happy-Eyeball Dual-Stack %s:%s",
-                        self.host,
-                        self.port or "443",
-                    )
-
-                    intermediary_addresses = []
-                    for ipv6_entry, ipv4_entry in zip_longest(
-                        ipv6_addresses, ipv4_addresses
-                    ):
-                        if ipv6_entry:
-                            intermediary_addresses.append(ipv6_entry)
-                        if ipv4_entry:
-                            intermediary_addresses.append(ipv4_entry)
-                    ip_addresses = intermediary_addresses
-                else:
-                    log.debug(
-                        "Happy-Eyeball Single-Stack %s:%s",
-                        self.host,
-                        self.port or "443",
-                    )
-
-                challengers = []
-                max_task = (
-                    4 if isinstance(self.happy_eyeballs, bool) else self.happy_eyeballs
-                )
-
-                for ip_address in ip_addresses[:max_task]:
-                    conn_kw = self.conn_kw.copy()
-                    target_solo_addr = (
-                        f"[{ip_address[-1][0]}]"
-                        if ip_address[0] == socket.AF_INET6
-                        else ip_address[-1][0]
-                    )
-                    conn_kw["resolver"] = AsyncResolverDescription.from_url(
-                        f"in-memory://default?hosts={self.host}:{target_solo_addr}"
-                    ).new()
-                    conn_kw["socket_family"] = ip_address[0]
-
-                    if (
-                        "source_address" in conn_kw
-                        and conn_kw["source_address"] is not None
-                    ):
-                        conn_kw["source_address"] = (conn_kw["source_address"][0], 0)
-
-                    challengers.append(
-                        self.ConnectionCls(
-                            host=self.host,
-                            port=self.port,
-                            timeout=override_timeout,
-                            **conn_kw,
-                        )
-                    )
-
-                tasks = [
-                    asyncio.create_task(challenger.connect())
-                    for i, challenger in enumerate(challengers)
-                ]
-
-                winner_task = None
-                remnant_tasks = []
-                pending: set[Task[None]] = set()
-
-                while True:
-                    done, pending = await asyncio.wait(
-                        tasks if not pending else pending,
-                        return_when=asyncio.FIRST_COMPLETED,
-                        timeout=override_timeout,
-                    )
-
-                    while done:
-                        finished_task = done.pop()
-
-                        if finished_task.exception() is None:
-                            winner_task = finished_task
-
-                        if finished_task.exception():
-                            continue
-
-                        remnant_tasks.append(finished_task)
-
-                    if winner_task or not pending:
-                        break
-
-                for task in pending:
-                    task.cancel()
-
-                if winner_task is None:
-                    within_delay_msg: str = (
-                        f" within {override_timeout}s" if override_timeout else ""
-                    )
-                    raise NewConnectionError(
-                        challengers[0],
-                        f"Failed to establish a new connection: No suitable address to connect to using Happy Eyeballs algorithm for {self.host}:{self.port}{within_delay_msg}",
-                    ) from tasks[0].exception()
-
-                conn = challengers[tasks.index(winner_task)]
-
-                # we have to replace the resolution latency metric
-                if conn.conn_info:
-                    conn.conn_info.resolution_latency = delta_post_resolve
-
-                if len(remnant_tasks):
-                    # we may have more than one conn ready, we shall then carefully close the others.
-                    for disposable_remnant in remnant_tasks:
-                        await challengers[tasks.index(disposable_remnant)].close()
-            else:
+        async with self.pool.locate_or_hold() as swapper:
+            # this path is applicable if resolver yield at least two records.
+            # if A/AAAA records only (non-dual stack) -> spawn 4 (default) tasks with each record
+            # if A/AAAA records mixed (dual stack)    -> spawn 4 (default) tasks following this pattern (IPv6, IPv4, IPv6, IPv4)
+            # if single record A or AAAA -> ignore
+            # Don't mind about HTTP/2 or 3 in here, we're unencrypted here!
+            if self.happy_eyeballs:
                 log.debug(
-                    "Happy-Eyeball Ineligible %s:%s",
+                    "Attempting Happy-Eyeball %s:%s",
                     self.host,
                     self.port or "443",
                 )
 
-        if conn is None:
-            conn = self.ConnectionCls(
-                host=self.host,
-                port=self.port,
-                timeout=self.timeout.connect_timeout,
-                **self.conn_kw,
-            )
-        await self.pool.put(conn, immediately_unavailable=True)
+                if heb_timeout is None:
+                    heb_timeout = self.timeout
+
+                override_timeout = (
+                    heb_timeout.connect_timeout
+                    if heb_timeout.connect_timeout is not None
+                    and isinstance(heb_timeout.connect_timeout, (float, int))
+                    else None
+                )
+
+                dt_pre_resolve = datetime.now(tz=timezone.utc)
+
+                if override_timeout is not None:
+                    try:
+                        async with timeout(override_timeout):
+                            ip_addresses = await self._resolver.getaddrinfo(
+                                self.host,
+                                self.port,
+                                socket.AF_UNSPEC
+                                if "socket_family" not in self.conn_kw
+                                else self.conn_kw["socket_family"],
+                                socket.SOCK_STREAM,
+                                quic_upgrade_via_dns_rr=False,
+                            )
+                    except TimeoutError:
+                        new_err = socket.gaierror(
+                            f"unable to resolve '{self.host}' within {override_timeout}s"
+                        )
+                        raise NameResolutionError(self.host, self, new_err)
+                else:
+                    ip_addresses = await self._resolver.getaddrinfo(
+                        self.host,
+                        self.port,
+                        socket.AF_UNSPEC
+                        if "socket_family" not in self.conn_kw
+                        else self.conn_kw["socket_family"],
+                        socket.SOCK_STREAM,
+                        quic_upgrade_via_dns_rr=False,
+                    )
+
+                delta_post_resolve = datetime.now(tz=timezone.utc) - dt_pre_resolve
+
+                if len(ip_addresses) > 1:
+                    ipv6_addresses = []
+                    ipv4_addresses = []
+
+                    for ip_address in ip_addresses:
+                        if ip_address[0] == socket.AF_INET6:
+                            ipv6_addresses.append(ip_address)
+                        else:
+                            ipv4_addresses.append(ip_address)
+
+                    if ipv4_addresses and ipv6_addresses:
+                        log.debug(
+                            "Happy-Eyeball Dual-Stack %s:%s",
+                            self.host,
+                            self.port or "443",
+                        )
+
+                        intermediary_addresses = []
+                        for ipv6_entry, ipv4_entry in zip_longest(
+                            ipv6_addresses, ipv4_addresses
+                        ):
+                            if ipv6_entry:
+                                intermediary_addresses.append(ipv6_entry)
+                            if ipv4_entry:
+                                intermediary_addresses.append(ipv4_entry)
+                        ip_addresses = intermediary_addresses
+                    else:
+                        log.debug(
+                            "Happy-Eyeball Single-Stack %s:%s",
+                            self.host,
+                            self.port or "443",
+                        )
+
+                    challengers = []
+                    max_task = (
+                        4
+                        if isinstance(self.happy_eyeballs, bool)
+                        else self.happy_eyeballs
+                    )
+
+                    for ip_address in ip_addresses[:max_task]:
+                        conn_kw = self.conn_kw.copy()
+                        target_solo_addr = (
+                            f"[{ip_address[-1][0]}]"
+                            if ip_address[0] == socket.AF_INET6
+                            else ip_address[-1][0]
+                        )
+                        conn_kw["resolver"] = AsyncResolverDescription.from_url(
+                            f"in-memory://default?hosts={self.host}:{target_solo_addr}"
+                        ).new()
+                        conn_kw["socket_family"] = ip_address[0]
+
+                        if (
+                            "source_address" in conn_kw
+                            and conn_kw["source_address"] is not None
+                        ):
+                            conn_kw["source_address"] = (
+                                conn_kw["source_address"][0],
+                                0,
+                            )
+
+                        challengers.append(
+                            self.ConnectionCls(
+                                host=self.host,
+                                port=self.port,
+                                timeout=override_timeout,
+                                **conn_kw,
+                            )
+                        )
+
+                    tasks = [
+                        asyncio.create_task(challenger.connect())
+                        for i, challenger in enumerate(challengers)
+                    ]
+
+                    winner_task = None
+                    remnant_tasks = []
+                    pending: set[Task[None]] = set()
+
+                    while True:
+                        done, pending = await asyncio.wait(
+                            tasks if not pending else pending,
+                            return_when=asyncio.FIRST_COMPLETED,
+                            timeout=override_timeout,
+                        )
+
+                        while done:
+                            finished_task = done.pop()
+
+                            if finished_task.exception() is None:
+                                winner_task = finished_task
+
+                            if finished_task.exception():
+                                continue
+
+                            remnant_tasks.append(finished_task)
+
+                        if winner_task or not pending:
+                            break
+
+                    for task in pending:
+                        task.cancel()
+
+                    if winner_task is None:
+                        within_delay_msg: str = (
+                            f" within {override_timeout}s" if override_timeout else ""
+                        )
+                        raise NewConnectionError(
+                            challengers[0],
+                            f"Failed to establish a new connection: No suitable address to connect to using Happy Eyeballs algorithm for {self.host}:{self.port}{within_delay_msg}",
+                        ) from tasks[0].exception()
+
+                    conn = challengers[tasks.index(winner_task)]
+
+                    # we have to replace the resolution latency metric
+                    if conn.conn_info:
+                        conn.conn_info.resolution_latency = delta_post_resolve
+
+                    if len(remnant_tasks):
+                        # we may have more than one conn ready, we shall then carefully close the others.
+                        for disposable_remnant in remnant_tasks:
+                            await challengers[tasks.index(disposable_remnant)].close()
+                else:
+                    log.debug(
+                        "Happy-Eyeball Ineligible %s:%s",
+                        self.host,
+                        self.port or "443",
+                    )
+
+            if conn is None:
+                conn = self.ConnectionCls(
+                    host=self.host,
+                    port=self.port,
+                    timeout=self.timeout.connect_timeout,
+                    **self.conn_kw,
+                )
+
+            await swapper(conn)  # type: ignore[operator]
+
         return conn
 
     async def _get_conn(
@@ -2109,239 +2117,243 @@ class AsyncHTTPSConnectionPool(AsyncHTTPConnectionPool):
 
         conn = None
 
-        if self.happy_eyeballs:
-            # Taking this path forward will establish a connection (aka. connect) prior to what usually
-            # take place. This is the only place where it is the most convenient.
-            log.debug(
-                "Attempting Happy-Eyeball %s:%s",
-                self.host,
-                self.port or "443",
-            )
-
-            if heb_timeout is None:
-                heb_timeout = self.timeout
-
-            override_timeout = (
-                heb_timeout.connect_timeout
-                if heb_timeout.connect_timeout is not None
-                and isinstance(heb_timeout.connect_timeout, (float, int))
-                else None
-            )
-
-            # we have to get this metric here, as the underlying Connection object
-            # will have the DNS resolution set to 0s!
-            dt_pre_resolve = datetime.now(tz=timezone.utc)
-            if override_timeout is not None:
-                try:
-                    async with timeout(override_timeout):
-                        ip_addresses = await self._resolver.getaddrinfo(
-                            actual_host,
-                            actual_port,
-                            socket.AF_UNSPEC
-                            if "socket_family" not in self.conn_kw
-                            else self.conn_kw["socket_family"],
-                            socket.SOCK_STREAM,
-                            quic_upgrade_via_dns_rr=True,
-                            # we don't know if H3 is actually supported by the underlying Connection,
-                            # we don't care, it will sort it out later.
-                        )
-                except TimeoutError:
-                    new_err = socket.gaierror(
-                        f"unable to resolve '{actual_host}' within {override_timeout}s"
-                    )
-                    raise NameResolutionError(actual_host, self, new_err)
-
-            else:
-                ip_addresses = await self._resolver.getaddrinfo(
-                    actual_host,
-                    actual_port,
-                    socket.AF_UNSPEC
-                    if "socket_family" not in self.conn_kw
-                    else self.conn_kw["socket_family"],
-                    socket.SOCK_STREAM,
-                    quic_upgrade_via_dns_rr=True,
-                    # we don't know if H3 is actually supported by the underlying Connection,
-                    # we don't care, it will sort it out later.
-                )
-
-            delta_post_resolve = datetime.now(tz=timezone.utc) - dt_pre_resolve
-
-            target_pqc = {}
-
-            # does the user provided us with a quic capability cache? if so, use it!
-            if (
-                "preemptive_quic_cache" in self.conn_kw
-                and self.conn_kw["preemptive_quic_cache"] is not None
-            ):
-                target_pqc = self.conn_kw["preemptive_quic_cache"]
-
-            # if the resolver hinted us toward using a DGRAM, we inject it into the quic capability cache.
-            if any(_[1] == socket.SOCK_DGRAM for _ in ip_addresses):
-                if (self.host, self.port) not in target_pqc:
-                    target_pqc[(self.host, self.port)] = (self.host, self.port)
-
-            # HEB algorithm only make sense if the name resolution yield more than 1 record.
-            if len(ip_addresses) > 1:
-                ipv6_addresses = []
-                ipv4_addresses = []
-
-                for ip_address in ip_addresses:
-                    if ip_address[0] == socket.AF_INET6:
-                        ipv6_addresses.append(ip_address)
-                    else:
-                        ipv4_addresses.append(ip_address)
-
-                # if we have BOTH IPv4 and IPv6 entries, we want to reorder the records
-                # so that we can be as fair as possible when spawning the tasks.
-                if ipv4_addresses and ipv6_addresses:
-                    log.debug(
-                        "Happy-Eyeball Dual-Stack %s:%s",
-                        self.host,
-                        self.port or "443",
-                    )
-                    intermediary_addresses = []
-                    for ipv6_entry, ipv4_entry in zip_longest(
-                        ipv6_addresses, ipv4_addresses
-                    ):
-                        if ipv6_entry:
-                            intermediary_addresses.append(ipv6_entry)
-                        if ipv4_entry:
-                            intermediary_addresses.append(ipv4_entry)
-                    ip_addresses = intermediary_addresses
-                else:
-                    log.debug(
-                        "Happy-Eyeball Single-Stack %s:%s",
-                        self.host,
-                        self.port or "443",
-                    )
-
-                challengers = []
-                max_task = (
-                    4 if isinstance(self.happy_eyeballs, bool) else self.happy_eyeballs
-                )
-
-                for ip_address in ip_addresses[:max_task]:
-                    conn_kw = self.conn_kw.copy()
-                    target_solo_addr = (
-                        f"[{ip_address[-1][0]}]"
-                        if ip_address[0] == socket.AF_INET6
-                        else ip_address[-1][0]
-                    )
-                    conn_kw["resolver"] = AsyncResolverDescription.from_url(
-                        f"in-memory://default?hosts={self.host}:{target_solo_addr}"
-                    ).new()
-                    conn_kw["socket_family"] = ip_address[0]
-                    conn_kw["preemptive_quic_cache"] = target_pqc
-
-                    challengers.append(
-                        self.ConnectionCls(
-                            host=actual_host,
-                            port=actual_port,
-                            timeout=override_timeout,
-                            cert_file=self.cert_file,
-                            key_file=self.key_file,
-                            key_password=self.key_password,
-                            cert_reqs=self.cert_reqs,
-                            ca_certs=self.ca_certs,
-                            ca_cert_dir=self.ca_cert_dir,
-                            ca_cert_data=self.ca_cert_data,
-                            assert_hostname=self.assert_hostname,
-                            assert_fingerprint=self.assert_fingerprint,
-                            ssl_version=self.ssl_version,
-                            ssl_minimum_version=self.ssl_minimum_version,
-                            ssl_maximum_version=self.ssl_maximum_version,
-                            cert_data=self.cert_data,
-                            key_data=self.key_data,
-                            **conn_kw,
-                        )
-                    )
-
-                tasks = [
-                    asyncio.create_task(challenger.connect())
-                    for i, challenger in enumerate(challengers)
-                ]
-
-                winner_task = None
-                remnant_tasks = []
-                pending: set[Task[None]] = set()
-
-                # here we'll need at least one task that ended successfully OR every task terminated/completed.
-                while True:
-                    done, pending = await asyncio.wait(
-                        tasks if not pending else pending,
-                        return_when=asyncio.FIRST_COMPLETED,
-                        timeout=override_timeout,
-                    )
-
-                    while done:
-                        finished_task = done.pop()
-
-                        if finished_task.exception() is None:
-                            winner_task = finished_task
-
-                        if finished_task.exception():
-                            continue
-
-                        remnant_tasks.append(finished_task)
-
-                    if winner_task or not pending:
-                        break
-
-                # we need to kill the remaining tasks.
-                for task in pending:
-                    task.cancel()
-
-                if winner_task is None:
-                    within_delay_msg: str = (
-                        f" within {override_timeout}s" if override_timeout else ""
-                    )
-                    raise NewConnectionError(
-                        challengers[
-                            0
-                        ],  # that's a bummer, but it wasn't planned for this algorithm.
-                        f"Failed to establish a new connection: No suitable address to connect to using Happy Eyeballs algorithm for {actual_host}:{actual_port}{within_delay_msg}",
-                    ) from tasks[0].exception()
-
-                conn = challengers[tasks.index(winner_task)]
-
-                # we have to replace the resolution latency metric
-                if conn.conn_info:
-                    conn.conn_info.resolution_latency = delta_post_resolve
-
-                if len(remnant_tasks):
-                    # we may have more than one conn ready, we shall then carefully close the others.
-                    for disposable_remnant in remnant_tasks:
-                        await challengers[tasks.index(disposable_remnant)].close()
-            else:
+        async with self.pool.locate_or_hold() as swapper:
+            if self.happy_eyeballs:
+                # Taking this path forward will establish a connection (aka. connect) prior to what usually
+                # take place. This is the only place where it is the most convenient.
                 log.debug(
-                    "Happy-Eyeball Ineligible %s:%s",
+                    "Attempting Happy-Eyeball %s:%s",
                     self.host,
                     self.port or "443",
                 )
 
-        if conn is None:
-            conn = self.ConnectionCls(
-                host=actual_host,
-                port=actual_port,
-                timeout=self.timeout.connect_timeout,
-                cert_file=self.cert_file,
-                key_file=self.key_file,
-                key_password=self.key_password,
-                cert_reqs=self.cert_reqs,
-                ca_certs=self.ca_certs,
-                ca_cert_dir=self.ca_cert_dir,
-                ca_cert_data=self.ca_cert_data,
-                assert_hostname=self.assert_hostname,
-                assert_fingerprint=self.assert_fingerprint,
-                ssl_version=self.ssl_version,
-                ssl_minimum_version=self.ssl_minimum_version,
-                ssl_maximum_version=self.ssl_maximum_version,
-                cert_data=self.cert_data,
-                key_data=self.key_data,
-                **self.conn_kw,
-            )
+                if heb_timeout is None:
+                    heb_timeout = self.timeout
 
-        await self.pool.put(conn, immediately_unavailable=True)
+                override_timeout = (
+                    heb_timeout.connect_timeout
+                    if heb_timeout.connect_timeout is not None
+                    and isinstance(heb_timeout.connect_timeout, (float, int))
+                    else None
+                )
+
+                # we have to get this metric here, as the underlying Connection object
+                # will have the DNS resolution set to 0s!
+                dt_pre_resolve = datetime.now(tz=timezone.utc)
+                if override_timeout is not None:
+                    try:
+                        async with timeout(override_timeout):
+                            ip_addresses = await self._resolver.getaddrinfo(
+                                actual_host,
+                                actual_port,
+                                socket.AF_UNSPEC
+                                if "socket_family" not in self.conn_kw
+                                else self.conn_kw["socket_family"],
+                                socket.SOCK_STREAM,
+                                quic_upgrade_via_dns_rr=True,
+                                # we don't know if H3 is actually supported by the underlying Connection,
+                                # we don't care, it will sort it out later.
+                            )
+                    except TimeoutError:
+                        new_err = socket.gaierror(
+                            f"unable to resolve '{actual_host}' within {override_timeout}s"
+                        )
+                        raise NameResolutionError(actual_host, self, new_err)
+
+                else:
+                    ip_addresses = await self._resolver.getaddrinfo(
+                        actual_host,
+                        actual_port,
+                        socket.AF_UNSPEC
+                        if "socket_family" not in self.conn_kw
+                        else self.conn_kw["socket_family"],
+                        socket.SOCK_STREAM,
+                        quic_upgrade_via_dns_rr=True,
+                        # we don't know if H3 is actually supported by the underlying Connection,
+                        # we don't care, it will sort it out later.
+                    )
+
+                delta_post_resolve = datetime.now(tz=timezone.utc) - dt_pre_resolve
+
+                target_pqc = {}
+
+                # does the user provided us with a quic capability cache? if so, use it!
+                if (
+                    "preemptive_quic_cache" in self.conn_kw
+                    and self.conn_kw["preemptive_quic_cache"] is not None
+                ):
+                    target_pqc = self.conn_kw["preemptive_quic_cache"]
+
+                # if the resolver hinted us toward using a DGRAM, we inject it into the quic capability cache.
+                if any(_[1] == socket.SOCK_DGRAM for _ in ip_addresses):
+                    if (self.host, self.port) not in target_pqc:
+                        target_pqc[(self.host, self.port)] = (self.host, self.port)
+
+                # HEB algorithm only make sense if the name resolution yield more than 1 record.
+                if len(ip_addresses) > 1:
+                    ipv6_addresses = []
+                    ipv4_addresses = []
+
+                    for ip_address in ip_addresses:
+                        if ip_address[0] == socket.AF_INET6:
+                            ipv6_addresses.append(ip_address)
+                        else:
+                            ipv4_addresses.append(ip_address)
+
+                    # if we have BOTH IPv4 and IPv6 entries, we want to reorder the records
+                    # so that we can be as fair as possible when spawning the tasks.
+                    if ipv4_addresses and ipv6_addresses:
+                        log.debug(
+                            "Happy-Eyeball Dual-Stack %s:%s",
+                            self.host,
+                            self.port or "443",
+                        )
+                        intermediary_addresses = []
+                        for ipv6_entry, ipv4_entry in zip_longest(
+                            ipv6_addresses, ipv4_addresses
+                        ):
+                            if ipv6_entry:
+                                intermediary_addresses.append(ipv6_entry)
+                            if ipv4_entry:
+                                intermediary_addresses.append(ipv4_entry)
+                        ip_addresses = intermediary_addresses
+                    else:
+                        log.debug(
+                            "Happy-Eyeball Single-Stack %s:%s",
+                            self.host,
+                            self.port or "443",
+                        )
+
+                    challengers = []
+                    max_task = (
+                        4
+                        if isinstance(self.happy_eyeballs, bool)
+                        else self.happy_eyeballs
+                    )
+
+                    for ip_address in ip_addresses[:max_task]:
+                        conn_kw = self.conn_kw.copy()
+                        target_solo_addr = (
+                            f"[{ip_address[-1][0]}]"
+                            if ip_address[0] == socket.AF_INET6
+                            else ip_address[-1][0]
+                        )
+                        conn_kw["resolver"] = AsyncResolverDescription.from_url(
+                            f"in-memory://default?hosts={self.host}:{target_solo_addr}"
+                        ).new()
+                        conn_kw["socket_family"] = ip_address[0]
+                        conn_kw["preemptive_quic_cache"] = target_pqc
+
+                        challengers.append(
+                            self.ConnectionCls(
+                                host=actual_host,
+                                port=actual_port,
+                                timeout=override_timeout,
+                                cert_file=self.cert_file,
+                                key_file=self.key_file,
+                                key_password=self.key_password,
+                                cert_reqs=self.cert_reqs,
+                                ca_certs=self.ca_certs,
+                                ca_cert_dir=self.ca_cert_dir,
+                                ca_cert_data=self.ca_cert_data,
+                                assert_hostname=self.assert_hostname,
+                                assert_fingerprint=self.assert_fingerprint,
+                                ssl_version=self.ssl_version,
+                                ssl_minimum_version=self.ssl_minimum_version,
+                                ssl_maximum_version=self.ssl_maximum_version,
+                                cert_data=self.cert_data,
+                                key_data=self.key_data,
+                                **conn_kw,
+                            )
+                        )
+
+                    tasks = [
+                        asyncio.create_task(challenger.connect())
+                        for i, challenger in enumerate(challengers)
+                    ]
+
+                    winner_task = None
+                    remnant_tasks = []
+                    pending: set[Task[None]] = set()
+
+                    # here we'll need at least one task that ended successfully OR every task terminated/completed.
+                    while True:
+                        done, pending = await asyncio.wait(
+                            tasks if not pending else pending,
+                            return_when=asyncio.FIRST_COMPLETED,
+                            timeout=override_timeout,
+                        )
+
+                        while done:
+                            finished_task = done.pop()
+
+                            if finished_task.exception() is None:
+                                winner_task = finished_task
+
+                            if finished_task.exception():
+                                continue
+
+                            remnant_tasks.append(finished_task)
+
+                        if winner_task or not pending:
+                            break
+
+                    # we need to kill the remaining tasks.
+                    for task in pending:
+                        task.cancel()
+
+                    if winner_task is None:
+                        within_delay_msg: str = (
+                            f" within {override_timeout}s" if override_timeout else ""
+                        )
+                        raise NewConnectionError(
+                            challengers[
+                                0
+                            ],  # that's a bummer, but it wasn't planned for this algorithm.
+                            f"Failed to establish a new connection: No suitable address to connect to using Happy Eyeballs algorithm for {actual_host}:{actual_port}{within_delay_msg}",
+                        ) from tasks[0].exception()
+
+                    conn = challengers[tasks.index(winner_task)]
+
+                    # we have to replace the resolution latency metric
+                    if conn.conn_info:
+                        conn.conn_info.resolution_latency = delta_post_resolve
+
+                    if len(remnant_tasks):
+                        # we may have more than one conn ready, we shall then carefully close the others.
+                        for disposable_remnant in remnant_tasks:
+                            await challengers[tasks.index(disposable_remnant)].close()
+                else:
+                    log.debug(
+                        "Happy-Eyeball Ineligible %s:%s",
+                        self.host,
+                        self.port or "443",
+                    )
+
+            if conn is None:
+                conn = self.ConnectionCls(
+                    host=actual_host,
+                    port=actual_port,
+                    timeout=self.timeout.connect_timeout,
+                    cert_file=self.cert_file,
+                    key_file=self.key_file,
+                    key_password=self.key_password,
+                    cert_reqs=self.cert_reqs,
+                    ca_certs=self.ca_certs,
+                    ca_cert_dir=self.ca_cert_dir,
+                    ca_cert_data=self.ca_cert_data,
+                    assert_hostname=self.assert_hostname,
+                    assert_fingerprint=self.assert_fingerprint,
+                    ssl_version=self.ssl_version,
+                    ssl_minimum_version=self.ssl_minimum_version,
+                    ssl_maximum_version=self.ssl_maximum_version,
+                    cert_data=self.cert_data,
+                    key_data=self.key_data,
+                    **self.conn_kw,
+                )
+
+            await swapper(conn)  # type: ignore[operator]
+
         return conn
 
     async def _validate_conn(self, conn: AsyncHTTPConnection) -> None:

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.12.913"
+__version__ = "2.12.914"

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -483,180 +483,188 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         if self.pool is None:
             raise ClosedPoolError(self, "Pool is closed")
 
-        self.num_connections += 1
-        log.debug(
-            "Starting new HTTP connection (%d): %s:%s",
-            self.num_connections,
-            self.host,
-            self.port or "80",
-        )
-
-        conn = None
-
-        if self.happy_eyeballs:
+        with self.pool.locate_or_hold() as swapper:
+            self.num_connections += 1
             log.debug(
-                "Attempting Happy-Eyeball %s:%s",
+                "Starting new HTTP connection (%d): %s:%s",
+                self.num_connections,
                 self.host,
-                self.port or "443",
+                self.port or "80",
             )
 
-            dt_pre_resolve = datetime.now(tz=timezone.utc)
-            ip_addresses = self._resolver.getaddrinfo(
-                self.host,
-                self.port,
-                socket.AF_UNSPEC
-                if "socket_family" not in self.conn_kw
-                else self.conn_kw["socket_family"],
-                socket.SOCK_STREAM,
-                quic_upgrade_via_dns_rr=False,
-            )
-            delta_post_resolve = datetime.now(tz=timezone.utc) - dt_pre_resolve
+            conn = None
 
-            if len(ip_addresses) > 1:
-                ipv6_addresses = []
-                ipv4_addresses = []
-
-                for ip_address in ip_addresses:
-                    if ip_address[0] == socket.AF_INET6:
-                        ipv6_addresses.append(ip_address)
-                    else:
-                        ipv4_addresses.append(ip_address)
-
-                if ipv4_addresses and ipv6_addresses:
-                    log.debug(
-                        "Happy-Eyeball Dual-Stack %s:%s",
-                        self.host,
-                        self.port or "443",
-                    )
-
-                    intermediary_addresses = []
-                    for ipv6_entry, ipv4_entry in zip_longest(
-                        ipv6_addresses, ipv4_addresses
-                    ):
-                        if ipv6_entry:
-                            intermediary_addresses.append(ipv6_entry)
-                        if ipv4_entry:
-                            intermediary_addresses.append(ipv4_entry)
-                    ip_addresses = intermediary_addresses
-                else:
-                    log.debug(
-                        "Happy-Eyeball Single-Stack %s:%s",
-                        self.host,
-                        self.port or "443",
-                    )
-
-                challengers = []
-                max_task = (
-                    4 if isinstance(self.happy_eyeballs, bool) else self.happy_eyeballs
-                )
-
-                if heb_timeout is None:
-                    heb_timeout = self.timeout
-
-                override_timeout = (
-                    heb_timeout.connect_timeout
-                    if heb_timeout.connect_timeout is not None
-                    and isinstance(heb_timeout.connect_timeout, (float, int))
-                    else 5.0
-                )
-
-                for ip_address in ip_addresses[:max_task]:
-                    conn_kw = self.conn_kw.copy()
-                    target_solo_addr = (
-                        f"[{ip_address[-1][0]}]"
-                        if ip_address[0] == socket.AF_INET6
-                        else ip_address[-1][0]
-                    )
-                    conn_kw["resolver"] = ResolverDescription.from_url(
-                        f"in-memory://default?hosts={self.host}:{target_solo_addr}"
-                    ).new()
-                    conn_kw["socket_family"] = ip_address[0]
-
-                    if (
-                        "source_address" in conn_kw
-                        and conn_kw["source_address"] is not None
-                    ):
-                        conn_kw["source_address"] = (conn_kw["source_address"][0], 0)
-
-                    challengers.append(
-                        self.ConnectionCls(
-                            host=self.host,
-                            port=self.port,
-                            timeout=override_timeout,
-                            **conn_kw,
-                        )
-                    )
-
-                event = threading.Event()
-                winning_task: Future[None] | None = None
-                completed_count: int = 0
-
-                def _happy_eyeballs_completed(t: Future[None]) -> None:
-                    nonlocal winning_task, event, completed_count
-
-                    if winning_task is None and t.exception() is None:
-                        winning_task = t
-                        event.set()
-
-                        return
-
-                    completed_count += 1
-
-                    if completed_count >= len(challengers):
-                        event.set()
-
-                tpe = ThreadPoolExecutor(max_workers=max_task)
-
-                tasks: list[Future[None]] = []
-
-                for challenger in challengers:
-                    task = tpe.submit(challenger.connect)
-                    task.add_done_callback(_happy_eyeballs_completed)
-
-                    tasks.append(task)
-
-                event.wait()
-
-                for task in tasks:
-                    if task == winning_task:
-                        continue
-
-                    if task.running():
-                        task.cancel()
-                    else:
-                        challengers[tasks.index(task)].close()
-
-                if winning_task is None:
-                    within_delay_msg: str = (
-                        f" within {override_timeout}s" if override_timeout else ""
-                    )
-                    raise NewConnectionError(
-                        challengers[0],
-                        f"Failed to establish a new connection: No suitable address to connect to using Happy Eyeballs for {self.host}:{self.port}{within_delay_msg}",
-                    ) from tasks[0].exception()
-
-                conn = challengers[tasks.index(winning_task)]
-
-                # we have to replace the resolution latency metric
-                if conn.conn_info:
-                    conn.conn_info.resolution_latency = delta_post_resolve
-
-                tpe.shutdown(wait=False)
-            else:
+            if self.happy_eyeballs:
                 log.debug(
-                    "Happy-Eyeball Ineligible %s:%s",
+                    "Attempting Happy-Eyeball %s:%s",
                     self.host,
                     self.port or "443",
                 )
 
-        if conn is None:
-            conn = self.ConnectionCls(
-                host=self.host,
-                port=self.port,
-                timeout=self.timeout.connect_timeout,
-                **self.conn_kw,
-            )
-        self.pool.put(conn, immediately_unavailable=True)
+                dt_pre_resolve = datetime.now(tz=timezone.utc)
+                ip_addresses = self._resolver.getaddrinfo(
+                    self.host,
+                    self.port,
+                    socket.AF_UNSPEC
+                    if "socket_family" not in self.conn_kw
+                    else self.conn_kw["socket_family"],
+                    socket.SOCK_STREAM,
+                    quic_upgrade_via_dns_rr=False,
+                )
+                delta_post_resolve = datetime.now(tz=timezone.utc) - dt_pre_resolve
+
+                if len(ip_addresses) > 1:
+                    ipv6_addresses = []
+                    ipv4_addresses = []
+
+                    for ip_address in ip_addresses:
+                        if ip_address[0] == socket.AF_INET6:
+                            ipv6_addresses.append(ip_address)
+                        else:
+                            ipv4_addresses.append(ip_address)
+
+                    if ipv4_addresses and ipv6_addresses:
+                        log.debug(
+                            "Happy-Eyeball Dual-Stack %s:%s",
+                            self.host,
+                            self.port or "443",
+                        )
+
+                        intermediary_addresses = []
+                        for ipv6_entry, ipv4_entry in zip_longest(
+                            ipv6_addresses, ipv4_addresses
+                        ):
+                            if ipv6_entry:
+                                intermediary_addresses.append(ipv6_entry)
+                            if ipv4_entry:
+                                intermediary_addresses.append(ipv4_entry)
+                        ip_addresses = intermediary_addresses
+                    else:
+                        log.debug(
+                            "Happy-Eyeball Single-Stack %s:%s",
+                            self.host,
+                            self.port or "443",
+                        )
+
+                    challengers = []
+                    max_task = (
+                        4
+                        if isinstance(self.happy_eyeballs, bool)
+                        else self.happy_eyeballs
+                    )
+
+                    if heb_timeout is None:
+                        heb_timeout = self.timeout
+
+                    override_timeout = (
+                        heb_timeout.connect_timeout
+                        if heb_timeout.connect_timeout is not None
+                        and isinstance(heb_timeout.connect_timeout, (float, int))
+                        else 5.0
+                    )
+
+                    for ip_address in ip_addresses[:max_task]:
+                        conn_kw = self.conn_kw.copy()
+                        target_solo_addr = (
+                            f"[{ip_address[-1][0]}]"
+                            if ip_address[0] == socket.AF_INET6
+                            else ip_address[-1][0]
+                        )
+                        conn_kw["resolver"] = ResolverDescription.from_url(
+                            f"in-memory://default?hosts={self.host}:{target_solo_addr}"
+                        ).new()
+                        conn_kw["socket_family"] = ip_address[0]
+
+                        if (
+                            "source_address" in conn_kw
+                            and conn_kw["source_address"] is not None
+                        ):
+                            conn_kw["source_address"] = (
+                                conn_kw["source_address"][0],
+                                0,
+                            )
+
+                        challengers.append(
+                            self.ConnectionCls(
+                                host=self.host,
+                                port=self.port,
+                                timeout=override_timeout,
+                                **conn_kw,
+                            )
+                        )
+
+                    event = threading.Event()
+                    winning_task: Future[None] | None = None
+                    completed_count: int = 0
+
+                    def _happy_eyeballs_completed(t: Future[None]) -> None:
+                        nonlocal winning_task, event, completed_count
+
+                        if winning_task is None and t.exception() is None:
+                            winning_task = t
+                            event.set()
+
+                            return
+
+                        completed_count += 1
+
+                        if completed_count >= len(challengers):
+                            event.set()
+
+                    tpe = ThreadPoolExecutor(max_workers=max_task)
+
+                    tasks: list[Future[None]] = []
+
+                    for challenger in challengers:
+                        task = tpe.submit(challenger.connect)
+                        task.add_done_callback(_happy_eyeballs_completed)
+
+                        tasks.append(task)
+
+                    event.wait()
+
+                    for task in tasks:
+                        if task == winning_task:
+                            continue
+
+                        if task.running():
+                            task.cancel()
+                        else:
+                            challengers[tasks.index(task)].close()
+
+                    if winning_task is None:
+                        within_delay_msg: str = (
+                            f" within {override_timeout}s" if override_timeout else ""
+                        )
+                        raise NewConnectionError(
+                            challengers[0],
+                            f"Failed to establish a new connection: No suitable address to connect to using Happy Eyeballs for {self.host}:{self.port}{within_delay_msg}",
+                        ) from tasks[0].exception()
+
+                    conn = challengers[tasks.index(winning_task)]
+
+                    # we have to replace the resolution latency metric
+                    if conn.conn_info:
+                        conn.conn_info.resolution_latency = delta_post_resolve
+
+                    tpe.shutdown(wait=False)
+                else:
+                    log.debug(
+                        "Happy-Eyeball Ineligible %s:%s",
+                        self.host,
+                        self.port or "443",
+                    )
+
+            if conn is None:
+                conn = self.ConnectionCls(
+                    host=self.host,
+                    port=self.port,
+                    timeout=self.timeout.connect_timeout,
+                    **self.conn_kw,
+                )
+
+            swapper(conn)  # type: ignore[operator]
+
         return conn
 
     def _get_conn(
@@ -1816,13 +1824,14 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             ):
                 self.pool.memorize(response, conn)  # type: ignore[union-attr]
 
-            if release_this_conn is True:
+            if (
+                release_this_conn is True and self.pool is not None
+            ):  # the pool could be in shutdown procedure here.
                 if conn is not None:
-                    assert self.pool is not None
                     if self.pool.is_held(conn) is True:
                         self._put_conn(conn)
                 else:
-                    self.pool.kill_cursor()  # type: ignore[union-attr]
+                    self.pool.kill_cursor()
 
         if not conn:
             # Try again
@@ -2031,6 +2040,12 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         """
         if self.pool is None:
             raise ClosedPoolError(self, "Pool is closed")
+
+        if not self.ConnectionCls or self.ConnectionCls is DummyConnection:  # type: ignore[comparison-overlap]
+            raise ImportError(
+                "Can't connect to HTTPS URL because the SSL module is not available."
+            )
+
         self.num_connections += 1
         log.debug(
             "Starting new HTTPS connection (%d): %s:%s",
@@ -2039,235 +2054,232 @@ class HTTPSConnectionPool(HTTPConnectionPool):
             self.port or "443",
         )
 
-        if not self.ConnectionCls or self.ConnectionCls is DummyConnection:  # type: ignore[comparison-overlap]
-            raise ImportError(
-                "Can't connect to HTTPS URL because the SSL module is not available."
-            )
-
         actual_host: str = self.host
         actual_port = self.port
         if self.proxy is not None and self.proxy.host is not None:
             actual_host = self.proxy.host
             actual_port = self.proxy.port
 
-        conn = None
+        with self.pool.locate_or_hold() as swapper:
+            conn = None
 
-        if self.happy_eyeballs:
-            log.debug(
-                "Attempting Happy-Eyeball %s:%s",
-                self.host,
-                self.port or "443",
-            )
-
-            dt_pre_resolve = datetime.now(tz=timezone.utc)
-            ip_addresses = self._resolver.getaddrinfo(
-                actual_host,
-                actual_port,
-                socket.AF_UNSPEC
-                if "socket_family" not in self.conn_kw
-                else self.conn_kw["socket_family"],
-                socket.SOCK_STREAM,
-                quic_upgrade_via_dns_rr=True,
-            )
-            delta_post_resolve = datetime.now(tz=timezone.utc) - dt_pre_resolve
-
-            target_pqc = {}
-
-            if (
-                "preemptive_quic_cache" in self.conn_kw
-                and self.conn_kw["preemptive_quic_cache"] is not None
-            ):
-                target_pqc = self.conn_kw["preemptive_quic_cache"]
-
-            if any(_[1] == socket.SOCK_DGRAM for _ in ip_addresses):
-                if (self.host, self.port) not in target_pqc:
-                    target_pqc[(self.host, self.port)] = (self.host, self.port)
-
-            if len(ip_addresses) > 1:
-                ipv6_addresses = []
-                ipv4_addresses = []
-
-                for ip_address in ip_addresses:
-                    if ip_address[0] == socket.AF_INET6:
-                        ipv6_addresses.append(ip_address)
-                    else:
-                        ipv4_addresses.append(ip_address)
-
-                if ipv4_addresses and ipv6_addresses:
-                    log.debug(
-                        "Happy-Eyeball Dual-Stack %s:%s",
-                        self.host,
-                        self.port or "443",
-                    )
-
-                    intermediary_addresses = []
-                    for ipv6_entry, ipv4_entry in zip_longest(
-                        ipv6_addresses, ipv4_addresses
-                    ):
-                        if ipv6_entry:
-                            intermediary_addresses.append(ipv6_entry)
-                        if ipv4_entry:
-                            intermediary_addresses.append(ipv4_entry)
-                    ip_addresses = intermediary_addresses
-                else:
-                    log.debug(
-                        "Happy-Eyeball Single-Stack %s:%s",
-                        self.host,
-                        self.port or "443",
-                    )
-
-                challengers = []
-                max_task = (
-                    4 if isinstance(self.happy_eyeballs, bool) else self.happy_eyeballs
-                )
-
-                if heb_timeout is None:
-                    heb_timeout = self.timeout
-
-                override_timeout = (
-                    heb_timeout.connect_timeout
-                    if heb_timeout.connect_timeout is not None
-                    and isinstance(heb_timeout.connect_timeout, (float, int))
-                    else 5.0
-                )
-
-                for ip_address in ip_addresses[:max_task]:
-                    conn_kw = self.conn_kw.copy()
-                    target_solo_addr = (
-                        f"[{ip_address[-1][0]}]"
-                        if ip_address[0] == socket.AF_INET6
-                        else ip_address[-1][0]
-                    )
-                    conn_kw["resolver"] = ResolverDescription.from_url(
-                        f"in-memory://default?hosts={self.host}:{target_solo_addr}"
-                    ).new()
-                    conn_kw["socket_family"] = ip_address[0]
-                    conn_kw["preemptive_quic_cache"] = target_pqc
-
-                    challengers.append(
-                        self.ConnectionCls(
-                            host=actual_host,
-                            port=actual_port,
-                            timeout=override_timeout,
-                            cert_file=self.cert_file,
-                            key_file=self.key_file,
-                            key_password=self.key_password,
-                            cert_reqs=self.cert_reqs,
-                            ca_certs=self.ca_certs,
-                            ca_cert_dir=self.ca_cert_dir,
-                            ca_cert_data=self.ca_cert_data,
-                            assert_hostname=self.assert_hostname,
-                            assert_fingerprint=self.assert_fingerprint,
-                            ssl_version=self.ssl_version,
-                            ssl_minimum_version=self.ssl_minimum_version,
-                            ssl_maximum_version=self.ssl_maximum_version,
-                            cert_data=self.cert_data,
-                            key_data=self.key_data,
-                            **conn_kw,
-                        )
-                    )
-
-                event = threading.Event()
-                winning_task: Future[None] | None = None
-                completed_count: int = 0
-
-                def _happy_eyeballs_completed(t: Future[None]) -> None:
-                    nonlocal winning_task, event, completed_count
-
-                    if winning_task is None and t.exception() is None:
-                        winning_task = t
-                        event.set()
-                        return
-
-                    completed_count += 1
-
-                    if completed_count >= len(challengers):
-                        event.set()
-
-                tpe = ThreadPoolExecutor(max_workers=max_task)
-
-                tasks: list[Future[None]] = []
-
-                for challenger in challengers:
-                    task = tpe.submit(challenger.connect)
-                    task.add_done_callback(_happy_eyeballs_completed)
-
-                    tasks.append(task)
-
-                event.wait()
-
-                for task in tasks:
-                    if task == winning_task:
-                        continue
-
-                    associated_conn = challengers[tasks.index(task)]
-
-                    if task.running():
-                        # dangling TCP conn
-                        try:
-                            if associated_conn._resolver._sock_cursor:
-                                associated_conn._resolver._sock_cursor.shutdown(0)
-                                associated_conn._resolver._sock_cursor.close()
-                            # dangling UDP conn (they usually stuck later in the process)
-                            elif associated_conn.sock:
-                                associated_conn.sock.shutdown(0)
-                                associated_conn.sock.close()
-                                associated_conn.sock = (
-                                    None  # ensure it's not used to send close frames
-                                )
-                        except OSError:
-                            pass  # ignore any error
-                        associated_conn.close()
-                        task.cancel()
-                    else:
-                        associated_conn.close()
-
-                if winning_task is None:
-                    within_delay_msg: str = (
-                        f" within {override_timeout}s" if override_timeout else ""
-                    )
-                    raise NewConnectionError(
-                        challengers[0],
-                        f"Failed to establish a new connection: No suitable address to connect to using Happy Eyeballs algorithm for {actual_host}:{actual_port}{within_delay_msg}",
-                    ) from tasks[0].exception()
-
-                conn = challengers[tasks.index(winning_task)]
-
-                # we have to replace the resolution latency metric
-                if conn.conn_info:
-                    conn.conn_info.resolution_latency = delta_post_resolve
-
-                tpe.shutdown(wait=False)
-            else:
+            if self.happy_eyeballs:
                 log.debug(
-                    "Happy-Eyeball Ineligible %s:%s",
+                    "Attempting Happy-Eyeball %s:%s",
                     self.host,
                     self.port or "443",
                 )
 
-        if conn is None:
-            conn = self.ConnectionCls(
-                host=actual_host,
-                port=actual_port,
-                timeout=self.timeout.connect_timeout,
-                cert_file=self.cert_file,
-                key_file=self.key_file,
-                key_password=self.key_password,
-                cert_reqs=self.cert_reqs,
-                ca_certs=self.ca_certs,
-                ca_cert_dir=self.ca_cert_dir,
-                ca_cert_data=self.ca_cert_data,
-                assert_hostname=self.assert_hostname,
-                assert_fingerprint=self.assert_fingerprint,
-                ssl_version=self.ssl_version,
-                ssl_minimum_version=self.ssl_minimum_version,
-                ssl_maximum_version=self.ssl_maximum_version,
-                cert_data=self.cert_data,
-                key_data=self.key_data,
-                **self.conn_kw,
-            )
+                dt_pre_resolve = datetime.now(tz=timezone.utc)
+                ip_addresses = self._resolver.getaddrinfo(
+                    actual_host,
+                    actual_port,
+                    socket.AF_UNSPEC
+                    if "socket_family" not in self.conn_kw
+                    else self.conn_kw["socket_family"],
+                    socket.SOCK_STREAM,
+                    quic_upgrade_via_dns_rr=True,
+                )
+                delta_post_resolve = datetime.now(tz=timezone.utc) - dt_pre_resolve
 
-        self.pool.put(conn, immediately_unavailable=True)
+                target_pqc = {}
+
+                if (
+                    "preemptive_quic_cache" in self.conn_kw
+                    and self.conn_kw["preemptive_quic_cache"] is not None
+                ):
+                    target_pqc = self.conn_kw["preemptive_quic_cache"]
+
+                if any(_[1] == socket.SOCK_DGRAM for _ in ip_addresses):
+                    if (self.host, self.port) not in target_pqc:
+                        target_pqc[(self.host, self.port)] = (self.host, self.port)
+
+                if len(ip_addresses) > 1:
+                    ipv6_addresses = []
+                    ipv4_addresses = []
+
+                    for ip_address in ip_addresses:
+                        if ip_address[0] == socket.AF_INET6:
+                            ipv6_addresses.append(ip_address)
+                        else:
+                            ipv4_addresses.append(ip_address)
+
+                    if ipv4_addresses and ipv6_addresses:
+                        log.debug(
+                            "Happy-Eyeball Dual-Stack %s:%s",
+                            self.host,
+                            self.port or "443",
+                        )
+
+                        intermediary_addresses = []
+                        for ipv6_entry, ipv4_entry in zip_longest(
+                            ipv6_addresses, ipv4_addresses
+                        ):
+                            if ipv6_entry:
+                                intermediary_addresses.append(ipv6_entry)
+                            if ipv4_entry:
+                                intermediary_addresses.append(ipv4_entry)
+                        ip_addresses = intermediary_addresses
+                    else:
+                        log.debug(
+                            "Happy-Eyeball Single-Stack %s:%s",
+                            self.host,
+                            self.port or "443",
+                        )
+
+                    challengers = []
+                    max_task = (
+                        4
+                        if isinstance(self.happy_eyeballs, bool)
+                        else self.happy_eyeballs
+                    )
+
+                    if heb_timeout is None:
+                        heb_timeout = self.timeout
+
+                    override_timeout = (
+                        heb_timeout.connect_timeout
+                        if heb_timeout.connect_timeout is not None
+                        and isinstance(heb_timeout.connect_timeout, (float, int))
+                        else 5.0
+                    )
+
+                    for ip_address in ip_addresses[:max_task]:
+                        conn_kw = self.conn_kw.copy()
+                        target_solo_addr = (
+                            f"[{ip_address[-1][0]}]"
+                            if ip_address[0] == socket.AF_INET6
+                            else ip_address[-1][0]
+                        )
+                        conn_kw["resolver"] = ResolverDescription.from_url(
+                            f"in-memory://default?hosts={self.host}:{target_solo_addr}"
+                        ).new()
+                        conn_kw["socket_family"] = ip_address[0]
+                        conn_kw["preemptive_quic_cache"] = target_pqc
+
+                        challengers.append(
+                            self.ConnectionCls(
+                                host=actual_host,
+                                port=actual_port,
+                                timeout=override_timeout,
+                                cert_file=self.cert_file,
+                                key_file=self.key_file,
+                                key_password=self.key_password,
+                                cert_reqs=self.cert_reqs,
+                                ca_certs=self.ca_certs,
+                                ca_cert_dir=self.ca_cert_dir,
+                                ca_cert_data=self.ca_cert_data,
+                                assert_hostname=self.assert_hostname,
+                                assert_fingerprint=self.assert_fingerprint,
+                                ssl_version=self.ssl_version,
+                                ssl_minimum_version=self.ssl_minimum_version,
+                                ssl_maximum_version=self.ssl_maximum_version,
+                                cert_data=self.cert_data,
+                                key_data=self.key_data,
+                                **conn_kw,
+                            )
+                        )
+
+                    event = threading.Event()
+                    winning_task: Future[None] | None = None
+                    completed_count: int = 0
+
+                    def _happy_eyeballs_completed(t: Future[None]) -> None:
+                        nonlocal winning_task, event, completed_count
+
+                        if winning_task is None and t.exception() is None:
+                            winning_task = t
+                            event.set()
+                            return
+
+                        completed_count += 1
+
+                        if completed_count >= len(challengers):
+                            event.set()
+
+                    tpe = ThreadPoolExecutor(max_workers=max_task)
+
+                    tasks: list[Future[None]] = []
+
+                    for challenger in challengers:
+                        task = tpe.submit(challenger.connect)
+                        task.add_done_callback(_happy_eyeballs_completed)
+
+                        tasks.append(task)
+
+                    event.wait()
+
+                    for task in tasks:
+                        if task == winning_task:
+                            continue
+
+                        associated_conn = challengers[tasks.index(task)]
+
+                        if task.running():
+                            # dangling TCP conn
+                            try:
+                                if associated_conn._resolver._sock_cursor:
+                                    associated_conn._resolver._sock_cursor.shutdown(0)
+                                    associated_conn._resolver._sock_cursor.close()
+                                # dangling UDP conn (they usually stuck later in the process)
+                                elif associated_conn.sock:
+                                    associated_conn.sock.shutdown(0)
+                                    associated_conn.sock.close()
+                                    associated_conn.sock = None  # ensure it's not used to send close frames
+                            except OSError:
+                                pass  # ignore any error
+                            associated_conn.close()
+                            task.cancel()
+                        else:
+                            associated_conn.close()
+
+                    if winning_task is None:
+                        within_delay_msg: str = (
+                            f" within {override_timeout}s" if override_timeout else ""
+                        )
+                        raise NewConnectionError(
+                            challengers[0],
+                            f"Failed to establish a new connection: No suitable address to connect to using Happy Eyeballs algorithm for {actual_host}:{actual_port}{within_delay_msg}",
+                        ) from tasks[0].exception()
+
+                    conn = challengers[tasks.index(winning_task)]
+
+                    # we have to replace the resolution latency metric
+                    if conn.conn_info:
+                        conn.conn_info.resolution_latency = delta_post_resolve
+
+                    tpe.shutdown(wait=False)
+                else:
+                    log.debug(
+                        "Happy-Eyeball Ineligible %s:%s",
+                        self.host,
+                        self.port or "443",
+                    )
+
+            if conn is None:
+                conn = self.ConnectionCls(
+                    host=actual_host,
+                    port=actual_port,
+                    timeout=self.timeout.connect_timeout,
+                    cert_file=self.cert_file,
+                    key_file=self.key_file,
+                    key_password=self.key_password,
+                    cert_reqs=self.cert_reqs,
+                    ca_certs=self.ca_certs,
+                    ca_cert_dir=self.ca_cert_dir,
+                    ca_cert_data=self.ca_cert_data,
+                    assert_hostname=self.assert_hostname,
+                    assert_fingerprint=self.assert_fingerprint,
+                    ssl_version=self.ssl_version,
+                    ssl_minimum_version=self.ssl_minimum_version,
+                    ssl_maximum_version=self.ssl_maximum_version,
+                    cert_data=self.cert_data,
+                    key_data=self.key_data,
+                    **self.conn_kw,
+                )
+
+            swapper(conn)  # type: ignore[operator]
+
         return conn
 
     def _validate_conn(self, conn: HTTPConnection) -> None:

--- a/src/urllib3/util/traffic_police.py
+++ b/src/urllib3/util/traffic_police.py
@@ -465,6 +465,13 @@ class TrafficPolice(typing.Generic[T]):
                         break
 
             if conn_or_pool is None:
+                # hmm.. this should not exist..
+                # unfortunately Requests has a wierd test case
+                # that set pool_size=0 to force trigger an
+                # exception. don't remove that.
+                if self.maxsize == 0:
+                    raise UnavailableTraffic("No connection available")
+
                 if block is False:
                     time.sleep(0.001)
 

--- a/src/urllib3/util/traffic_police.py
+++ b/src/urllib3/util/traffic_police.py
@@ -34,6 +34,17 @@ class TrafficState(int, Enum):
     SATURATED = 2
 
 
+class ItemPlaceholder:
+    """A dummy placeholder to be inserted for spot reservation into the TrafficPolice."""
+
+    @property
+    def is_saturated(self) -> typing.Literal[True]:
+        return True
+
+    def close(self) -> None:
+        pass
+
+
 class TrafficPoliceFine(Exception): ...
 
 
@@ -328,7 +339,9 @@ class TrafficPolice(typing.Generic[T]):
                         "You must release the previous connection in order to acquire a new one."
                     )
 
-                if self.concurrency is True:
+                if self.concurrency is True and not isinstance(
+                    conn_or_pool, ItemPlaceholder
+                ):
                     self._container[obj_id] = conn_or_pool
 
         if traffic_indicators:
@@ -401,7 +414,9 @@ class TrafficPolice(typing.Generic[T]):
                 # This part is ugly but set for backward compatibility
                 # urllib3 used to fill the bag with 'None'. This simulates that
                 # old and bad behavior.
-                if not self._container and self.maxsize is not None:
+                if (
+                    not self._container or self.bag_only_saturated
+                ) and self.maxsize is not None:
                     if self.maxsize > len(self._registry):
                         return None
 
@@ -450,7 +465,7 @@ class TrafficPolice(typing.Generic[T]):
                         break
 
             if conn_or_pool is None:
-                if block is True:
+                if block is False:
                     time.sleep(0.001)
 
                     if timeout is not None:
@@ -511,6 +526,56 @@ class TrafficPolice(typing.Generic[T]):
             del self._map[key]
             del self._map_types[key]
 
+    @contextlib.contextmanager
+    def locate_or_hold(
+        self,
+        traffic_indicator: MappableTraffic | None = None,
+    ) -> typing.Generator[typing.Callable[[T], None] | T]:
+        """Reserve a spot into the TrafficPolice instance while you construct your conn_or_pool.
+
+        Creating a conn_or_pool may or may not take significant time, in order
+        to avoid having many thread racing for TrafficPolice insert, we must
+        have a way to instantly reserve a spot meanwhile we built what
+        is required.
+        """
+        if traffic_indicator is not None:
+            conn_or_pool = self.locate(traffic_indicator=traffic_indicator)
+
+            if conn_or_pool is not None:
+                yield conn_or_pool
+                return
+
+        traffic_indicators = []
+
+        if traffic_indicator is not None:
+            traffic_indicators.append(traffic_indicator)
+
+        self.put(
+            ItemPlaceholder(),  # type: ignore[arg-type]
+            *traffic_indicators,
+            immediately_unavailable=True,
+        )
+
+        swap_made: bool = False
+
+        def inner_swap(swappable_conn_or_pool: T) -> None:
+            nonlocal swap_made
+
+            swap_made = True
+
+            with self._lock:
+                self.kill_cursor()
+                self.put(
+                    swappable_conn_or_pool,
+                    *traffic_indicators,
+                    immediately_unavailable=True,
+                )
+
+        yield inner_swap
+
+        if not swap_made:
+            self.kill_cursor()
+
     def locate(
         self,
         traffic_indicator: MappableTraffic,
@@ -521,35 +586,51 @@ class TrafficPolice(typing.Generic[T]):
         wait_clock = 0.0
         conn_or_pool: T | None
 
-        if not isinstance(traffic_indicator, type):
-            key: PoolKey | int = (
-                traffic_indicator
-                if isinstance(traffic_indicator, tuple)
-                else id(traffic_indicator)
-            )
-
+        while True:
             with self._lock:
-                if key not in self._map:
-                    # we must fallback on beacon (sub police officer if any)
-                    conn_or_pool, obj_id = None, None
+                if not isinstance(traffic_indicator, type):
+                    key: PoolKey | int = (
+                        traffic_indicator
+                        if isinstance(traffic_indicator, tuple)
+                        else id(traffic_indicator)
+                    )
+
+                    if key not in self._map:
+                        # we must fallback on beacon (sub police officer if any)
+                        conn_or_pool, obj_id = None, None
+                    else:
+                        conn_or_pool = self._map[key]
+                        obj_id = id(conn_or_pool)
                 else:
-                    conn_or_pool = self._map[key]
-                    obj_id = id(conn_or_pool)
-        else:
-            raise ValueError("unsupported traffic_indicator")
+                    raise ValueError("unsupported traffic_indicator")
 
-        if conn_or_pool is None and obj_id is None:
-            with self._lock:
-                for r_obj_id, r_conn_or_pool in self._registry.items():
-                    if hasattr(r_conn_or_pool, "pool") and isinstance(
-                        r_conn_or_pool.pool, TrafficPolice
-                    ):
-                        if r_conn_or_pool.pool.beacon(traffic_indicator):
-                            conn_or_pool, obj_id = r_conn_or_pool, r_obj_id
-                            break
+                if (
+                    conn_or_pool is None
+                    and obj_id is None
+                    and not isinstance(traffic_indicator, tuple)
+                ):
+                    for r_obj_id, r_conn_or_pool in self._registry.items():
+                        if hasattr(r_conn_or_pool, "pool") and isinstance(
+                            r_conn_or_pool.pool, TrafficPolice
+                        ):
+                            if r_conn_or_pool.pool.beacon(traffic_indicator):
+                                conn_or_pool, obj_id = r_conn_or_pool, r_obj_id
+                                break
 
-        if conn_or_pool is None or obj_id is None:
-            return None
+                if conn_or_pool is None or obj_id is None:
+                    return None
+
+                if not isinstance(conn_or_pool, ItemPlaceholder):
+                    break
+
+            time.sleep(0.001)
+
+            if timeout is not None:
+                wait_clock += 0.001
+                if wait_clock >= timeout:
+                    raise TimeoutError(
+                        "Timed out while waiting for conn_or_pool to become available"
+                    )
 
         cursor_key = current_thread().name
 


### PR DESCRIPTION
2.12.914 (2024-03-30)
=====================

- Fixed a rare thread safety issue when the size of PoolManager is inferior to the thread count. An edge case permitted
  the creation of two ``ConnectionPool`` for the same ``PoolKey``.
- Changed the default behavior of threads management to not raise an exception if the thread count is greater than
  the pool size. Making it that way better align with upstream, our initial decision revealed itself to cause
  confusions for some of our users. No longer will urllib3-future raise ``OverwhelmedTraffic`` in default configuration.
- Fixed an error when ``happy_eyeballs=True`` is set with more tasks or threads than the pool size.

