### PR TITLE
Fix http3 idle timeout is terminated

### DIFF
--- a/.github/workflows/ci-dead-things.yml
+++ b/.github/workflows/ci-dead-things.yml
@@ -38,23 +38,3 @@ jobs:
 
       - name: "Run against Python 3.7 built with OpenSSL 1.0.2q"
         run: ./ci/run_legacy_openssl.sh
-
-  dead-pip:
-    name: Ensure pip <21.2.4
-    runs-on: ubuntu-20.04
-    timeout-minutes: 5
-
-    steps:
-      - name: "Checkout repository"
-        uses: "actions/checkout@d632683dd7b4114ad314bca15554477dd762a938"
-
-      - name: "Setup Python"
-        uses: "actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55"
-        with:
-          python-version: "3.7"
-
-      - name: "Enforce pip 20.x"
-        run: python -m pip install "pip<21"
-
-      - name: "Ensure that urllib3-future can be installed"
-        run: python -m pip install .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,7 @@ jobs:
         os:
           - macos-13
           - windows-2022
-          - ubuntu-20.04  # OpenSSL 1.1.1
-          - ubuntu-22.04  # OpenSSL 3.0
+          - ubuntu-22.04
         nox-session: ['']
         include:
           - experimental: false
@@ -66,11 +65,6 @@ jobs:
             nox-session: test_ssl_large_resources-3.13
             python-version: "3.13"
             os: windows-2022
-            experimental: false
-          - traefik-server: false
-            nox-session: test_ssl_large_resources-3.7
-            python-version: "3.7"
-            os: ubuntu-20.04
             experimental: false
           - traefik-server: false
             nox-session: test_ssl_large_resources-3.9
@@ -122,11 +116,6 @@ jobs:
             os: ubuntu-22.04
             experimental: false
             nox-session: test_brotlipy
-          # Test CPython with a broken hostname_checks_common_name (the fix is in 3.9.3)
-          - python-version: "3.9.2"
-            os: ubuntu-20.04  # CPython 3.9.2 is not available for ubuntu-22.04.
-            experimental: false
-            nox-session: test-3.9
         exclude:
           # Ubuntu 22.04 comes with OpenSSL 3.0, so only CPython 3.9+ is compatible with it
           # https://github.com/python/cpython/issues/83001
@@ -136,7 +125,7 @@ jobs:
             os: ubuntu-22.04
 
     runs-on: ${{ matrix.os }}
-    name: ${{ fromJson('{"macos-13":"macOS","windows-2022":"Windows","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)","ubuntu-22.04":"Ubuntu 22 (OpenSSL 3+)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session }}
+    name: ${{ fromJson('{"macos-13":"macOS","windows-2022":"Windows","ubuntu-22.04":"Ubuntu"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session }}
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 60
     steps:
@@ -145,7 +134,7 @@ jobs:
 
       - name: "Traefik: Prerequisites - Colima (MacOS)"
         if: ${{ matrix.traefik-server && contains(matrix.os, 'mac') }}
-        uses: douglascamata/setup-docker-macos-action@f2b307ddc57e8b9d3f9761f3cafa8883b2cdffd4
+        uses: douglascamata/setup-docker-macos-action@e2e1549b0c687dfa1ba2805a97d7855461e70fbd
         with:
           colima-network-address: true
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.12.918 (2024-04-19)
+=====================
+
+- Fixed http3 QUIC idle timeout did not force the connection to be dropped by the pool.
+
 2.12.917 (2024-04-10)
 =====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.12.917"
+__version__ = "2.12.918"

--- a/src/urllib3/contrib/hface/protocols/http3/_qh3.py
+++ b/src/urllib3/contrib/hface/protocols/http3/_qh3.py
@@ -156,6 +156,7 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
                 and self._quic._close_event is not None
             ):
                 self._events.extend(self._map_quic_event(self._quic._close_event))
+                self._terminated = True
         return self._terminated or self._goaway_to_honor
 
     @property


### PR DESCRIPTION
2.12.918 (2024-04-19)
=====================

- Fixed http3 QUIC idle timeout did not force the connection to be dropped by the pool.

