### PR TITLE
Release 2.13.903

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.13.903 (2024-08-11)
+=====================
+
+- Bumped lower bound of qh3. The ``crlDistributionPoints`` getter is now officially implemented in qh3 >= 1.5.4.
+
 2.13.902 (2024-08-10)
 =====================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 requires-python = ">=3.7"
 dynamic = ["version"]
 dependencies = [
-  "qh3>=1.5.3,<2.0.0; (platform_python_implementation != 'CPython' or python_full_version > '3.7.10') and (platform_system == 'Darwin' or platform_system == 'Windows' or platform_system == 'Linux') and (platform_machine == 'x86_64' or platform_machine == 's390x' or platform_machine == 'armv7l' or platform_machine == 'ppc64le' or platform_machine == 'ppc64' or platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ARM64' or platform_machine == 'x86' or platform_machine == 'i686') and (platform_python_implementation == 'CPython' or (platform_python_implementation == 'PyPy' and python_version < '3.12'))",
+  "qh3>=1.5.4,<2.0.0; (platform_python_implementation != 'CPython' or python_full_version > '3.7.10') and (platform_system == 'Darwin' or platform_system == 'Windows' or platform_system == 'Linux') and (platform_machine == 'x86_64' or platform_machine == 's390x' or platform_machine == 'armv7l' or platform_machine == 'ppc64le' or platform_machine == 'ppc64' or platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ARM64' or platform_machine == 'x86' or platform_machine == 'i686') and (platform_python_implementation == 'CPython' or (platform_python_implementation == 'PyPy' and python_version < '3.12'))",
   "h11>=0.11.0,<1.0.0",
   "jh2>=5.0.3,<6.0.0",
 ]
@@ -59,7 +59,7 @@ socks = [
   "python-socks>=2.0,<=2.6.1",
 ]
 qh3 = [
-  "qh3>=1.5.3,<2.0.0",
+  "qh3>=1.5.4,<2.0.0",
 ]
 ws = [
   "wsproto>=1.2,<2",

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.13.902"
+__version__ = "2.13.903"

--- a/src/urllib3/contrib/hface/protocols/http3/_qh3.py
+++ b/src/urllib3/contrib/hface/protocols/http3/_qh3.py
@@ -548,13 +548,11 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
 
         peer_info["crlDistributionPoints"] = []
 
-        # may not be available[...]
-        if hasattr(x509_certificate, "get_crl_endpoints"):
-            for endpoint in x509_certificate.get_crl_endpoints():
-                decoded_endpoint = endpoint.decode()
-                peer_info["crlDistributionPoints"].append(  # type: ignore[attr-defined]
-                    decoded_endpoint[decoded_endpoint.index("(") + 1 : -1]
-                )
+        for endpoint in x509_certificate.get_crl_endpoints():
+            decoded_endpoint = endpoint.decode()
+            peer_info["crlDistributionPoints"].append(  # type: ignore[attr-defined]
+                decoded_endpoint[decoded_endpoint.index("(") + 1 : -1]
+            )
 
         pop_keys = []
 

--- a/test/with_dummyserver/asynchronous/test_https.py
+++ b/test/with_dummyserver/asynchronous/test_https.py
@@ -365,7 +365,7 @@ class TestAsyncHTTPS(HTTPSDummyServerTestCase):
                 r = await https_pool.request("GET", "/")
                 assert r.status == 200
 
-            assert [str(wm) for wm in w] == []
+            assert [str(wm) for wm in w if "ResourceWarning" not in str(wm)] == []
 
     @pytest.mark.asyncio
     async def test_invalid_common_name(self) -> None:


### PR DESCRIPTION
2.13.903 (2024-08-11)
=====================

- Bumped lower bound of qh3. The ``crlDistributionPoints`` getter is now officially implemented in qh3 >= 1.5.4.

