### PR TITLE
Release 2.13.902

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-2.13.902 (2024-08-06)
+2.13.902 (2024-08-10)
 =====================
 
 - Fixed long standing missing ``ciphers`` kwargs that can be propagated without a

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.13.902 (2024-08-06)
+=====================
+
+- Fixed long standing missing ``ciphers`` kwargs that can be propagated without a
+  custom ``ssl.SSLContext`` via ``(Async)PoolManager`` and others.
+
 2.13.901 (2024-08-02)
 =====================
 

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -191,6 +191,7 @@ def ssl_options_to_context(  # type: ignore[no-untyped-def]
 
     ctx.load_cert_chain(certfile, keyfile)
     ctx.verify_mode = cert_reqs
+
     if ctx.verify_mode != cert_none:
         ctx.load_verify_locations(cafile=ca_certs)
     if alpn_protocols and hasattr(ctx, "set_alpn_protocols"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ filterwarnings = [
     '''ignore:.*set_event_loop.*:DeprecationWarning''',
     '''ignore:.*EventLoopPolicy.*:DeprecationWarning''',
     '''ignore:.*but not measured.*:coverage.exceptions.CoverageWarning''',
+    '''ignore:.*No data was collected*.:coverage.exceptions.CoverageWarning''',
     '''default:ssl\.PROTOCOL_TLS is deprecated:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLSv1 is deprecated:DeprecationWarning''',
     '''default:ssl\.TLSVersion\.TLSv1_1 is deprecated:DeprecationWarning''',

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -698,6 +698,7 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
     key_password: str | None = None
     cert_data: str | bytes | None = None
     key_data: str | bytes | None = None
+    ciphers: str | None = None
 
     def __init__(
         self,
@@ -732,6 +733,7 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
         key_password: str | None = None,
         cert_data: str | bytes | None = None,
         key_data: str | bytes | None = None,
+        ciphers: str | None = None,
     ) -> None:
         if not is_capable_for_quic(ssl_context, ssl_maximum_version):
             if disabled_svn is None:
@@ -770,6 +772,7 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
         self.ca_certs = ca_certs and os.path.expanduser(ca_certs)
         self.ca_cert_dir = ca_cert_dir and os.path.expanduser(ca_cert_dir)
         self.ca_cert_data = ca_cert_data
+        self.ciphers = ciphers
 
         # cert_reqs depends on ssl_context so calculate last.
         if cert_reqs is None:
@@ -881,6 +884,7 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
                 alpn_protocols=alpn_protocols or None,
                 cert_data=self.cert_data,
                 key_data=self.key_data,
+                ciphers=self.ciphers,
             )
 
             # we want the http3 upgrade to behave
@@ -944,6 +948,7 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
             ssl_context=ssl_context,
             assert_hostname=proxy_config.assert_hostname,
             assert_fingerprint=proxy_config.assert_fingerprint,
+            ciphers=self.ciphers,
             # Features that aren't implemented for proxies yet:
             cert_file=None,
             key_file=None,
@@ -988,6 +993,7 @@ async def _ssl_wrap_socket_and_match_hostname(
     alpn_protocols: list[str] | None = None,
     cert_data: str | bytes | None = None,
     key_data: str | bytes | None = None,
+    ciphers: str | None = None,
 ) -> _WrappedAndVerifiedSocket:
     """Logic for constructing an SSLContext from all TLS parameters, passing
     that down into ssl_wrap_socket, and then doing certificate verification
@@ -1052,6 +1058,7 @@ async def _ssl_wrap_socket_and_match_hostname(
         certdata=cert_data,
         keydata=key_data,
         sharable_ssl_context=sharable_ext_options if default_ssl_context else None,
+        ciphers=ciphers,
     )
 
     try:

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -2035,6 +2035,7 @@ class AsyncHTTPSConnectionPool(AsyncHTTPConnectionPool):
         ca_cert_data: None | str | bytes = None,
         cert_data: str | bytes | None = None,
         key_data: str | bytes | None = None,
+        ciphers: str | None = None,
         **conn_kw: typing.Any,
     ) -> None:
         super().__init__(
@@ -2064,6 +2065,7 @@ class AsyncHTTPSConnectionPool(AsyncHTTPConnectionPool):
         self.ssl_maximum_version = ssl_maximum_version
         self.assert_hostname = assert_hostname
         self.assert_fingerprint = assert_fingerprint
+        self.ciphers = ciphers
 
     async def _prepare_proxy(self, conn: AsyncHTTPSConnection) -> None:  # type: ignore[override]
         """Establishes a tunnel connection through HTTP CONNECT."""
@@ -2268,6 +2270,7 @@ class AsyncHTTPSConnectionPool(AsyncHTTPConnectionPool):
                                 ssl_maximum_version=self.ssl_maximum_version,
                                 cert_data=self.cert_data,
                                 key_data=self.key_data,
+                                ciphers=self.ciphers,
                                 **conn_kw,
                             )
                         )
@@ -2354,6 +2357,7 @@ class AsyncHTTPSConnectionPool(AsyncHTTPConnectionPool):
                     ssl_maximum_version=self.ssl_maximum_version,
                     cert_data=self.cert_data,
                     key_data=self.key_data,
+                    ciphers=self.ciphers,
                     **self.conn_kw,
                 )
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.13.901"
+__version__ = "2.13.902"

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -675,6 +675,7 @@ class HTTPSConnection(HTTPConnection):
     key_password: str | None = None
     cert_data: str | bytes | None = None
     key_data: str | bytes | None = None
+    ciphers: str | None = None
 
     def __init__(
         self,
@@ -709,6 +710,7 @@ class HTTPSConnection(HTTPConnection):
         key_password: str | None = None,
         cert_data: str | bytes | None = None,
         key_data: str | bytes | None = None,
+        ciphers: str | None = None,
     ) -> None:
         if not is_capable_for_quic(ssl_context, ssl_maximum_version):
             if disabled_svn is None:
@@ -747,6 +749,7 @@ class HTTPSConnection(HTTPConnection):
         self.ca_certs = ca_certs and os.path.expanduser(ca_certs)
         self.ca_cert_dir = ca_cert_dir and os.path.expanduser(ca_cert_dir)
         self.ca_cert_data = ca_cert_data
+        self.ciphers = ciphers
 
         # cert_reqs depends on ssl_context so calculate last.
         if cert_reqs is None:
@@ -858,6 +861,7 @@ class HTTPSConnection(HTTPConnection):
                 alpn_protocols=alpn_protocols or None,
                 cert_data=self.cert_data,
                 key_data=self.key_data,
+                ciphers=self.ciphers,
             )
 
             # we want the http3 upgrade to behave
@@ -916,6 +920,7 @@ class HTTPSConnection(HTTPConnection):
             ssl_context=ssl_context,
             assert_hostname=proxy_config.assert_hostname,
             assert_fingerprint=proxy_config.assert_fingerprint,
+            ciphers=self.ciphers,
             # Features that aren't implemented for proxies yet:
             cert_file=None,
             key_file=None,
@@ -960,6 +965,7 @@ def _ssl_wrap_socket_and_match_hostname(
     alpn_protocols: list[str] | None = None,
     cert_data: str | bytes | None = None,
     key_data: str | bytes | None = None,
+    ciphers: str | None = None,
 ) -> _WrappedAndVerifiedSocket:
     """Logic for constructing an SSLContext from all TLS parameters, passing
     that down into ssl_wrap_socket, and then doing certificate verification
@@ -1024,6 +1030,7 @@ def _ssl_wrap_socket_and_match_hostname(
         certdata=cert_data,
         keydata=key_data,
         sharable_ssl_context=sharable_ext_options if default_ssl_context else None,
+        ciphers=ciphers,
     )
 
     try:

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1992,6 +1992,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         ca_cert_data: None | str | bytes = None,
         cert_data: str | bytes | None = None,
         key_data: str | bytes | None = None,
+        ciphers: str | None = None,
         **conn_kw: typing.Any,
     ) -> None:
         super().__init__(
@@ -2019,6 +2020,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         self.ssl_version = ssl_version
         self.ssl_minimum_version = ssl_minimum_version
         self.ssl_maximum_version = ssl_maximum_version
+        self.ciphers = ciphers
         self.assert_hostname = assert_hostname
         self.assert_fingerprint = assert_fingerprint
 
@@ -2179,6 +2181,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                                 ssl_maximum_version=self.ssl_maximum_version,
                                 cert_data=self.cert_data,
                                 key_data=self.key_data,
+                                ciphers=self.ciphers,
                                 **conn_kw,
                             )
                         )
@@ -2278,6 +2281,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                     ssl_maximum_version=self.ssl_maximum_version,
                     cert_data=self.cert_data,
                     key_data=self.key_data,
+                    ciphers=self.ciphers,
                     **self.conn_kw,
                 )
 

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -66,6 +66,7 @@ SSL_KEYWORDS = (
     "server_hostname",
     "cert_data",
     "key_data",
+    "ciphers",
 )
 
 _SelfT = typing.TypeVar("_SelfT")
@@ -98,6 +99,7 @@ class PoolKey(typing.NamedTuple):
     key_ca_cert_dir: str | None
     key_ca_cert_data: str | bytes | None
     key_ssl_context: ssl.SSLContext | None
+    key_ciphers: str | None
     key_maxsize: int | None
     key_headers: frozenset[tuple[str, str]] | None
     key__proxy: Url | None

--- a/src/urllib3/util/_async/ssl_.py
+++ b/src/urllib3/util/_async/ssl_.py
@@ -156,6 +156,9 @@ async def ssl_wrap_socket(
             ):  # Defensive: in CI, we always have set_alpn_protocols
                 pass
 
+            if ciphers:
+                context.set_ciphers(ciphers)
+
             if sharable_ssl_context is not None:
                 _SSLContextCache.save(context)
         else:

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -721,6 +721,9 @@ def ssl_wrap_socket(
             ):  # Defensive: in CI, we always have set_alpn_protocols
                 pass
 
+            if ciphers:
+                context.set_ciphers(ciphers)
+
             if sharable_ssl_context is not None:
                 _SSLContextCache.save(context)
         else:
@@ -794,22 +797,6 @@ def is_capable_for_quic(
                 ctx.maximum_version != ssl.TLSVersion.MAXIMUM_SUPPORTED
                 and ctx.maximum_version <= ssl.TLSVersion.TLSv1_2
             ):
-                quic_disable = True
-        else:
-            any_capable_cipher: bool = False
-            for cipher_dict in ctx.get_ciphers():
-                if cipher_dict["name"] in [
-                    "TLS_AES_128_GCM_SHA256",
-                    "TLS_AES_256_GCM_SHA384",
-                    "TLS_CHACHA20_POLY1305_SHA256",
-                    # Alias-cipher
-                    "CHACHA20-POLY1305-SHA256",
-                    "AES-256-GCM-SHA384",
-                    "AES-128-GCM-SHA256",
-                ]:
-                    any_capable_cipher = True
-                    break
-            if not any_capable_cipher:
                 quic_disable = True
 
     if ssl_maximum_version and ssl_maximum_version <= ssl.TLSVersion.TLSv1_2:

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -776,7 +776,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
 
         conn_info: ConnectionInfo | None = None
 
-        def _retrieve_conn_info(info):
+        def _retrieve_conn_info(info: ConnectionInfo) -> None:
             nonlocal conn_info
             conn_info = info
 


### PR DESCRIPTION

2.13.902 (2024-08-10)
=====================

- Fixed long standing missing ``ciphers`` kwargs that can be propagated without a
  custom ``ssl.SSLContext`` via ``(Async)PoolManager`` and others.
