### PR TITLE
Release 2.12.917

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.12.917 (2024-04-10)
+=====================
+
+- Improve keepalive handling for connections. We know listen for an incoming pong frame after emitting a ping frame.
+  Moreover we ensure better strictness around set ``keepalive_delay`` and consider every connection dropped after set delay.
+
 2.12.916 (2024-04-09)
 =====================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 2.12.917 (2024-04-10)
 =====================
 
-- Improve keepalive handling for connections. We know listen for an incoming pong frame after emitting a ping frame.
+- Improve keepalive handling for connections. We now listen for an incoming pong frame after emitting a ping frame.
   Moreover we ensure better strictness around set ``keepalive_delay`` and consider every connection dropped after set delay.
 
 2.12.916 (2024-04-09)

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import socket
+import time
 import typing
 import warnings
 from datetime import datetime, timedelta
@@ -286,6 +287,13 @@ class AsyncHTTPConnection(AsyncHfaceBackend):
             return False
         if self._promises or self._pending_responses:
             return True
+        # consider the conn dead after our keep alive delay passed.
+        if (
+            self._keepalive_delay is not None
+            and self.connected_at is not None
+            and time.monotonic() - self.connected_at >= self._keepalive_delay
+        ):
+            return False
         return self._protocol is not None and self._protocol.has_expired() is False
 
     @property

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -200,6 +200,7 @@ async def idle_conn_watch_task(
                                 if idle_delay >= keepalive_idle_window:
                                     pool.num_pings += 1
                                     await conn.ping()
+                                    await conn.peek_and_react(expect_frame=True)
             except AttributeError:
                 return
     except (ReferenceError, asyncio.CancelledError):

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.12.916"
+__version__ = "2.12.917"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -750,7 +750,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         bck_timeout = self.sock.gettimeout()
         # either there is data ready for us, or there's nothing and we stop waiting
         # almost instantaneously.
-        self.sock.settimeout(0.001 if expect_frame is False else 0.1)
+        self.sock.settimeout(0.001 if not expect_frame else 0.1)
 
         try:
             peek_data = await self.sock.recv(self.blocksize)

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -732,7 +732,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         self._protocol = None
         self._protocol_factory = None
 
-    async def peek_and_react(self) -> bool:
+    async def peek_and_react(self, expect_frame: bool = False) -> bool:
         """This method should be called by a thread using TrafficPolice when it is idle.
         Multiplexed protocols can receive incoming data unsolicited. Like when using QUIC
         or when reaching a WebSocket.
@@ -750,7 +750,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         bck_timeout = self.sock.gettimeout()
         # either there is data ready for us, or there's nothing and we stop waiting
         # almost instantaneously.
-        self.sock.settimeout(0.001)
+        self.sock.settimeout(0.001 if expect_frame is False else 0.1)
 
         try:
             peek_data = await self.sock.recv(self.blocksize)

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -788,7 +788,7 @@ class HfaceBackend(BaseBackend):
         self._protocol = None
         self._protocol_factory = None
 
-    def peek_and_react(self) -> bool:
+    def peek_and_react(self, expect_frame: bool = False) -> bool:
         """This method should be called by a thread using TrafficPolice when it is idle.
         Multiplexed protocols can receive incoming data unsolicited. Like when using QUIC
         or when reaching a WebSocket.
@@ -805,7 +805,7 @@ class HfaceBackend(BaseBackend):
 
         bck_timeout = self.sock.gettimeout()
 
-        self.sock.settimeout(0.001)
+        self.sock.settimeout(0.001 if not expect_frame else 0.1)
 
         try:
             peek_data = self.sock.recv(self.blocksize)

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import socket
+import time
 import typing
 import warnings
 from datetime import datetime, timedelta
@@ -297,6 +298,13 @@ class HTTPConnection(HfaceBackend):
         # with GoAway for example.
         if self._promises or self._pending_responses:
             return True
+        # consider the conn dead after our keep alive delay passed.
+        if (
+            self._keepalive_delay is not None
+            and self.connected_at is not None
+            and time.monotonic() - self.connected_at >= self._keepalive_delay
+        ):
+            return False
         return self._protocol is not None and self._protocol.has_expired() is False
 
     @property

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -213,6 +213,7 @@ def idle_conn_watch_task(
                                 if idle_delay >= keepalive_idle_window:
                                     pool.num_pings += 1
                                     conn.ping()
+                                    conn.peek_and_react(expect_frame=True)
             except AttributeError:
                 return
     except ReferenceError:


### PR DESCRIPTION
2.12.917 (2024-04-10)
=====================

- Improve keepalive handling for connections. We now listen for an incoming pong frame after emitting a ping frame.
  Moreover we ensure better strictness around set ``keepalive_delay`` and consider every connection dropped after set delay. (Close https://github.com/jawah/niquests/issues/240)

