### PR TITLE
Release 2.13.904

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.13.904 (2024-08-19)
+=====================
+
+- Improved performance when creating TLS connection. We removed a redundant ssl_ctx creation due to our
+  caching / reusability for ssl.SSLContext.
+- Fixed forcing disabling SSL renegotiation when explicitly setting ``@SECLEVEL=0`` in the cipher suite.
+
 2.13.903 (2024-08-11)
 =====================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 - Improved performance when creating TLS connection. We removed a redundant ssl_ctx creation due to our
   caching / reusability for ssl.SSLContext.
 - Fixed forcing disabling SSL renegotiation when explicitly setting ``@SECLEVEL=0`` in the cipher suite.
+- Fixed ssl_ctx caching invalidation when ca_certs and/or ca_cert_dir file/directory changed.
 
 2.13.903 (2024-08-11)
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-2.13.904 (2024-08-19)
+2.13.904 (2024-08-20)
 =====================
 
 - Improved performance when creating TLS connection. We removed a redundant ssl_ctx creation due to our

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.13.903"
+__version__ = "2.13.904"

--- a/src/urllib3/util/_async/ssl_.py
+++ b/src/urllib3/util/_async/ssl_.py
@@ -118,6 +118,8 @@ async def ssl_wrap_socket(
                     cert_reqs,
                     ciphers=ciphers,
                     caller_id=_KnownCaller.NIQUESTS,
+                    ssl_minimum_version=ssl_minimum_version,
+                    ssl_maximum_version=ssl_maximum_version,
                 )
 
             if cert_reqs is not None:

--- a/src/urllib3/util/_async/ssl_.py
+++ b/src/urllib3/util/_async/ssl_.py
@@ -4,6 +4,7 @@ import io
 import os
 import typing
 import warnings
+from pathlib import Path
 
 if typing.TYPE_CHECKING:
     import ssl
@@ -93,12 +94,12 @@ async def ssl_wrap_socket(
 
     with _SSLContextCache.lock(
         keyfile,
-        certfile,
+        certfile if certfile is None else Path(certfile),
         cert_reqs,
         ca_certs,
         ssl_version,
         ciphers,
-        ca_cert_dir,
+        ca_cert_dir if ca_cert_dir is None else Path(ca_cert_dir),
         alpn_protocols,
         certdata,
         keydata,

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -464,11 +464,14 @@ def create_urllib3_context(
     # PROTOCOL_TLS is deprecated in Python 3.10 so we always use PROTOCOL_TLS_CLIENT
     context = SSLContext(PROTOCOL_TLS_CLIENT)
 
+    default_tlsv1_2: bool = False
+
     if SUPPORT_MIN_MAX_TLS_VERSION:
         if ssl_minimum_version is not None:
             context.minimum_version = ssl_minimum_version
         else:  # Python <3.10 defaults to 'MINIMUM_SUPPORTED' so explicitly set TLSv1.2 here
             context.minimum_version = TLSVersion.TLSv1_2
+            default_tlsv1_2 = True
 
         if ssl_maximum_version is not None:
             context.maximum_version = ssl_maximum_version
@@ -477,7 +480,7 @@ def create_urllib3_context(
     # the case of OpenSSL 1.1.1+ or use our own secure default ciphers.
     if ciphers:
         context.set_ciphers(ciphers)
-    else:
+    elif default_tlsv1_2:  # we should not set recommended ciphers if not TLS1.2 min!
         # Only apply if Niquests or direct urllib3-future usage
         # Don't bother other or Requests.
         if caller_id is None or caller_id is _KnownCaller.NIQUESTS:

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -505,9 +505,15 @@ def create_urllib3_context(
         # Only apply if Niquests or direct urllib3-future usage
         # Don't bother other or Requests.
         if caller_id is None or caller_id is _KnownCaller.NIQUESTS:
+            # some may want to still enable the renegotiation due to
+            # compatibility issue. we found some old IIS server rejecting HTTP
+            # request (with close conn) when this setting is set...!
+            weak_security_set = ciphers is not None and ciphers.upper().endswith(
+                "@SECLEVEL=0"
+            )
             # Disable renegotiation as it was proven to be weak and dangerous.
             if (
-                OP_NO_RENEGOTIATION is not None
+                OP_NO_RENEGOTIATION is not None and weak_security_set is False
             ):  # Not always available depending on your interpreter.
                 options |= OP_NO_RENEGOTIATION
 

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -112,8 +112,10 @@ class _CacheableSSLContext:
         key = _compute_key_ctx_build(*args)
         with self._lock:
             self._cursor = key
-            yield
-            self._cursor = None
+            try:
+                yield
+            finally:
+                self._cursor = None
 
     def get(self) -> ssl.SSLContext | None:
         with self._lock:

--- a/src/urllib3/util/ssltransport.py
+++ b/src/urllib3/util/ssltransport.py
@@ -135,6 +135,10 @@ class SSLTransport:
     def cipher(self) -> tuple[str, str, int] | None:
         return self.sslobj.cipher()
 
+    @property
+    def context(self) -> ssl.SSLContext:
+        return self.sslobj.context
+
     def selected_alpn_protocol(self) -> str | None:
         return self.sslobj.selected_alpn_protocol()
 

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -248,6 +248,7 @@ class TestConnection:
         context.wrap_socket.return_value.getpeercert.return_value = {
             "subjectAltName": (("DNS", "google.com"),)
         }
+        context.wrap_socket.return_value.context = context
         conn = HTTPSConnection(
             "google.com", port=443, assert_hostname="example.com", ssl_context=context
         )

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -131,14 +131,20 @@ class TestSSL:
     def test_create_urllib3_context_default_ciphers(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        support_min_max = hasattr(ssl_.SSLContext, "minimum_version")
+
         context = mock.create_autospec(ssl_.SSLContext)
         context.set_ciphers = mock.Mock()
         context.options = 0
+
         monkeypatch.setattr(ssl_, "SSLContext", lambda *_, **__: context)
 
         ssl_.create_urllib3_context(caller_id=ssl_._KnownCaller.NIQUESTS)
 
-        context.set_ciphers.assert_called_once_with(MOZ_INTERMEDIATE_CIPHERS)
+        if support_min_max:
+            context.set_ciphers.assert_called_once_with(MOZ_INTERMEDIATE_CIPHERS)
+        else:
+            context.set_ciphers.assert_not_called()
 
     @pytest.mark.parametrize(
         "kwargs",

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -84,10 +84,10 @@ class TestSSL:
         monkeypatch.setattr(ssl_, "SSLContext", lambda *_, **__: context)
 
         sock = mock.Mock()
-        ssl_.ssl_wrap_socket(sock, ca_certs="/tmp/fake-file")
+        ssl_.ssl_wrap_socket(sock, ca_certs="/tmp/fake-file-1")
 
         context.load_default_certs.assert_not_called()
-        context.load_verify_locations.assert_called_with("/tmp/fake-file", None, None)
+        context.load_verify_locations.assert_called_with("/tmp/fake-file-1", None, None)
 
     def test_wrap_socket_default_loads_default_certs(
         self, monkeypatch: pytest.MonkeyPatch

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1024,7 +1024,12 @@ class TestUtilSSL:
         ssl_wrap_socket(socket, cert_reqs=ssl.CERT_REQUIRED)
 
         create_urllib3_context.assert_called_once_with(
-            None, 2, ciphers=None, caller_id=_KnownCaller.OTHER
+            None,
+            2,
+            ciphers=None,
+            caller_id=_KnownCaller.OTHER,
+            ssl_minimum_version=None,
+            ssl_maximum_version=None,
         )
 
     def test_ssl_wrap_socket_loads_verify_locations(self) -> None:


### PR DESCRIPTION
2.13.904 (2024-08-20)
=====================

- Improved performance when creating TLS connection. We removed a redundant ssl_ctx creation due to our
  caching / reusability for ssl.SSLContext.
- Fixed forcing disabling SSL renegotiation when explicitly setting ``@SECLEVEL=0`` in the cipher suite.
- Fixed ssl_ctx caching invalidation when ca_certs and/or ca_cert_dir file/directory changed.
