### PR TITLE
Release 2.13.900

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,15 @@
+2.13.900 (2024-06-22)
+=====================
+
+- Fixed passing ``ca_cert_data`` as ``bytes`` instead of ``str``.
+- Backported Security fix CVE-2025-50181 (5.3 Medium, GHSA-pq67-6m6q-mj2v) from upstream urllib3 v2.5.0
+- Fixed backward incompatible change on the ssl configuration when urllib3-future is invoked by other than Niquests.
+  The default cipher list will fallback to system's default when Niquests is not the invoker. Also stop setting
+  ``OP_NO_RENEGOTIATION`` in ssl_options when it's not Niquests.
+- Fixed a rare bug causing the connection to improperly upgrade to QUIC when no ssl ca are given.
+- Updated the low bound version requirement for ``qh3`` to v1.5.3 due to some significant improvement toward
+  unifying PKI validation behaviors with Python default expectation (w/ OpenSSL).
+
 2.12.922 (2024-05-19)
 =====================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
 - Fixed a rare bug causing the connection to improperly upgrade to QUIC when no ssl ca are given.
 - Updated the low bound version requirement for ``qh3`` to v1.5.3 due to some significant improvement toward
   unifying PKI validation behaviors with Python default expectation (w/ OpenSSL).
+- Changed default behavior when passing a SSLContext with no loaded CA in store. Previously we did not called
+  ``load_default_certs``. We now check if the store is empty, then we load the default certs.
 
 2.12.922 (2024-05-19)
 =====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 requires-python = ">=3.7"
 dynamic = ["version"]
 dependencies = [
-  "qh3>=1.2.0,<2.0.0; (platform_python_implementation != 'CPython' or python_full_version > '3.7.10') and (platform_system == 'Darwin' or platform_system == 'Windows' or platform_system == 'Linux') and (platform_machine == 'x86_64' or platform_machine == 's390x' or platform_machine == 'armv7l' or platform_machine == 'ppc64le' or platform_machine == 'ppc64' or platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ARM64' or platform_machine == 'x86' or platform_machine == 'i686') and (platform_python_implementation == 'CPython' or (platform_python_implementation == 'PyPy' and python_version < '3.12'))",
+  "qh3>=1.5.3,<2.0.0; (platform_python_implementation != 'CPython' or python_full_version > '3.7.10') and (platform_system == 'Darwin' or platform_system == 'Windows' or platform_system == 'Linux') and (platform_machine == 'x86_64' or platform_machine == 's390x' or platform_machine == 'armv7l' or platform_machine == 'ppc64le' or platform_machine == 'ppc64' or platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ARM64' or platform_machine == 'x86' or platform_machine == 'i686') and (platform_python_implementation == 'CPython' or (platform_python_implementation == 'PyPy' and python_version < '3.12'))",
   "h11>=0.11.0,<1.0.0",
   "jh2>=5.0.3,<6.0.0",
 ]
@@ -58,7 +58,7 @@ socks = [
   "python-socks>=2.0,<=2.6.1",
 ]
 qh3 = [
-  "qh3>=1.2.0,<2.0.0",
+  "qh3>=1.5.3,<2.0.0",
 ]
 ws = [
   "wsproto>=1.2,<2",
@@ -112,6 +112,7 @@ filterwarnings = [
     '''ignore:.*get_event_loop.*:DeprecationWarning''',
     '''ignore:.*set_event_loop.*:DeprecationWarning''',
     '''ignore:.*EventLoopPolicy.*:DeprecationWarning''',
+    '''ignore:.*but not measured.*:coverage.exceptions.CoverageWarning''',
     '''default:ssl\.PROTOCOL_TLS is deprecated:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLSv1 is deprecated:DeprecationWarning''',
     '''default:ssl\.TLSVersion\.TLSv1_1 is deprecated:DeprecationWarning''',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -796,7 +796,6 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
             and self.ca_cert_dir is None
             and self.ca_cert_data is None
             and self.ssl_context is None
-            and self._upgrade_ctx is None
         ):
             self._upgrade_ctx = create_urllib3_context()
 

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -1027,19 +1027,6 @@ async def _ssl_wrap_socket_and_match_hostname(
     ):
         context.check_hostname = False
 
-    # Try to load OS default certs if none are given.
-    # We need to do the hasattr() check for our custom
-    # pyOpenSSL and SecureTransport SSLContext objects
-    # because neither support load_default_certs().
-    if (
-        not ca_certs
-        and not ca_cert_dir
-        and not ca_cert_data
-        and default_ssl_context
-        and hasattr(context, "load_default_certs")
-    ):
-        context.load_default_certs()
-
     # Ensure that IPv6 addresses are in the proper format and don't have a
     # scope ID. Python's SSL module fails to recognize scoped IPv6 addresses
     # and interprets them as DNS hostnames.

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.12.922"
+__version__ = "2.13.900"

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -999,19 +999,6 @@ def _ssl_wrap_socket_and_match_hostname(
     ):
         context.check_hostname = False
 
-    # Try to load OS default certs if none are given.
-    # We need to do the hasattr() check for our custom
-    # pyOpenSSL and SecureTransport SSLContext objects
-    # because neither support load_default_certs().
-    if (
-        not ca_certs
-        and not ca_cert_dir
-        and not ca_cert_data
-        and default_ssl_context
-        and hasattr(context, "load_default_certs")
-    ):
-        context.load_default_certs()
-
     # Ensure that IPv6 addresses are in the proper format and don't have a
     # scope ID. Python's SSL module fails to recognize scoped IPv6 addresses
     # and interprets them as DNS hostnames.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -773,7 +773,6 @@ class HTTPSConnection(HTTPConnection):
             and self.ca_cert_dir is None
             and self.ca_cert_data is None
             and self.ssl_context is None
-            and self._upgrade_ctx is None
         ):
             self._upgrade_ctx = create_urllib3_context()
 

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -239,6 +239,27 @@ class PoolManager(RequestMethods):
         **connection_pool_kw: typing.Any,
     ) -> None:
         super().__init__(headers)
+
+        if "retries" in connection_pool_kw:
+            retries = connection_pool_kw["retries"]
+            if not isinstance(retries, Retry):
+                # When Retry is initialized, raise_on_redirect is based
+                # on a redirect boolean value.
+                # But requests made via a pool manager always set
+                # redirect to False, and raise_on_redirect always ends
+                # up being False consequently.
+                # Here we fix the issue by setting raise_on_redirect to
+                # a value needed by the pool manager without considering
+                # the redirect boolean.
+
+                raise_on_redirect = retries is not False
+
+                retries = Retry.from_int(retries, redirect=False)
+                retries.raise_on_redirect = raise_on_redirect
+
+                connection_pool_kw = connection_pool_kw.copy()
+                connection_pool_kw["retries"] = retries
+
         self.connection_pool_kw = connection_pool_kw
 
         self._num_pools = num_pools
@@ -904,7 +925,7 @@ class PoolManager(RequestMethods):
             for should_be_removed_header in NOT_FORWARDABLE_HEADERS:
                 kw["headers"].discard(should_be_removed_header)
 
-        retries = kw.get("retries")
+        retries = kw.get("retries", response.retries)
         if not isinstance(retries, Retry):
             retries = Retry.from_int(retries, redirect=redirect)
 

--- a/src/urllib3/util/_async/ssl_.py
+++ b/src/urllib3/util/_async/ssl_.py
@@ -122,9 +122,11 @@ async def ssl_wrap_socket(
                 except OSError as e:
                     raise SSLError(e) from e
 
-            elif ssl_context is None and hasattr(context, "load_default_certs"):
+            elif hasattr(context, "load_default_certs"):
+                store_stats = context.cert_store_stats()
                 # try to load OS default certs; works well on Windows.
-                context.load_default_certs()
+                if "x509_ca" not in store_stats or not store_stats["x509_ca"]:
+                    context.load_default_certs()
 
             # Attempt to detect if we get the goofy behavior of the
             # keyfile being encrypted and OpenSSL asking for the

--- a/src/urllib3/util/_async/ssl_.py
+++ b/src/urllib3/util/_async/ssl_.py
@@ -113,6 +113,10 @@ async def ssl_wrap_socket(
                 )
 
             if ca_certs or ca_cert_dir or ca_cert_data:
+                # SSLContext does not support bytes for cadata[...]
+                if ca_cert_data and isinstance(ca_cert_data, bytes):
+                    ca_cert_data = ca_cert_data.decode()
+
                 try:
                     context.load_verify_locations(ca_certs, ca_cert_dir, ca_cert_data)
                 except OSError as e:

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -10,6 +10,8 @@ import sys
 import threading
 import typing
 import warnings
+import enum
+import traceback
 from binascii import unhexlify
 
 from .._constant import MOZ_INTERMEDIATE_CIPHERS
@@ -36,6 +38,25 @@ HASHFUNC_MAP = {
         (64, "sha256"),
     )
 }
+
+
+class _KnownCaller(enum.Enum):
+    REQUESTS = "Requests"
+    NIQUESTS = "Niquests"
+    OTHER = "Other"
+
+
+def _caller_id() -> _KnownCaller:
+    for frame in traceback.extract_stack():
+        module_path = frame.filename
+
+        if frame.filename.endswith("adapters.py"):
+            if "requests" in module_path:
+                return _KnownCaller.REQUESTS
+            elif "niquests" in module_path:
+                return _KnownCaller.NIQUESTS
+
+    return _KnownCaller.OTHER
 
 
 def _compute_key_ctx_build(
@@ -379,6 +400,7 @@ def create_urllib3_context(
     ciphers: str | None = None,
     ssl_minimum_version: int | None = None,
     ssl_maximum_version: int | None = None,
+    caller_id: _KnownCaller | None = None,
 ) -> ssl.SSLContext:
     """Creates and configures an :class:`ssl.SSLContext` instance for use with urllib3.
 
@@ -449,10 +471,13 @@ def create_urllib3_context(
     if ciphers:
         context.set_ciphers(ciphers)
     else:
-        # avoid relying on cpython default cipher list
-        # and instead retrieve OpenSSL own default. This should make
-        # urllib3.future less flagged by basic firewall anti-bot rules.
-        context.set_ciphers(MOZ_INTERMEDIATE_CIPHERS)
+        # Only apply if Niquests or direct urllib3-future usage
+        # Don't bother other or Requests.
+        if caller_id is None or caller_id is _KnownCaller.NIQUESTS:
+            # avoid relying on cpython default cipher list
+            # and instead retrieve OpenSSL own default. This should make
+            # urllib3.future less flagged by basic firewall anti-bot rules.
+            context.set_ciphers(MOZ_INTERMEDIATE_CIPHERS)
 
     # Setting the default here, as we may have no ssl module on import
     cert_reqs = ssl.CERT_REQUIRED if cert_reqs is None else cert_reqs
@@ -472,11 +497,14 @@ def create_urllib3_context(
         # if the server is not rotating its ticketing keys properly.
         options |= OP_NO_TICKET
 
-        # Disable renegotiation as it was proven to be weak and dangerous.
-        if (
-            OP_NO_RENEGOTIATION is not None
-        ):  # Not always available depending on your interpreter.
-            options |= OP_NO_RENEGOTIATION
+        # Only apply if Niquests or direct urllib3-future usage
+        # Don't bother other or Requests.
+        if caller_id is None or caller_id is _KnownCaller.NIQUESTS:
+            # Disable renegotiation as it was proven to be weak and dangerous.
+            if (
+                OP_NO_RENEGOTIATION is not None
+            ):  # Not always available depending on your interpreter.
+                options |= OP_NO_RENEGOTIATION
 
     context.options |= options
 
@@ -611,6 +639,7 @@ def ssl_wrap_socket(
         Specify an in-memory client intermediary key for mTLS.
     """
     context = ssl_context
+    caller_id = _caller_id()
 
     with _SSLContextCache.lock(
         keyfile,
@@ -626,6 +655,7 @@ def ssl_wrap_socket(
         keydata,
         key_password,
         ca_cert_data,
+        caller_id.value,
     ):
         cached_ctx = (
             _SSLContextCache.get() if sharable_ssl_context is not None else None
@@ -636,7 +666,10 @@ def ssl_wrap_socket(
                 # Note: This branch of code and all the variables in it are only used in tests.
                 # We should consider deprecating and removing this code.
                 context = create_urllib3_context(
-                    ssl_version, cert_reqs, ciphers=ciphers
+                    ssl_version,
+                    cert_reqs,
+                    ciphers=ciphers,
+                    caller_id=caller_id,
                 )
 
             if ca_certs or ca_cert_dir or ca_cert_data:

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -640,6 +640,10 @@ def ssl_wrap_socket(
                 )
 
             if ca_certs or ca_cert_dir or ca_cert_data:
+                # SSLContext does not support bytes for cadata[...]
+                if ca_cert_data and isinstance(ca_cert_data, bytes):
+                    ca_cert_data = ca_cert_data.decode()
+
                 try:
                     context.load_verify_locations(ca_certs, ca_cert_dir, ca_cert_data)
                 except OSError as e:

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -431,6 +431,11 @@ def create_urllib3_context(
     if SSLContext is None:
         raise TypeError("Can't create an SSLContext object without an ssl module")
 
+    if caller_id is None:
+        # a version of Requests attempted the ssl_ctx caching from globals in adapters.py
+        # calling this function directly... Requests regretted that change.
+        caller_id = _caller_id()
+
     # This means 'ssl_version' was specified as an exact value.
     if ssl_version not in (None, PROTOCOL_TLS, PROTOCOL_TLS_CLIENT):
         # Disallow setting 'ssl_version' and 'ssl_minimum|maximum_version'

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -687,9 +687,11 @@ def ssl_wrap_socket(
                 except OSError as e:
                     raise SSLError(e) from e
 
-            elif ssl_context is None and hasattr(context, "load_default_certs"):
+            elif hasattr(context, "load_default_certs"):
+                store_stats = context.cert_store_stats()
                 # try to load OS default certs; works well on Windows.
-                context.load_default_certs()
+                if "x509_ca" not in store_stats or not store_stats["x509_ca"]:
+                    context.load_default_certs()
 
             # Attempt to detect if we get the goofy behavior of the
             # keyfile being encrypted and OpenSSL asking for the

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -379,9 +379,10 @@ class TestPoolManager:
 
     def test_merge_pool_kwargs(self) -> None:
         """Assert _merge_pool_kwargs works in the happy case"""
-        p = PoolManager(retries=100)
+        retries = retry.Retry(total=100)
+        p = PoolManager(retries=retries)
         merged = p._merge_pool_kwargs({"new_key": "value"})
-        assert {"retries": 100, "new_key": "value"} == merged
+        assert {"retries": retries, "new_key": "value"} == merged
 
     def test_merge_pool_kwargs_none(self) -> None:
         """Assert false-y values to _merge_pool_kwargs result in defaults"""

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -67,6 +67,7 @@ class TestSSL:
     def test_wrap_socket_given_context_no_load_default_certs(self) -> None:
         context = mock.create_autospec(ssl_.SSLContext)
         context.load_default_certs = mock.Mock()
+        context.cert_store_stats = mock.Mock(return_value={"x509_ca": 5})
 
         sock = mock.Mock()
         ssl_.ssl_wrap_socket(sock, ssl_context=context)

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -135,7 +135,7 @@ class TestSSL:
         context.options = 0
         monkeypatch.setattr(ssl_, "SSLContext", lambda *_, **__: context)
 
-        ssl_.create_urllib3_context()
+        ssl_.create_urllib3_context(caller_id=ssl_._KnownCaller.NIQUESTS)
 
         context.set_ciphers.assert_called_once_with(MOZ_INTERMEDIATE_CIPHERS)
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -33,6 +33,7 @@ from urllib3.util.ssl_ import (
     resolve_cert_reqs,
     resolve_ssl_version,
     ssl_wrap_socket,
+    _KnownCaller,
 )
 from urllib3.util.timeout import _DEFAULT_TIMEOUT, Timeout
 from urllib3.util.url import Url, _encode_invalid_chars, parse_url
@@ -1019,7 +1020,9 @@ class TestUtilSSL:
         socket = Mock()
         ssl_wrap_socket(socket, cert_reqs=ssl.CERT_REQUIRED)
 
-        create_urllib3_context.assert_called_once_with(None, 2, ciphers=None)
+        create_urllib3_context.assert_called_once_with(
+            None, 2, ciphers=None, caller_id=_KnownCaller.OTHER
+        )
 
     def test_ssl_wrap_socket_loads_verify_locations(self) -> None:
         socket = Mock()

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1007,6 +1007,7 @@ class TestUtilSSL:
     def test_ssl_wrap_socket_loads_the_cert_chain(self) -> None:
         socket = Mock()
         mock_context = Mock()
+        mock_context.cert_store_stats = mock.Mock(return_value={"x509_ca": 5})
         ssl_wrap_socket(
             ssl_context=mock_context, sock=socket, certfile="/path/to/certfile"
         )
@@ -1056,6 +1057,7 @@ class TestUtilSSL:
         self, sock: socket.socket, server_hostname: str | None
     ) -> tuple[Mock, MagicMock]:
         mock_context = Mock()
+        mock_context.cert_store_stats = mock.Mock(return_value={"x509_ca": 5})
         with patch("warnings.warn") as warn:
             ssl_wrap_socket(
                 ssl_context=mock_context,

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -102,6 +102,89 @@ class TestPoolManager(HTTPDummyServerTestCase):
             assert r.status == 200
             assert r.data == b"Dummy server!"
 
+    @pytest.mark.parametrize(
+        "retries",
+        (0, Retry(total=0), Retry(redirect=0), Retry(total=0, redirect=0)),
+    )
+    def test_redirects_disabled_for_pool_manager_with_0(
+        self, retries: int | Retry
+    ) -> None:
+        """
+        Check handling redirects when retries is set to 0 on the pool
+        manager.
+        """
+        with PoolManager(retries=retries) as http:
+            with pytest.raises(MaxRetryError):
+                http.request("GET", f"{self.base_url}/redirect")
+
+            # Setting redirect=True should not change the behavior.
+            with pytest.raises(MaxRetryError):
+                http.request("GET", f"{self.base_url}/redirect", redirect=True)
+
+            # Setting redirect=False should not make it follow the redirect,
+            # but MaxRetryError should not be raised.
+            response = http.request("GET", f"{self.base_url}/redirect", redirect=False)
+            assert response.status == 303
+
+    @pytest.mark.parametrize(
+        "retries",
+        (
+            False,
+            Retry(total=False),
+            Retry(redirect=False),
+            Retry(total=False, redirect=False),
+        ),
+    )
+    def test_redirects_disabled_for_pool_manager_with_false(
+        self, retries: bool | Retry
+    ) -> None:
+        """
+        Check that setting retries set to False on the pool manager disables
+        raising MaxRetryError and redirect=True does not change the
+        behavior.
+        """
+        with PoolManager(retries=retries) as http:
+            response = http.request("GET", f"{self.base_url}/redirect")
+            assert response.status == 303
+
+            response = http.request("GET", f"{self.base_url}/redirect", redirect=True)
+            assert response.status == 303
+
+            response = http.request("GET", f"{self.base_url}/redirect", redirect=False)
+            assert response.status == 303
+
+    def test_redirects_disabled_for_individual_request(self) -> None:
+        """
+        Check handling redirects when they are meant to be disabled
+        on the request level.
+        """
+        with PoolManager() as http:
+            # Check when redirect is not passed.
+            with pytest.raises(MaxRetryError):
+                http.request("GET", f"{self.base_url}/redirect", retries=0)
+            response = http.request("GET", f"{self.base_url}/redirect", retries=False)
+            assert response.status == 303
+
+            # Check when redirect=True.
+            with pytest.raises(MaxRetryError):
+                http.request(
+                    "GET", f"{self.base_url}/redirect", retries=0, redirect=True
+                )
+            response = http.request(
+                "GET", f"{self.base_url}/redirect", retries=False, redirect=True
+            )
+            assert response.status == 303
+
+            # Check when redirect=False.
+            response = http.request(
+                "GET", f"{self.base_url}/redirect", retries=0, redirect=False
+            )
+            assert response.status == 303
+            response = http.request(
+                "GET", f"{self.base_url}/redirect", retries=False, redirect=False
+            )
+            assert response.status == 303
+
     def test_cross_host_redirect(self) -> None:
         with PoolManager() as http:
             cross_host_location = f"{self.base_url_alt}/echo?a=b"
@@ -155,6 +238,24 @@ class TestPoolManager(HTTPDummyServerTestCase):
             assert len(http.pools) == 1
             pool = http.connection_from_host(self.host, self.port)
             assert pool.num_connections == 1
+
+        # Check when retries are configured for the pool manager.
+        with PoolManager(retries=1) as http:
+            with pytest.raises(MaxRetryError):
+                http.request(
+                    "GET",
+                    f"{self.base_url}/redirect",
+                    fields={"target": f"/redirect?target={self.base_url}/"},
+                )
+
+            # Here we allow more retries for the request.
+            response = http.request(
+                "GET",
+                f"{self.base_url}/redirect",
+                fields={"target": f"/redirect?target={self.base_url}/"},
+                retries=2,
+            )
+            assert response.status == 200
 
     def test_redirect_cross_host_remove_headers(self) -> None:
         with PoolManager() as http:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1634,6 +1634,7 @@ class TestSSL(SocketDummyServerTestCase):
 
         context = mock.create_autospec(ssl_.SSLContext)
         context.load_default_certs = mock.Mock()
+        context.cert_store_stats = mock.Mock(return_value={"x509_ca": 5})
         context.options = 0
 
         with mock.patch("urllib3.util.ssl_.SSLContext", lambda *_, **__: context):


### PR DESCRIPTION
2.13.900 (2024-06-22)
=====================

- Fixed passing ``ca_cert_data`` as ``bytes`` instead of ``str``.
- Backported Security fix CVE-2025-50181 (5.3 Medium, GHSA-pq67-6m6q-mj2v) from upstream urllib3 v2.5.0
- Fixed backward incompatible change on the ssl configuration when urllib3-future is invoked by other than Niquests.
  The default cipher list will fallback to system's default when Niquests is not the invoker. Also stop setting
  ``OP_NO_RENEGOTIATION`` in ssl_options when it's not Niquests.
- Fixed a rare bug causing the connection to improperly upgrade to QUIC when no ssl ca are given.
- Updated the low bound version requirement for ``qh3`` to v1.5.3 due to some significant improvement toward
  unifying PKI validation behaviors with Python default expectation (w/ OpenSSL).
- Changed default behavior when passing a SSLContext with no loaded CA in store. Previously we did not called
  ``load_default_certs``. We now check if the store is empty, then we load the default certs.

