### PR TITLE
:bug: fix rare edge cases where upgrading or forcing HTTP/3 over QUIC with zero SSL configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.13.905 (2024-08-23)
+=====================
+
+- Fixed rare edge cases where upgrading or forcing HTTP/3 over QUIC with zero SSL configuration would lead
+  to an error validating the chain of certificate. This would also trigger needlessly a ``load_default_certs``
+  when not needed.
+
 2.13.904 (2024-08-20)
 =====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.13.904"
+__version__ = "2.13.905"

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -334,6 +334,23 @@ class HfaceBackend(BaseBackend):
 
         allow_insecure: bool = False
 
+        if not allow_insecure and resolve_cert_reqs(cert_reqs) == ssl.CERT_NONE:
+            allow_insecure = True
+
+        if (
+            not allow_insecure
+            and ca_certs is None
+            and ca_cert_dir is None
+            and ca_cert_data is None
+            and ssl_context is None
+        ):
+            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+            if hasattr(ssl_context, "load_default_certs"):
+                ssl_context.load_default_certs()
+            else:
+                ssl_context = None
+
         if ssl_context:
             cert_use_common_name = (
                 getattr(ssl_context, "hostname_checks_common_name", False) or False
@@ -356,9 +373,6 @@ class HfaceBackend(BaseBackend):
                 and ssl_context.check_hostname is False
             ):
                 assert_hostname = False
-
-        if not allow_insecure and resolve_cert_reqs(cert_reqs) == ssl.CERT_NONE:
-            allow_insecure = True
 
         self.__custom_tls_settings = QuicTLSConfig(
             insecure=allow_insecure,

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -53,7 +53,6 @@ from .util import SKIP_HEADER, SKIPPABLE_HEADERS
 from .util.request import body_to_chunks
 from .util.ssl_ import assert_fingerprint as _assert_fingerprint
 from .util.ssl_ import (
-    create_urllib3_context,
     is_capable_for_quic,
     is_ipaddress,
     resolve_cert_reqs,
@@ -768,30 +767,10 @@ class HTTPSConnection(HTTPConnection):
         sock: socket.socket | ssl.SSLSocket
         self.sock = sock = self._new_conn()
 
-        for_quic_ctx: ssl.SSLContext | None
-
-        # we need to have a usable configuration in case
-        # one decide to jump directly to the QUIC layer
-        # without any CA configured
-        if (
-            self.ca_certs is None
-            and self.ca_cert_dir is None
-            and self.ca_cert_data is None
-            and self.ssl_context is None
-        ):
-            self._upgrade_ctx = create_urllib3_context()
-
-            if hasattr(self._upgrade_ctx, "load_default_certs"):
-                self._upgrade_ctx.load_default_certs()
-
-            for_quic_ctx = self._upgrade_ctx
-        else:
-            for_quic_ctx = self.ssl_context
-
         # the protocol/state-machine may also ship with an external TLS Engine.
         if (
             self._custom_tls(
-                for_quic_ctx,
+                self.ssl_context,
                 self.ca_certs,
                 self.ca_cert_dir,
                 self.ca_cert_data,


### PR DESCRIPTION
2.13.905 (2024-08-23)
=====================

- Fixed rare edge cases where upgrading or forcing HTTP/3 over QUIC with zero SSL configuration would lead
  to an error validating the chain of certificate. This would also trigger needlessly a ``load_default_certs``
  when not needed.
