### PR TITLE
Release 2.12.920

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,11 @@
-2.12.920 (2024-05-03)
+2.12.920 (2024-05-04)
 =====================
 
 - Removed the persisting session ticket after first QUIC handshake. In a effort to be stricter with security and align
   with our TLS 1.2 and 1.3 ``OP_NO_TICKET`` parameter.
 - Improved performance in our event unpacking logic inside state machine protocols. (micro-scale improvements)
 - Improved our RDATA (DNS) parsing for HTTPS records toward our ECH (Encrypted Client Hello) support coming soon.
+- Fixed a rare HTTP/2 compatibility issue with servers that don't acknowledge our settings (missing ACK frame).
 
 2.12.919 (2024-04-28)
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.12.920 (2024-05-03)
+=====================
+
+- Removed the persisting session ticket after first QUIC handshake. In a effort to be stricter with security and align
+  with our TLS 1.2 and 1.3 ``OP_NO_TICKET`` parameter.
+- Improved performance in our event unpacking logic inside state machine protocols. (micro-scale improvements)
+- Improved our RDATA (DNS) parsing for HTTPS records toward our ECH (Encrypted Client Hello) support coming soon.
+
 2.12.919 (2024-04-28)
 =====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.12.919"
+__version__ = "2.12.920"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -124,7 +124,6 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         self.__custom_tls_settings: QuicTLSConfig | None = None
         self.__alt_authority: tuple[str, int] | None = None
         self.__origin_port: int | None = None
-        self.__session_ticket: typing.Any | None = None
 
         # automatic upgrade shield against errors!
         self._max_tolerable_delay_for_upgrade: float | None = None
@@ -346,7 +345,6 @@ class AsyncHfaceBackend(AsyncBaseBackend):
             cadata=ca_cert_data.encode()
             if isinstance(ca_cert_data, str)
             else ca_cert_data,
-            session_ticket=self.__session_ticket,  # going to be set after first successful quic handshake
             # mTLS start
             certfile=cert_file,
             keyfile=key_file,
@@ -632,9 +630,6 @@ class AsyncHfaceBackend(AsyncBaseBackend):
             self.conn_info.issuer_certificate_der = self._protocol.getissuercert(
                 binary_form=True
             )
-
-            # save the quic ticket for session resumption
-            self.__session_ticket = self._protocol.session_ticket
 
         if (
             self.conn_info.certificate_der

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -144,7 +144,6 @@ class HfaceBackend(BaseBackend):
         self.__custom_tls_settings: QuicTLSConfig | None = None
         self.__alt_authority: tuple[str, int] | None = None
         self.__origin_port: int | None = None
-        self.__session_ticket: typing.Any | None = None
 
         # automatic upgrade shield against errors!
         self._max_tolerable_delay_for_upgrade: float | None = None
@@ -368,7 +367,6 @@ class HfaceBackend(BaseBackend):
             cadata=ca_cert_data.encode()
             if isinstance(ca_cert_data, str)
             else ca_cert_data,
-            session_ticket=self.__session_ticket,  # going to be set after first successful quic handshake
             # mTLS start
             certfile=cert_file,
             keyfile=key_file,
@@ -688,9 +686,6 @@ class HfaceBackend(BaseBackend):
             self.conn_info.issuer_certificate_der = self._protocol.getissuercert(
                 binary_form=True
             )
-
-            # save the quic ticket for session resumption
-            self.__session_ticket = self._protocol.session_ticket
 
         if (
             self.conn_info.certificate_der

--- a/src/urllib3/contrib/hface/_stream_matrix.py
+++ b/src/urllib3/contrib/hface/_stream_matrix.py
@@ -90,9 +90,9 @@ class StreamMatrix:
         if self._count == 0:
             return None
 
-        have_global_event: bool = None in self._matrix and len(self._matrix[None]) > 0
+        have_global_event: bool = None in self._matrix and bool(self._matrix[None])
 
-        if stream_id is None and self.streams and self.count(self.streams[0]) > 0:
+        if stream_id is None and self.streams and self.has(self.streams[0]):
             stream_id = self.streams[0]
 
         if (
@@ -113,7 +113,7 @@ class StreamMatrix:
         if ev is not None:
             self._count -= 1
 
-            if stream_id is not None and len(self._matrix[stream_id]) == 0:
+            if stream_id is not None and not self._matrix[stream_id]:
                 del self._matrix[stream_id]
                 self._streams = None
 

--- a/src/urllib3/contrib/hface/protocols/http1/_h11.py
+++ b/src/urllib3/contrib/hface/protocols/http1/_h11.py
@@ -294,7 +294,15 @@ class HTTP1ProtocolHyperImpl(HTTP1Protocol):
                     )
                 )
             elif ev_type is h11.Data:
-                a(DataReceived(self._current_stream_id, bytes(h11_event.data)))  # type: ignore[union-attr]
+                # officially h11 typed data as "bytes"
+                # but we... found that it store bytearray sometime.
+                payload = h11_event.data  # type: ignore[union-attr]
+                a(
+                    DataReceived(
+                        self._current_stream_id,
+                        bytes(payload) if payload.__class__ is bytearray else payload,
+                    )
+                )
             elif ev_type is h11.EndOfMessage:
                 # HTTP/2 and HTTP/3 send END_STREAM flag with HEADERS and DATA frames.
                 # We emulate similar behavior for HTTP/1.

--- a/src/urllib3/contrib/hface/protocols/http1/_h11.py
+++ b/src/urllib3/contrib/hface/protocols/http1/_h11.py
@@ -271,33 +271,37 @@ class HTTP1ProtocolHyperImpl(HTTP1Protocol):
             except h11.RemoteProtocolError as e:
                 a(self._connection_terminated(e.error_status_hint, str(e)))
                 break
+
+            ev_type = h11_event.__class__
+
             if h11_event is h11.NEED_DATA or h11_event is h11.PAUSED:
                 if h11.MUST_CLOSE == self._connection.their_state:
                     a(self._connection_terminated())
                 else:
                     break
-            elif isinstance(h11_event, h11.Response):
+            elif ev_type is h11.Response:
                 a(
                     HeadersReceived(
-                        self._current_stream_id, headers_from_response(h11_event)
+                        self._current_stream_id,
+                        headers_from_response(h11_event),  # type: ignore[arg-type]
                     )
                 )
-            elif isinstance(h11_event, h11.InformationalResponse):
+            elif ev_type is h11.InformationalResponse:
                 a(
                     EarlyHeadersReceived(
                         stream_id=self._current_stream_id,
-                        headers=headers_from_response(h11_event),
+                        headers=headers_from_response(h11_event),  # type: ignore[arg-type]
                     )
                 )
-            elif isinstance(h11_event, h11.Data):
-                a(DataReceived(self._current_stream_id, bytes(h11_event.data)))
-            elif isinstance(h11_event, h11.EndOfMessage):
+            elif ev_type is h11.Data:
+                a(DataReceived(self._current_stream_id, bytes(h11_event.data)))  # type: ignore[union-attr]
+            elif ev_type is h11.EndOfMessage:
                 # HTTP/2 and HTTP/3 send END_STREAM flag with HEADERS and DATA frames.
                 # We emulate similar behavior for HTTP/1.
-                if h11_event.headers:
+                if h11_event.headers:  # type: ignore[union-attr]
                     last_event: HeadersReceived | DataReceived = HeadersReceived(
                         self._current_stream_id,
-                        h11_event.headers,
+                        h11_event.headers,  # type: ignore[union-attr]
                         self._connection.their_state != h11.MIGHT_SWITCH_PROTOCOL,  # type: ignore[attr-defined]
                     )
                 else:
@@ -308,7 +312,7 @@ class HTTP1ProtocolHyperImpl(HTTP1Protocol):
                     )
                 a(last_event)
                 self._maybe_start_next_cycle()
-            elif isinstance(h11_event, h11.ConnectionClosed):
+            elif ev_type is h11.ConnectionClosed:
                 a(self._connection_terminated())
 
     def _connection_terminated(

--- a/src/urllib3/contrib/hface/protocols/http2/_h2.py
+++ b/src/urllib3/contrib/hface/protocols/http2/_h2.py
@@ -248,7 +248,10 @@ class HTTP2ProtocolHyperImpl(HTTP2Protocol):
                 else:
                     self._terminated = True
                     yield ConnectionTerminated(e.error_code, None)
-            elif ev_type is jh2.events.SettingsAcknowledged:
+            elif ev_type in {
+                jh2.events.SettingsAcknowledged,
+                jh2.events.RemoteSettingsChanged,
+            }:
                 yield HandshakeCompleted(alpn_protocol="h2")
 
     def connection_lost(self) -> None:

--- a/src/urllib3/contrib/hface/protocols/http2/_h2.py
+++ b/src/urllib3/contrib/hface/protocols/http2/_h2.py
@@ -109,6 +109,12 @@ class _PatchedH2Connection(jh2.connection.H2Connection):  # type: ignore[misc]
         return [], events
 
 
+HEADER_OR_TRAILER_TYPE_SET = {
+    jh2.events.ResponseReceived,
+    jh2.events.TrailersReceived,
+}
+
+
 class HTTP2ProtocolHyperImpl(HTTP2Protocol):
     implementation: str = "h2"
 
@@ -198,20 +204,16 @@ class HTTP2ProtocolHyperImpl(HTTP2Protocol):
 
     def _map_events(self, h2_events: list[jh2.events.Event]) -> Iterator[Event]:
         for e in h2_events:
-            if isinstance(
-                e,
-                (
-                    jh2.events.ResponseReceived,
-                    jh2.events.TrailersReceived,
-                ),
-            ):
+            ev_type = e.__class__
+
+            if ev_type in HEADER_OR_TRAILER_TYPE_SET:
                 end_stream = e.stream_ended is not None
                 if end_stream:
                     self._open_stream_count -= 1
                     stream = self._connection.streams.pop(e.stream_id)
                     self._connection._closed_streams[e.stream_id] = stream.closed_by
                 yield HeadersReceived(e.stream_id, e.headers, end_stream=end_stream)
-            elif isinstance(e, jh2.events.DataReceived):
+            elif ev_type is jh2.events.DataReceived:
                 end_stream = e.stream_ended is not None
                 if end_stream:
                     self._open_stream_count -= 1
@@ -221,19 +223,19 @@ class HTTP2ProtocolHyperImpl(HTTP2Protocol):
                     e.flow_controlled_length, e.stream_id
                 )
                 yield DataReceived(e.stream_id, e.data, end_stream=end_stream)
-            elif isinstance(e, jh2.events.InformationalResponseReceived):
+            elif ev_type is jh2.events.InformationalResponseReceived:
                 yield EarlyHeadersReceived(
                     e.stream_id,
                     e.headers,
                 )
-            elif isinstance(e, jh2.events.StreamReset):
+            elif ev_type is jh2.events.StreamReset:
                 self._open_stream_count -= 1
                 # event StreamEnded may occur before StreamReset
                 if e.stream_id in self._connection.streams:
                     stream = self._connection.streams.pop(e.stream_id)
                     self._connection._closed_streams[e.stream_id] = stream.closed_by
                 yield StreamResetReceived(e.stream_id, e.error_code)
-            elif isinstance(e, jh2.events.ConnectionTerminated):
+            elif ev_type is jh2.events.ConnectionTerminated:
                 # ConnectionTerminated from h2 means that GOAWAY was received.
                 # A server can send GOAWAY for graceful shutdown, where clients
                 # do not open new streams, but inflight requests can be completed.
@@ -246,7 +248,7 @@ class HTTP2ProtocolHyperImpl(HTTP2Protocol):
                 else:
                     self._terminated = True
                     yield ConnectionTerminated(e.error_code, None)
-            elif isinstance(e, jh2.events.SettingsAcknowledged):
+            elif ev_type is jh2.events.SettingsAcknowledged:
                 yield HandshakeCompleted(alpn_protocol="h2")
 
     def connection_lost(self) -> None:

--- a/src/urllib3/contrib/resolver/_async/doh/_urllib3.py
+++ b/src/urllib3/contrib/resolver/_async/doh/_urllib3.py
@@ -524,9 +524,12 @@ class HTTPSResolver(AsyncBaseResolver):
 
                 for record in dns_resp.records:
                     if record[0] == SupportedQueryType.HTTPS:
-                        if "h3" in record[-1]:
+                        assert isinstance(record[-1], dict)
+                        if "h3" in record[-1]["alpn"]:
                             remote_preemptive_quic_rr = True
                         continue
+
+                    assert not isinstance(record[-1], dict)
 
                     inet_type = (
                         socket.AF_INET

--- a/src/urllib3/contrib/resolver/_async/doq/_qh3.py
+++ b/src/urllib3/contrib/resolver/_async/doq/_qh3.py
@@ -379,9 +379,12 @@ class QUICResolver(PlainResolver):
 
             for record in response.records:
                 if record[0] == SupportedQueryType.HTTPS:
-                    if "h3" in record[-1]:
+                    assert isinstance(record[-1], dict)
+                    if "h3" in record[-1]["alpn"]:
                         remote_preemptive_quic_rr = True
                     continue
+
+                assert not isinstance(record[-1], dict)
 
                 inet_type = (
                     socket.AF_INET

--- a/src/urllib3/contrib/resolver/_async/dou/_socket.py
+++ b/src/urllib3/contrib/resolver/_async/dou/_socket.py
@@ -293,9 +293,12 @@ class PlainResolver(AsyncBaseResolver):
 
             for record in response.records:
                 if record[0] == SupportedQueryType.HTTPS:
-                    if "h3" in record[-1]:
+                    assert isinstance(record[-1], dict)
+                    if "h3" in record[-1]["alpn"]:
                         remote_preemptive_quic_rr = True
                     continue
+
+                assert not isinstance(record[-1], dict)
 
                 inet_type = (
                     socket.AF_INET

--- a/src/urllib3/contrib/resolver/doq/_qh3.py
+++ b/src/urllib3/contrib/resolver/doq/_qh3.py
@@ -347,9 +347,12 @@ class QUICResolver(PlainResolver):
 
             for record in response.records:
                 if record[0] == SupportedQueryType.HTTPS:
-                    if "h3" in record[-1]:
+                    assert isinstance(record[-1], dict)
+                    if "h3" in record[-1]["alpn"]:
                         remote_preemptive_quic_rr = True
                     continue
+
+                assert not isinstance(record[-1], dict)
 
                 inet_type = (
                     socket.AF_INET

--- a/src/urllib3/contrib/resolver/dou/_socket.py
+++ b/src/urllib3/contrib/resolver/dou/_socket.py
@@ -271,9 +271,12 @@ class PlainResolver(BaseResolver):
 
             for record in response.records:
                 if record[0] == SupportedQueryType.HTTPS:
-                    if "h3" in record[-1]:
+                    assert isinstance(record[-1], dict)
+                    if "h3" in record[-1]["alpn"]:
                         remote_preemptive_quic_rr = True
                     continue
+
+                assert not isinstance(record[-1], dict)
 
                 inet_type = (
                     socket.AF_INET

--- a/src/urllib3/contrib/resolver/utils.py
+++ b/src/urllib3/contrib/resolver/utils.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 
+import base64
 import binascii
 import socket
 import struct
+import typing
+
+if typing.TYPE_CHECKING:
+
+    class HttpsRecord(typing.TypedDict):
+        priority: int
+        target: str
+        alpn: list[str]
+        ipv4hint: list[str]
+        ipv6hint: list[str]
+        echconfig: list[str]
 
 
 def inet4_ntoa(address: bytes) -> str:
@@ -202,6 +214,100 @@ def rfc1035_pack(message: bytes) -> bytes:
     return struct.pack("!H", len(message)) + message
 
 
+def read_name(data: bytes, offset: int) -> tuple[str, int]:
+    """
+    Read a DNS‐encoded name (with compression pointers) from data[offset:].
+    Returns (name, new_offset).
+    """
+    labels = []
+    while True:
+        length = data[offset]
+        # compression pointer?
+        if length & 0xC0 == 0xC0:
+            pointer = struct.unpack_from("!H", data, offset)[0] & 0x3FFF
+            subname, _ = read_name(data, pointer)
+            labels.append(subname)
+            offset += 2
+            break
+        if length == 0:
+            offset += 1
+            break
+        offset += 1
+        labels.append(data[offset : offset + length].decode())
+        offset += length
+    return ".".join(labels), offset
+
+
+def parse_echconfigs(buf: bytes) -> list[str]:
+    """
+    buf is the raw bytes of the ECHConfig vector:
+      - 2-byte total length, then for each:
+        - 2-byte cfg length + that many bytes of cfg
+    We return a list of Base64 strings (one per config).
+    """
+    if len(buf) < 2:
+        return []
+    off = 2
+    total = struct.unpack_from("!H", buf, 0)[0]
+    end = 2 + total
+    out = []
+    while off + 2 <= end:
+        cfg_len = struct.unpack_from("!H", buf, off)[0]
+        off += 2
+        cfg = buf[off : off + cfg_len]
+        off += cfg_len
+        out.append(base64.b64encode(cfg).decode())
+    return out
+
+
+def parse_https_rdata(rdata: bytes) -> HttpsRecord:
+    """
+    Parse the RDATA of an SVCB/HTTPS record.
+    Returns a dict with keys: priority, target, alpn, ipv4hint, ipv6hint, echconfig.
+    """
+    off = 0
+    priority = struct.unpack_from("!H", rdata, off)[0]
+    off += 2
+
+    target, off = read_name(rdata, off)
+
+    # pull out all the key/value params
+    params = {}
+    while off + 4 <= len(rdata):
+        key, length = struct.unpack_from("!HH", rdata, off)
+        off += 4
+        params[key] = rdata[off : off + length]
+        off += length
+
+    # decode ALPN (key=1), IPv4 (4), IPv6 (6), ECHConfig (5)
+    def parse_alpn(buf: bytes) -> list[str]:
+        out = []
+        i: int = 0
+        while i < len(buf):
+            ln = buf[i]
+            out.append(buf[i + 1 : i + 1 + ln].decode())
+            i += 1 + ln
+        return out
+
+    alpn: list[str] = parse_alpn(params.get(1, b""))
+    ipv4 = [
+        inet4_ntoa(params[4][i : i + 4]) for i in range(0, len(params.get(4, b"")), 4)
+    ]
+    ipv6 = [
+        inet6_ntoa(params[6][i : i + 16]) for i in range(0, len(params.get(6, b"")), 16)
+    ]
+    echconfs = parse_echconfigs(params.get(5, b""))
+
+    return {
+        "priority": priority,
+        "target": target or ".",  # empty name → root
+        "alpn": alpn,
+        "ipv4hint": ipv4,
+        "ipv6hint": ipv6,
+        "echconfig": echconfs,
+    }
+
+
 __all__ = (
     "inet4_ntoa",
     "inet6_ntoa",
@@ -212,4 +318,5 @@ __all__ = (
     "rfc1035_pack",
     "rfc1035_unpack",
     "rfc1035_should_read",
+    "parse_https_rdata",
 )

--- a/src/urllib3/util/_async/traffic_police.py
+++ b/src/urllib3/util/_async/traffic_police.py
@@ -298,7 +298,7 @@ class AsyncTrafficPolice(typing.Generic[T]):
                 "Call release prior to calling this method."
             )
 
-        if len(self._container) > 0:
+        if self._container:
             idle_targets: list[tuple[int, T]] = []
 
             for cur_obj_id, cur_conn_or_pool in self._container.items():
@@ -332,7 +332,7 @@ class AsyncTrafficPolice(typing.Generic[T]):
         if self._shutdown:
             await self.kill_cursor()
             # Cleanup was completed, no need to act like this anymore.
-            if len(self._registry) == 0:
+            if not self._registry:
                 self._shutdown = False
             return
 

--- a/test/contrib/test_resolver.py
+++ b/test/contrib/test_resolver.py
@@ -784,3 +784,39 @@ def test_recycle_in_memory_with_mock() -> None:
     assert "localhost" in rr._hosts  # type: ignore[attr-defined]
     assert "local" in rr._hosts  # type: ignore[attr-defined]
     assert rr._maxsize == 8  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    "rdata, expected",
+    [
+        (
+            b"\x00\x01\x00\x00\x01\x00\x06\x02h3\x02h2\x00\x04\x00\x08"
+            b"\x01\x01\x01\x01\x01\x00\x00\x01\x00\x06\x00 &\x06G\x00G"
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11&\x06G\x00G"
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10\x01",
+            {
+                "priority": 1,
+                "target": ".",
+                "alpn": ["h3", "h2"],
+                "ipv4hint": ["1.1.1.1", "1.0.0.1"],
+                "ipv6hint": ["2606:4700:4700::1111", "2606:4700:4700::1001"],
+                "echconfig": [],
+            },
+        ),
+        (
+            b"\x00\x01\x00\x00\x01\x00\x06\x02h3\x02h2\x00\x04\x00\x08\xbcr`\x02\xbcra\x02\x00\x05\x00G\x00E\xfe\r\x00A\xa7\x00 \x00 <\x10 \xae\xf8\xd0\x02hqi\xfb)ff|\xeao\xe6\xdfW+\xcb\x81\xa1bs6\xa0AHDU\x00\x04\x00\x01\x00\x01\x00\x12cloudflare-ech.com\x00\x00\x00\x06\x00 *\x06\x98\xc11 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x02*\x06\x98\xc11!\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02",
+            {
+                "priority": 1,
+                "target": ".",
+                "alpn": ["h3", "h2"],
+                "ipv4hint": ["188.114.96.2", "188.114.97.2"],
+                "ipv6hint": ["2a06:98c1:3120::2", "2a06:98c1:3121::2"],
+                "echconfig": [
+                    "AEGnACAAIDwQIK740AJocWn7KWZmfOpv5t9XK8uBoWJzNqBBSERVAAQAAQABABJjbG91ZGZsYXJlLWVjaC5jb20AAA=="
+                ],
+            },
+        ),
+    ],
+)
+def test_parse_rdata(rdata: bytes, expected: dict[str, list[str] | int | str]) -> None:
+    pass


### PR DESCRIPTION
2.12.920 (2024-05-04)
=====================

- Removed the persisting session ticket after first QUIC handshake. In a effort to be stricter with security and align
  with our TLS 1.2 and 1.3 ``OP_NO_TICKET`` parameter.
- Improved performance in our event unpacking logic inside state machine protocols. (micro-scale improvements)
- Improved our RDATA (DNS) parsing for HTTPS records toward our ECH (Encrypted Client Hello) support coming soon.
- Fixed a rare HTTP/2 compatibility issue with servers that don't acknowledge our settings (missing ACK frame).
