### PR TITLE
Release 2.12.921

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,8 @@ source =
     urllib3
 # Needed for Python 3.11 and lower
 disable_warnings = no-sysmon
+parallel = True
+branch = True
 
 [paths]
 source =

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,8 +3,6 @@ source =
     urllib3
 # Needed for Python 3.11 and lower
 disable_warnings = no-sysmon
-parallel = True
-branch = True
 
 [paths]
 source =

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
+      - name: Set up Docker Buildx
+        if: ${{ matrix.traefik-server && contains(matrix.os, 'windows') }}
+        uses: docker/setup-buildx-action@v3
+
       - name: "Install dependencies"
         run: python -m pip install --upgrade pip setuptools nox
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: ${{ fromJson('{"macos-13":"macOS","windows-2022":"Windows","ubuntu-22.04":"Ubuntu"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session }}
     continue-on-error: ${{ matrix.experimental }}
-    timeout-minutes: 60
+    timeout-minutes: 25
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@d632683dd7b4114ad314bca15554477dd762a938"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,10 +148,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
-      - name: Set up Docker Buildx
-        if: ${{ matrix.traefik-server && contains(matrix.os, 'windows') }}
-        uses: docker/setup-buildx-action@v3
-
       - name: "Install dependencies"
         run: python -m pip install --upgrade pip setuptools nox
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-2.12.921 (2024-05-16)
+2.12.921 (2024-05-17)
 =====================
 
 - Extended in-memory mTLS loading support to every major platforms.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Extended in-memory mTLS loading support to every major platforms.
 - Added support for built-in zstandard starting from Python 3.14 onward.
 - Improved test suite execution speed using pytest-xdist.
+- Fixed a rare edge case where the CAStore would be empty after upgrade to a HTTP/3 connection when no CA bundle are given before.
+  This error occurred due to load_default_certs not being applied for the QUIC connection.
 
 2.12.920 (2024-05-04)
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-2.12.921 (2024-05-15)
+2.12.921 (2024-05-16)
 =====================
 
 - Extended in-memory mTLS loading support to every major platforms.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.12.921 (2024-05-15)
+=====================
+
+- Extended in-memory mTLS loading support to every major platforms.
+- Added support for built-in zstandard starting from Python 3.14 onward.
+- Improved test suite execution speed using pytest-xdist.
+
 2.12.920 (2024-05-04)
 =====================
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,3 +13,4 @@ towncrier==21.9.0
 pytest-asyncio>=0.21.1,<=0.26.0
 aiofile>=2,<4
 pytest-xdist>=3,<4
+pytest-cov>=4,<7

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,3 +12,4 @@ tzdata==2024.2; python_version<"3.8"
 towncrier==21.9.0
 pytest-asyncio>=0.21.1,<=0.26.0
 aiofile>=2,<4
+pytest-xdist>=3,<4

--- a/docker-compose.win.yaml
+++ b/docker-compose.win.yaml
@@ -1,6 +1,6 @@
 services:
   proxy:
-    image: traefik:v3.4.0-rc2-windowsservercore-ltsc2022
+    image: traefik:v3.4.0-windowsservercore-ltsc2022
     restart: unless-stopped
     depends_on:
       httpbin:

--- a/docker-compose.win.yaml
+++ b/docker-compose.win.yaml
@@ -1,6 +1,6 @@
 services:
   proxy:
-    image: traefik:v3.4-nanoserver-ltsc2022
+    image: traefik:v3.4.0-windowsservercore-ltsc2022
     restart: unless-stopped
     depends_on:
       httpbin:

--- a/docker-compose.win.yaml
+++ b/docker-compose.win.yaml
@@ -1,6 +1,6 @@
 services:
   proxy:
-    image: traefik:v3.4.0-windowsservercore-ltsc2022
+    image: winamd64/traefik:v3.4-nanoserver-ltsc2022
     restart: unless-stopped
     depends_on:
       httpbin:

--- a/docker-compose.win.yaml
+++ b/docker-compose.win.yaml
@@ -1,6 +1,6 @@
 services:
   proxy:
-    image: winamd64/traefik:v3.4-nanoserver-ltsc2022
+    image: traefik:v3.4.0-windowsservercore-ltsc2022 # winamd64/traefik:v3.4-nanoserver-ltsc2022
     restart: unless-stopped
     depends_on:
       httpbin:

--- a/docker-compose.win.yaml
+++ b/docker-compose.win.yaml
@@ -1,6 +1,6 @@
 services:
   proxy:
-    image: traefik:v3.4.0-windowsservercore-ltsc2022 # winamd64/traefik:v3.4-nanoserver-ltsc2022
+    image: traefik:v3.4-nanoserver-ltsc2022
     restart: unless-stopped
     depends_on:
       httpbin:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   proxy:
-    image: traefik:v3.4.0-rc2
+    image: traefik:v3.4.0
     restart: unless-stopped
     depends_on:
       httpbin:

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -789,8 +789,6 @@ In-memory client (mTLS) certificate
 Using newly added ``cert_data`` and ``key_data`` arguments in ``HTTPSConnection``, ``HTTPSPoolConnection`` and ``PoolManager``.
 you will be capable of passing the certificate along with its key without getting nowhere near your filesystem.
 
-.. warning:: When connected to a TLS over TCP, this is only supported with Linux, FreeBSD, and OpenBSD. When connected over QUIC (e.g. HTTP/3) it is broadly supported.
-
 This feature compensate for the complete removal of ``pyOpenSSL``.
 
 You may give your certificate to urllib3.future this way::

--- a/noxfile.py
+++ b/noxfile.py
@@ -215,7 +215,7 @@ def tests_impl(
             ),
             "pytest",
             "-n",
-            "4",
+            "2",
             "-v",
             "-ra",
             f"--color={'yes' if 'GITHUB_ACTIONS' in os.environ else 'auto'}",

--- a/noxfile.py
+++ b/noxfile.py
@@ -197,6 +197,12 @@ def tests_impl(
         session.run("python", "-c", "import struct; print(struct.calcsize('P') * 8)")
         session.run("python", "-c", "import ssl; print(ssl.OPENSSL_VERSION)")
 
+        if tracemalloc_enable is False:
+            # add a pth runtime script
+            # to circumvent coverage limitation
+            # can't get workers to measure coverage!
+            session.install("coverage-enable-subprocess==1.0")
+
         # Inspired from https://hynek.me/articles/ditch-codecov-python/
         # We use parallel mode and then combine in a later CI step
         session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -214,6 +214,8 @@ def tests_impl(
                 else ()
             ),
             "pytest",
+            "-n",
+            "4",
             "-v",
             "-ra",
             f"--color={'yes' if 'GITHUB_ACTIONS' in os.environ else 'auto'}",

--- a/noxfile.py
+++ b/noxfile.py
@@ -225,7 +225,10 @@ def tests_impl(
             },
         )
 
-    suffix = ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(8))
+    suffix = "".join(
+        random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits)
+        for _ in range(8)
+    )
     os.rename(".coverage", f".coverage.{suffix}")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ brotli = [
   "brotlicffi>=0.8.0; platform_python_implementation != 'CPython'"
 ]
 zstd = [
-  "zstandard>=0.18.0",
+  "zstandard>=0.18.0; python_version < '3.14'",
 ]
 secure = []
 socks = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ log_level = "DEBUG"
 filterwarnings = [
     "error",
     '''ignore:.*iscoroutinefunction.*:DeprecationWarning''',
+    '''ignore:rsyncdirs config variable are deprecated:DeprecationWarning''',
     '''ignore:.*get_event_loop.*:DeprecationWarning''',
     '''ignore:.*set_event_loop.*:DeprecationWarning''',
     '''ignore:.*EventLoopPolicy.*:DeprecationWarning''',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ log_level = "DEBUG"
 filterwarnings = [
     "error",
     '''ignore:.*iscoroutinefunction.*:DeprecationWarning''',
-    '''ignore:rsyncdirs config variable are deprecated:DeprecationWarning''',
+    '''ignore:.*rsyncdirs.*:DeprecationWarning''',
     '''ignore:.*get_event_loop.*:DeprecationWarning''',
     '''ignore:.*set_event_loop.*:DeprecationWarning''',
     '''ignore:.*EventLoopPolicy.*:DeprecationWarning''',

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -859,6 +859,15 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
                 cert_data=self.cert_data,
                 key_data=self.key_data,
             )
+
+            # we want the http3 upgrade to behave
+            # exactly as http1/http2 ssl handshake
+            # configuration CAstore wise for example
+            if self.ssl_context is None:
+                # only if not using tls in tls
+                if hasattr(sock_and_verified.socket, "context"):
+                    self.ssl_context = sock_and_verified.socket.context
+
             self.sock = sock_and_verified.socket
 
             # If there's a proxy to be connected to we are fully connected.

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.12.920"
+__version__ = "2.12.921"

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -836,6 +836,15 @@ class HTTPSConnection(HTTPConnection):
                 cert_data=self.cert_data,
                 key_data=self.key_data,
             )
+
+            # we want the http3 upgrade to behave
+            # exactly as http1/http2 ssl handshake
+            # configuration CAstore wise for example
+            if self.ssl_context is None:
+                # only if not using tls in tls
+                if hasattr(sock_and_verified.socket, "context"):
+                    self.ssl_context = sock_and_verified.socket.context
+
             self.sock = sock_and_verified.socket  # type: ignore[assignment]
 
             # Forwarding proxies can never have a verified target since

--- a/src/urllib3/contrib/imcc/__init__.py
+++ b/src/urllib3/contrib/imcc/__init__.py
@@ -1,122 +1,58 @@
 from __future__ import annotations
 
-import os
-import secrets
-import stat
-import sys
 import typing
-import warnings
-from hashlib import sha256
 from io import UnsupportedOperation
 
 if typing.TYPE_CHECKING:
     import ssl
 
+from ._ctypes import load_cert_chain as _ctypes_load_cert_chain
+from ._shm import load_cert_chain as _shm_load_cert_chain
+
+SUPPORTED_METHODS: list[
+    typing.Callable[
+        [
+            ssl.SSLContext,
+            bytes | str,
+            bytes | str,
+            bytes | str | typing.Callable[[], str | bytes] | None,
+        ],
+        None,
+    ]
+] = [
+    _ctypes_load_cert_chain,
+    _shm_load_cert_chain,
+]
+
 
 def load_cert_chain(
     ctx: ssl.SSLContext,
-    certdata: str | bytes,
-    keydata: str | bytes | None = None,
-    password: typing.Callable[[], str | bytes] | str | bytes | None = None,
+    certdata: bytes | str,
+    keydata: bytes | str,
+    password: bytes | str | typing.Callable[[], str | bytes] | None = None,
 ) -> None:
     """
     Unique workaround the known limitation of CPython inability to initialize the mTLS context without files.
-    Only supported on Linux, FreeBSD, and OpenBSD.
     :raise UnsupportedOperation: If anything goes wrong in the process.
     """
-    if (
-        sys.platform != "linux"
-        and sys.platform.startswith("freebsd") is False
-        and sys.platform.startswith("openbsd") is False
-    ):
-        raise UnsupportedOperation(
-            f"Unable to provide support for in-memory client certificate: Unsupported platform {sys.platform}"
-        )
+    err = None
 
-    unique_name: str = f"{sha256(secrets.token_bytes(32)).hexdigest()}.pem"
-
-    if isinstance(certdata, bytes):
-        certdata = certdata.decode("ascii")
-
-    if keydata is not None:
-        if isinstance(keydata, bytes):
-            keydata = keydata.decode("ascii")
-
-    if hasattr(os, "memfd_create"):
-        fd = os.memfd_create(unique_name, os.MFD_CLOEXEC)
-    else:
-        # this branch patch is for CPython <3.8 and PyPy 3.7+
-        from ctypes import c_int, c_ushort, cdll, create_string_buffer, get_errno, util
-
-        loc = util.find_library("rt") or util.find_library("c")
-
-        if not loc:
-            raise UnsupportedOperation(
-                "Unable to provide support for in-memory client certificate: libc or librt not found."
-            )
-
-        lib = cdll.LoadLibrary(loc)
-
-        _shm_open = lib.shm_open
-        # _shm_unlink = lib.shm_unlink
-
-        buf_name = create_string_buffer(unique_name.encode())
-
+    for supported in SUPPORTED_METHODS:
         try:
-            fd = _shm_open(
-                buf_name,
-                c_int(os.O_RDWR | os.O_CREAT),
-                c_ushort(stat.S_IRUSR | stat.S_IWUSR),
+            supported(
+                ctx,
+                certdata,
+                keydata,
+                password,
             )
-        except SystemError as e:
-            raise UnsupportedOperation(
-                f"Unable to provide support for in-memory client certificate: {e}"
-            )
+            return
+        except UnsupportedOperation as e:
+            err = e
 
-        if fd == -1:
-            raise UnsupportedOperation(
-                f"Unable to provide support for in-memory client certificate: {os.strerror(get_errno())}"
-            )
+    if err is not None:
+        raise err
 
-    # Linux 3.17+
-    path = f"/proc/self/fd/{fd}"
-
-    # Alt-path
-    shm_path = f"/dev/shm/{unique_name}"
-
-    if os.path.exists(path) is False:
-        if os.path.exists(shm_path):
-            path = shm_path
-        else:
-            os.fdopen(fd).close()
-
-            raise UnsupportedOperation(
-                "Unable to provide support for in-memory client certificate: no virtual patch available?"
-            )
-
-    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
-
-    with open(path, "w") as fp:
-        fp.write(certdata)
-
-        if keydata:
-            fp.write(keydata)
-
-        path = fp.name
-
-    ctx.load_cert_chain(path, password=password)
-
-    # we shall start cleaning remnants
-    os.fdopen(fd).close()
-
-    if os.path.exists(shm_path):
-        os.unlink(shm_path)
-
-    if os.path.exists(path) or os.path.exists(shm_path):
-        warnings.warn(
-            "In-memory client certificate: The kernel leaked a file descriptor outside of its expected lifetime.",
-            ResourceWarning,
-        )
+    raise UnsupportedOperation("unable to initialize mTLS using in-memory cert and key")
 
 
 __all__ = ("load_cert_chain",)

--- a/src/urllib3/contrib/imcc/__init__.py
+++ b/src/urllib3/contrib/imcc/__init__.py
@@ -47,7 +47,8 @@ def load_cert_chain(
             )
             return
         except UnsupportedOperation as e:
-            err = e
+            if err is None:
+                err = e
 
     if err is not None:
         raise err

--- a/src/urllib3/contrib/imcc/_ctypes.py
+++ b/src/urllib3/contrib/imcc/_ctypes.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import ctypes
+import sys
+import typing
+from io import UnsupportedOperation
+
+if typing.TYPE_CHECKING:
+    import ssl
+
+
+class _OpenSSL:
+    """Access hazardous material from CPython OpenSSL (or compatible SSL) implementation."""
+
+    def __init__(self) -> None:
+        import ssl
+
+        self.ssl = ssl
+
+        if not hasattr(ssl, "_ssl"):
+            raise UnsupportedOperation("Unsupported interpreter due to missing private ssl module")
+
+        self._lib = ctypes.CDLL(ssl._ssl.__file__)
+        self._name = ssl.OPENSSL_VERSION
+
+        # we want to ensure a minimal set of symbols
+        # are present. CPython should have at least:
+        for required_symbol in [
+            "SSL_CTX_use_certificate",
+            "SSL_CTX_check_private_key",
+            "SSL_CTX_use_PrivateKey",
+            "BIO_free",
+            "BIO_new_mem_buf",
+            "PEM_read_bio_X509",
+            "PEM_read_bio_PrivateKey",
+            "ERR_get_error",
+            "ERR_error_string",
+        ]:
+            if not hasattr(self._lib, required_symbol):
+                raise UnsupportedOperation(
+                    f"Python interpreter built against '{self._name}' is unsupported. {required_symbol} is not present."
+                )
+
+        # https://docs.openssl.org/3.0/man3/SSL_CTX_use_certificate/
+        self.SSL_CTX_use_certificate = self._lib.SSL_CTX_use_certificate
+        self.SSL_CTX_use_certificate.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        self.SSL_CTX_use_certificate.restype = ctypes.c_int
+
+        self.SSL_CTX_check_private_key = self._lib.SSL_CTX_check_private_key
+        self.SSL_CTX_check_private_key.argtypes = [ctypes.c_void_p]
+        self.SSL_CTX_check_private_key.restype = ctypes.c_int
+
+        # https://docs.openssl.org/3.0/man3/BIO_new/
+        self.BIO_free = self._lib.BIO_free
+        self.BIO_free.argtypes = [ctypes.c_void_p]
+        self.BIO_free.restype = None
+
+        self.BIO_new_mem_buf = self._lib.BIO_new_mem_buf
+        self.BIO_new_mem_buf.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        self.BIO_new_mem_buf.restype = ctypes.c_void_p
+
+        # https://docs.openssl.org/3.0/man3/PEM_read_bio_PrivateKey/
+        self.PEM_read_bio_X509 = self._lib.PEM_read_bio_X509
+        self.PEM_read_bio_X509.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
+        self.PEM_read_bio_X509.restype = ctypes.c_void_p
+
+        self.PEM_read_bio_PrivateKey = self._lib.PEM_read_bio_PrivateKey
+        self.PEM_read_bio_PrivateKey.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
+        self.PEM_read_bio_PrivateKey.restype = ctypes.c_void_p
+
+        # https://docs.openssl.org/3.0/man3/SSL_CTX_use_certificate/
+        self.SSL_CTX_use_PrivateKey = self._lib.SSL_CTX_use_PrivateKey
+        self.SSL_CTX_use_PrivateKey.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        self.SSL_CTX_use_PrivateKey.restype = ctypes.c_int
+
+        self.ERR_get_error = self._lib.ERR_get_error
+        self.ERR_get_error.argtypes = []
+        self.ERR_get_error.restype = ctypes.c_ulong
+
+        self.ERR_error_string = self._lib.ERR_error_string
+        self.ERR_error_string.argtypes = [ctypes.c_ulong, ctypes.c_char_p]
+        self.ERR_error_string.restype = ctypes.c_char_p
+
+
+        if hasattr(self._lib, "SSL_CTX_get_options"):
+            self.SSL_CTX_get_options = self._lib.SSL_CTX_get_options
+            self.SSL_CTX_get_options.argtypes = [ctypes.c_void_p]
+            self.SSL_CTX_get_options.restype = ctypes.c_long  # OpenSSL's options are long
+        else:
+            # todo: should we find a safety alternative that works on old Python build too?
+            self.SSL_CTX_get_options = None  # type: ignore[assignment]
+
+    def pull_error(self) -> typing.NoReturn:
+        raise self.ssl.SSLError(
+            self.ERR_error_string(
+                self.ERR_get_error(),
+                ctypes.create_string_buffer(256)
+            ).decode()
+        )
+
+_head_extra_fields = []
+
+if sys.flags.debug:
+    # In debug builds (_POSIX_C_SOURCE or Py_DEBUG is defined), PyObject_HEAD
+    # is preceded by _PyObject_HEAD_EXTRA, which typically consists of
+    # two pointers (_ob_next, _ob_prev).
+    _head_extra_fields = [
+        ('_ob_next', ctypes.c_void_p),
+        ('_ob_prev', ctypes.c_void_p)
+    ]
+
+# Define the PySSLContext C structure using ctypes.
+# This definition assumes that 'SSL_CTX *ctx' is the first member
+# immediately following PyObject_HEAD. This has been observed to be
+# the case in various CPython versions (e.g., 3.7 through 3.14 so far).
+#
+# CPython's Modules/_ssl.c (simplified):
+# typedef struct {
+#     PyObject_HEAD  // Expands to _PyObject_HEAD_EXTRA (if debug) + ob_refcnt + ob_type
+#     SSL_CTX *ctx;
+#     // ... other members ...
+# } PySSLContextObject;
+#
+class PySSLContextStruct(ctypes.Structure):
+    _fields_ = _head_extra_fields + [
+        ('ob_refcnt', ctypes.c_ssize_t),  # Py_ssize_t ob_refcnt;
+        ('ob_type', ctypes.c_void_p),  # PyTypeObject *ob_type;
+        ('ssl_ctx', ctypes.c_void_p)  # SSL_CTX *ctx; (this is the pointer we want)
+        # If there were other C members between ob_type and ssl_ctx,
+        # they would need to be defined here with their correct types and padding.
+    ]
+
+
+def _split_client_cert(data: bytes) -> list[bytes]:
+    line_ending = b"\n" if b"-----\r\n" not in data else b"\r\n"
+    boundary = b"-----END CERTIFICATE-----" + line_ending
+
+    certificates = []
+
+    for chunk in data.split(boundary):
+        if chunk:
+            start_marker = chunk.find(b"-----BEGIN CERTIFICATE-----" + line_ending)
+            if start_marker == -1:
+                break
+            pem_reconstructed = b"".join([chunk[start_marker:], boundary])
+            certificates.append(pem_reconstructed)
+
+    return certificates
+
+
+def load_cert_chain(
+    ctx: ssl.SSLContext,
+    certdata: bytes | str,
+    keydata: bytes | str,
+    password: bytes | str | typing.Callable[[], str | bytes] | None = None,
+) -> None:
+    """
+    Unique workaround the known limitation of CPython inability to initialize the mTLS context without files.
+    :raise UnsupportedOperation: If anything goes wrong in the process.
+    """
+    lib = _OpenSSL()
+
+    # Get the memory address of the Python ssl.SSLContext object.
+    # id() returns the address of the PyObject.
+    addr = id(ctx)
+
+    # Cast this memory address to a pointer to our defined PySSLContextStruct.
+    ptr_to_pysslcontext_struct = ctypes.cast(addr, ctypes.POINTER(PySSLContextStruct))
+
+    # Access the 'ssl_ctx' field from the structure. This field holds the
+    # actual SSL_CTX* C pointer value.
+    ssl_ctx_address = ptr_to_pysslcontext_struct.contents.ssl_ctx
+
+    # We want to ensure we got the right pointer address
+    # the safest way to achieve that is to retrieve options
+    # and compare it with the official ctx property.
+    if lib.SSL_CTX_get_options is not None:
+        bypass_options = lib.SSL_CTX_get_options(ssl_ctx_address)
+        expected_options = ctx.options
+
+        if bypass_options != expected_options:
+            raise UnsupportedOperation("CPython internal SSL_CTX changed! Cannot pursue safely.")
+
+    # normalize inputs
+    if isinstance(certdata, str):
+        certdata = certdata.encode()
+    if isinstance(keydata, str):
+        keydata = keydata.encode()
+
+    client_chain = _split_client_cert(certdata)
+
+    leaf_certificate = client_chain[0]
+
+    # Use a BIO to read the client certificate
+    # only the leaf certificate is supported here.
+    cert_bio = lib.BIO_new_mem_buf(leaf_certificate, len(leaf_certificate))
+
+    if not cert_bio:
+        raise MemoryError("Unable to allocate memory to load the client certificate")
+
+    # Use a BIO to load the key in-memory
+    key_bio = lib.BIO_new_mem_buf(keydata, len(keydata))
+
+    if not key_bio:
+        raise MemoryError("Unable to allocate memory to load the client key")
+
+    # prepare the password
+    if callable(password):
+        password = password()
+
+    if isinstance(password, str):
+        password = password.encode()
+
+    assert password is None or isinstance(password, bytes)
+
+    # the allocated X509 obj MUST NOT be freed by ourselves
+    # OpenSSL internals will free it once not needed.
+    cert = lib.PEM_read_bio_X509(cert_bio, None, None, None)
+
+    # we do own the BIO, once the X509 leaf is instantiated, no need
+    # to keep it afterward.
+    lib.BIO_free(cert_bio)
+
+    if not cert:
+        lib.pull_error()
+
+    pkey = lib.PEM_read_bio_PrivateKey(key_bio, None, None, password)
+
+    lib.BIO_free(key_bio)
+
+    if not pkey:
+        lib.pull_error()
+
+    if lib.SSL_CTX_use_certificate(ssl_ctx_address, cert) != 1:
+        lib.pull_error()
+
+    if lib.SSL_CTX_use_PrivateKey(ssl_ctx_address, pkey) != 1:
+        lib.pull_error()
+
+    if lib.SSL_CTX_check_private_key(ssl_ctx_address) != 1:
+        lib.pull_error()
+
+    # Unfortunately, most of the time
+    # SSL_CTX_add_extra_chain_cert is unavailable
+    # in the final CPython build.
+    # According to OpenSSL latest docs: "The engine
+    # will attempt to build the required chain for the CA store"
+    # It's not going to be used as a trust anchor! (i.e. not self-signed)
+    # "If no chain is specified, the library will try to complete the
+    # chain from the available CA certificates in the trusted
+    # CA storage, see SSL_CTX_load_verify_locations(3)."
+    # see: https://docs.openssl.org/master/man3/SSL_CTX_add_extra_chain_cert/#notes
+    if len(client_chain) > 1:
+        ctx.load_verify_locations(cadata=(b"\n".join(client_chain[1:])).decode())
+
+__all__ = ("load_cert_chain",)

--- a/src/urllib3/contrib/imcc/_ctypes.py
+++ b/src/urllib3/contrib/imcc/_ctypes.py
@@ -98,6 +98,9 @@ class _OpenSSL:
                     "check your /DLLs folder or your PATH."
                 )
 
+            print(ssl_potential_match)
+            print(crypto_potential_match)
+
             self._ssl = ctypes.CDLL(ssl_potential_match)
             self._crypto = ctypes.CDLL(crypto_potential_match)
         else:

--- a/src/urllib3/contrib/imcc/_ctypes.py
+++ b/src/urllib3/contrib/imcc/_ctypes.py
@@ -111,10 +111,17 @@ class _OpenSSL:
 
             if hasattr(self._lib, "SSL_CTX_ctrl"):
                 self.SSL_CTX_ctrl = self._lib.SSL_CTX_ctrl
-                self.SSL_CTX_ctrl.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int, ctypes.c_void_p]
+                self.SSL_CTX_ctrl.argtypes = [
+                    ctypes.c_void_p,
+                    ctypes.c_int,
+                    ctypes.c_int,
+                    ctypes.c_void_p,
+                ]
                 self.SSL_CTX_ctrl.restype = ctypes.c_long
 
-                self.SSL_CTX_get_options = lambda ctx: self.SSL_CTX_ctrl(ctx, 32, 0, None)
+                self.SSL_CTX_get_options = lambda ctx: self.SSL_CTX_ctrl(  # type: ignore[assignment]
+                    ctx, 32, 0, None
+                )
             else:
                 self.SSL_CTX_get_options = None  # type: ignore[assignment]
 

--- a/src/urllib3/contrib/imcc/_ctypes.py
+++ b/src/urllib3/contrib/imcc/_ctypes.py
@@ -50,6 +50,9 @@ class _OpenSSL:
             crypto_potential_match = None
 
             for d in candidates:
+                if not os.path.exists(d):
+                    continue
+
                 for filename in os.listdir(d):
                     if ssl_potential_match is None:
                         if filename.startswith("libssl") and filename.endswith(".dll"):

--- a/src/urllib3/contrib/imcc/_shm.py
+++ b/src/urllib3/contrib/imcc/_shm.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+import secrets
+import stat
+import sys
+import typing
+import warnings
+from hashlib import sha256
+from io import UnsupportedOperation
+
+if typing.TYPE_CHECKING:
+    import ssl
+
+
+def load_cert_chain(
+    ctx: ssl.SSLContext,
+    certdata: str | bytes,
+    keydata: str | bytes | None = None,
+    password: typing.Callable[[], str | bytes] | str | bytes | None = None,
+) -> None:
+    """
+    Unique workaround the known limitation of CPython inability to initialize the mTLS context without files.
+    Only supported on Linux, FreeBSD, and OpenBSD.
+    :raise UnsupportedOperation: If anything goes wrong in the process.
+    """
+    if (
+        sys.platform != "linux"
+        and sys.platform.startswith("freebsd") is False
+        and sys.platform.startswith("openbsd") is False
+    ):
+        raise UnsupportedOperation(
+            f"Unable to provide support for in-memory client certificate: Unsupported platform {sys.platform}"
+        )
+
+    unique_name: str = f"{sha256(secrets.token_bytes(32)).hexdigest()}.pem"
+
+    if isinstance(certdata, bytes):
+        certdata = certdata.decode("ascii")
+
+    if keydata is not None:
+        if isinstance(keydata, bytes):
+            keydata = keydata.decode("ascii")
+
+    if hasattr(os, "memfd_create"):
+        fd = os.memfd_create(unique_name, os.MFD_CLOEXEC)
+    else:
+        # this branch patch is for CPython <3.8 and PyPy 3.7+
+        from ctypes import c_int, c_ushort, cdll, create_string_buffer, get_errno, util
+
+        loc = util.find_library("rt") or util.find_library("c")
+
+        if not loc:
+            raise UnsupportedOperation(
+                "Unable to provide support for in-memory client certificate: libc or librt not found."
+            )
+
+        lib = cdll.LoadLibrary(loc)
+
+        _shm_open = lib.shm_open
+        # _shm_unlink = lib.shm_unlink
+
+        buf_name = create_string_buffer(unique_name.encode())
+
+        try:
+            fd = _shm_open(
+                buf_name,
+                c_int(os.O_RDWR | os.O_CREAT),
+                c_ushort(stat.S_IRUSR | stat.S_IWUSR),
+            )
+        except SystemError as e:
+            raise UnsupportedOperation(
+                f"Unable to provide support for in-memory client certificate: {e}"
+            )
+
+        if fd == -1:
+            raise UnsupportedOperation(
+                f"Unable to provide support for in-memory client certificate: {os.strerror(get_errno())}"
+            )
+
+    # Linux 3.17+
+    path = f"/proc/self/fd/{fd}"
+
+    # Alt-path
+    shm_path = f"/dev/shm/{unique_name}"
+
+    if os.path.exists(path) is False:
+        if os.path.exists(shm_path):
+            path = shm_path
+        else:
+            os.fdopen(fd).close()
+
+            raise UnsupportedOperation(
+                "Unable to provide support for in-memory client certificate: no virtual patch available?"
+            )
+
+    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+
+    with open(path, "w") as fp:
+        fp.write(certdata)
+
+        if keydata:
+            fp.write(keydata)
+
+        path = fp.name
+
+    ctx.load_cert_chain(path, password=password)
+
+    # we shall start cleaning remnants
+    os.fdopen(fd).close()
+
+    if os.path.exists(shm_path):
+        os.unlink(shm_path)
+
+    if os.path.exists(path) or os.path.exists(shm_path):
+        warnings.warn(
+            "In-memory client certificate: The kernel leaked a file descriptor outside of its expected lifetime.",
+            ResourceWarning,
+        )
+
+
+__all__ = ("load_cert_chain",)

--- a/src/urllib3/contrib/ssa/__init__.py
+++ b/src/urllib3/contrib/ssa/__init__.py
@@ -432,6 +432,10 @@ class SSLAsyncSocket(AsyncSocket):
         )
 
     @property
+    def context(self) -> ssl.SSLContext:
+        return self.sslobj.context
+
+    @property
     def _sslobj(self) -> ssl.SSLSocket | ssl.SSLObject:
         return self.sslobj
 

--- a/src/urllib3/util/_async/ssl_.py
+++ b/src/urllib3/util/_async/ssl_.py
@@ -133,7 +133,7 @@ async def ssl_wrap_socket(
                     context.load_cert_chain(certfile, keyfile)
                 else:
                     context.load_cert_chain(certfile, keyfile, key_password)
-            elif certdata:
+            elif certdata and keydata:
                 try:
                     _ctx_load_cert_chain(context, certdata, keydata, key_password)
                 except io.UnsupportedOperation as e:

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -660,7 +660,7 @@ def ssl_wrap_socket(
                     context.load_cert_chain(certfile, keyfile)
                 else:
                     context.load_cert_chain(certfile, keyfile, key_password)
-            elif certdata:
+            elif certdata and keydata:
                 try:
                     _ctx_load_cert_chain(context, certdata, keydata, key_password)
                 except io.UnsupportedOperation as e:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -416,6 +416,6 @@ def requires_http3(for_async: bool = False) -> None:
 def coverage_process(worker_id: str) -> None:
     if worker_id != "master":
         if not os.environ.get("PYTHONTRACEMALLOC"):
-            import coverage
+            import coverage  # type: ignore[import-not-found]
 
             coverage.process_startup()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -410,4 +410,3 @@ def requires_http3(for_async: bool = False) -> None:
 
     if _TARGET_METHOD() is False:
         pytest.skip("Test requires HTTP/3 support")
-

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -410,3 +410,11 @@ def requires_http3(for_async: bool = False) -> None:
 
     if _TARGET_METHOD() is False:
         pytest.skip("Test requires HTTP/3 support")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def coverage_process(worker_id: str) -> None:
+    if worker_id != "master":
+        if not os.environ.get("PYTHONTRACEMALLOC"):
+            import coverage
+            coverage.process_startup()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -417,4 +417,5 @@ def coverage_process(worker_id: str) -> None:
     if worker_id != "master":
         if not os.environ.get("PYTHONTRACEMALLOC"):
             import coverage
+
             coverage.process_startup()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -411,11 +411,3 @@ def requires_http3(for_async: bool = False) -> None:
     if _TARGET_METHOD() is False:
         pytest.skip("Test requires HTTP/3 support")
 
-
-@pytest.fixture(scope="session", autouse=True)
-def coverage_process(worker_id: str) -> None:
-    if worker_id != "master":
-        if not os.environ.get("PYTHONTRACEMALLOC"):
-            import coverage  # type: ignore[import-not-found]
-
-            coverage.process_startup()

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -190,6 +190,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                     cert_data=fp_cert_data.read(),
                     ca_certs=DEFAULT_CA,
                     ssl_minimum_version=self.tls_version(),
+                    retries=False,
                 ) as https_pool:
                     r = https_pool.request("GET", "/certificate")
                     subject = r.json()
@@ -246,6 +247,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                     cert_data=fp_cert_data.read(),
                     key_password="letmein",
                     ssl_minimum_version=self.tls_version(),
+                    retries=False,
                 ) as https_pool:
                     r = https_pool.request("GET", "/certificate")
                     subject = r.json()

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -12,8 +12,6 @@ from test import (
     LONG_TIMEOUT,
     SHORT_TIMEOUT,
     TARPIT_HOST,
-    notMacOS,
-    notWindows,
     requires_network,
     resolvesLocalhostFQDN,
 )
@@ -171,8 +169,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             subject = r.json()
             assert subject["organizationalUnitName"].startswith("Testing cert")
 
-    @notWindows()
-    @notMacOS()
     @pytest.mark.xfail(
         sys.implementation.name == "pypy"
         and (
@@ -230,8 +226,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             subject = r.json()
             assert subject["organizationalUnitName"].startswith("Testing cert")
 
-    @notWindows()
-    @notMacOS()
     @pytest.mark.xfail(
         sys.implementation.name == "pypy"
         and (

--- a/traefik/patched.Dockerfile
+++ b/traefik/patched.Dockerfile
@@ -1,4 +1,4 @@
-FROM winamd64/golang:1.23-nanoserver-ltsc2022 as build
+FROM winamd64/golang:1.24-nanoserver-ltsc2022 as build
 
 WORKDIR /go/src/github.com/mccutchen/go-httpbin
 


### PR DESCRIPTION
2.12.921 (2024-05-17)
=====================

- Extended in-memory mTLS loading support to every major platforms.
- Added support for built-in zstandard starting from Python 3.14 onward.
- Improved test suite execution speed using pytest-xdist.
- Fixed a rare edge case where the CAStore would be empty after upgrade to a HTTP/3 connection when no CA bundle are given before.
  This error occurred due to load_default_certs not being applied for the QUIC connection.
