### PR TITLE
Release 2.13.906

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.13.906 (2024-08-27)
+=====================
+
+- Fixed charset transparency setter to not enforce ``charset=utf-8`` in Content-Type anymore due to incompatibilities found
+  in widely requested servers that still don't parse HTTP headers appropriately. We saw a 3rd party report that
+  a server rejected a request because it expected Content-Type to be exactly "X" and not "X; charset=utf-8".
+
 2.13.905 (2024-08-23)
 =====================
 

--- a/ci/0001-Mark-100-Continue-tests-as-failing.patch
+++ b/ci/0001-Mark-100-Continue-tests-as-failing.patch
@@ -1,8 +1,8 @@
 diff --git a/tests/unit/test_awsrequest.py b/tests/unit/test_awsrequest.py
-index 22bd9a7..862a244 100644
+index 4118d74..7dc7414 100644
 --- a/tests/unit/test_awsrequest.py
 +++ b/tests/unit/test_awsrequest.py
-@@ -34,6 +34,7 @@ from botocore.compat import file_type, six
+@@ -34,6 +34,7 @@ from botocore.compat import file_type
  from botocore.exceptions import UnseekableStreamError
  from tests import mock, unittest
  
@@ -10,7 +10,7 @@ index 22bd9a7..862a244 100644
  
  class IgnoreCloseBytesIO(io.BytesIO):
      def close(self):
-@@ -370,6 +371,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -373,6 +374,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
          conn.response_class.return_value = self.mock_response
          return conn
  
@@ -18,7 +18,7 @@ index 22bd9a7..862a244 100644
      def test_expect_100_continue_returned(self):
          with mock.patch('urllib3.util.wait_for_read') as wait_mock:
              # Shows the server first sending a 100 continue response
-@@ -387,6 +389,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -390,6 +392,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
              # Now we should verify that our final response is the 200 OK
              self.assertEqual(response.status, 200)
  
@@ -26,7 +26,7 @@ index 22bd9a7..862a244 100644
      def test_handles_expect_100_with_different_reason_phrase(self):
          with mock.patch('urllib3.util.wait_for_read') as wait_mock:
              # Shows the server first sending a 100 continue response
-@@ -412,6 +415,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -415,6 +418,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
              # continue.
              self.assertIn(b'body', s.sent_data)
  
@@ -34,7 +34,15 @@ index 22bd9a7..862a244 100644
      def test_expect_100_sends_connection_header(self):
          # When using squid as an HTTP proxy, it will also send
          # a Connection: keep-alive header back with the 100 continue
-@@ -439,6 +443,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -442,6 +446,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+             response = conn.getresponse()
+             self.assertEqual(response.status, 500)
+ 
++    @pytest.mark.xfail(reason="https://github.com/urllib3/urllib3/pull/2565")
+     def test_expect_100_sends_connection_header_optional_continue(self):
+         # When using squid as an HTTP proxy, it will also send
+         # a Connection: keep-alive header back with the 100 continue
+@@ -469,6 +474,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
              response = conn.getresponse()
              self.assertEqual(response.status, 500)
  
@@ -42,7 +50,7 @@ index 22bd9a7..862a244 100644
      def test_expect_100_continue_sends_307(self):
          # This is the case where we send a 100 continue and the server
          # immediately sends a 307
-@@ -461,6 +466,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -491,6 +497,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
              # Now we should verify that our final response is the 307.
              self.assertEqual(response.status, 307)
  
@@ -50,7 +58,7 @@ index 22bd9a7..862a244 100644
      def test_expect_100_continue_no_response_from_server(self):
          with mock.patch('urllib3.util.wait_for_read') as wait_mock:
              # Shows the server first sending a 100 continue response
-@@ -566,6 +572,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -596,6 +603,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
          response = conn.getresponse()
          self.assertEqual(response.status, 200)
  
@@ -58,3 +66,4 @@ index 22bd9a7..862a244 100644
      def test_state_reset_on_connection_close(self):
          # This simulates what urllib3 does with connections
          # in its connection pool logic.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ filterwarnings = [
     '''default:ssl\.PROTOCOL_TLSv1_1 is deprecated:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLSv1_2 is deprecated:DeprecationWarning''',
     '''default:unclosed .*:ResourceWarning''',
+    '''default:.*leaks a thread.*:ResourceWarning''',
     '''ignore:No IPv6 support. Falling back to IPv4:Warning''',
     '''ignore:No IPv6 support. skipping:Warning''',
     '''ignore:ssl NPN is deprecated, use ALPN instead:DeprecationWarning''',

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -471,10 +471,7 @@ class AsyncHTTPConnection(AsyncHfaceBackend):
                 if isinstance(value_lower, bytes):
                     value_lower = value_lower.decode()
                     value = value.decode()
-                if "charset" not in value_lower:
-                    value = value.strip("; ")
-                    value = f"{value}; charset=utf-8"
-                else:
+                if "charset" in value_lower:
                     if (
                         "utf-8" not in value_lower
                         and "utf_8" not in value_lower
@@ -488,6 +485,7 @@ class AsyncHTTPConnection(AsyncHfaceBackend):
                             UserWarning,
                             stacklevel=2,
                         )
+
             self.putheader(header, value)
 
         try:

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -790,7 +790,7 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
         # the protocol/state-machine may also ship with an external TLS Engine.
         if (
             self._custom_tls(
-                self.ssl_context,
+                self.ssl_context or self._upgrade_ctx,
                 self.ca_certs,
                 self.ca_cert_dir,
                 self.ca_cert_data,

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.13.905"
+__version__ = "2.13.906"

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -767,7 +767,7 @@ class HTTPSConnection(HTTPConnection):
         # the protocol/state-machine may also ship with an external TLS Engine.
         if (
             self._custom_tls(
-                self.ssl_context,
+                self.ssl_context or self._upgrade_ctx,
                 self.ca_certs,
                 self.ca_cert_dir,
                 self.ca_cert_data,

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -475,10 +475,7 @@ class HTTPConnection(HfaceBackend):
                 if isinstance(value_lower, bytes):
                     value_lower = value_lower.decode()
                     value = value.decode()
-                if "charset" not in value_lower:
-                    value = value.strip("; ")
-                    value = f"{value}; charset=utf-8"
-                else:
+                if "charset" in value_lower:
                     if (
                         "utf-8" not in value_lower
                         and "utf_8" not in value_lower

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -2703,7 +2703,7 @@ class TestContentFraming(SocketDummyServerTestCase):
 
         sent_bytes = bytes(buffer)
 
-        assert b"Content-Type: application/json; charset=utf-8\r\n" in sent_bytes
+        assert b"Content-Type: application/json\r\n" in sent_bytes
 
     def test_partial_overrule_bytes_content_type(self) -> None:
         buffer = bytearray()
@@ -2740,7 +2740,7 @@ class TestContentFraming(SocketDummyServerTestCase):
 
         sent_bytes = bytes(buffer)
 
-        assert b"Content-Type: application/json; charset=utf-8\r\n" in sent_bytes
+        assert b"Content-Type: application/json\r\n" in sent_bytes
 
     def test_no_overrule_str_content_type(self) -> None:
         buffer = bytearray()

--- a/test/with_traefik/asynchronous/test_send_data.py
+++ b/test/with_traefik/asynchronous/test_send_data.py
@@ -30,6 +30,9 @@ class TestPostBody(TraefikTestCase):
             assert resp.status == 200
             assert "Content-Length" in (await resp.json())["headers"]
             assert (await resp.json())["headers"]["Content-Length"][0] == "4"
+            assert (await resp.json())["headers"]["Content-Type"][
+                0
+            ] == "text/plain; charset=utf-8"
 
     async def test_overrule_unicode_content_length_with_bytes_content_type(
         self,
@@ -44,15 +47,13 @@ class TestPostBody(TraefikTestCase):
                 "POST",
                 "/post",
                 body="🚀",
-                headers={"Content-Length": "1", "Content-Type": b"plain/text"},  # type: ignore[dict-item]
+                headers={"Content-Length": "1", "Content-Type": b"text/plain"},  # type: ignore[dict-item]
             )
 
             assert resp.status == 200
             assert "Content-Length" in (await resp.json())["headers"]
             assert "Content-Type" in (await resp.json())["headers"]
-            assert (await resp.json())["headers"]["Content-Type"][
-                0
-            ] == "plain/text; charset=utf-8"
+            assert (await resp.json())["headers"]["Content-Type"][0] == "text/plain"
             assert (await resp.json())["headers"]["Content-Length"][0] == "4"
 
     @pytest.mark.parametrize(

--- a/test/with_traefik/test_send_data.py
+++ b/test/with_traefik/test_send_data.py
@@ -28,6 +28,9 @@ class TestPostBody(TraefikTestCase):
 
             assert resp.status == 200
             assert "Content-Length" in resp.json()["headers"]
+            assert (
+                resp.json()["headers"]["Content-Type"][0] == "text/plain; charset=utf-8"
+            )
             assert resp.json()["headers"]["Content-Length"][0] == "4"
 
     def test_overrule_unicode_content_length_with_bytes_content_type(
@@ -43,15 +46,13 @@ class TestPostBody(TraefikTestCase):
                 "POST",
                 "/post",
                 body="🚀",
-                headers={"Content-Length": "1", "Content-Type": b"plain/text"},  # type: ignore[dict-item]
+                headers={"Content-Length": "1", "Content-Type": b"text/plain"},  # type: ignore[dict-item]
             )
 
             assert resp.status == 200
             assert "Content-Length" in resp.json()["headers"]
             assert "Content-Type" in resp.json()["headers"]
-            assert (
-                resp.json()["headers"]["Content-Type"][0] == "plain/text; charset=utf-8"
-            )
+            assert resp.json()["headers"]["Content-Type"][0] == "text/plain"
             assert resp.json()["headers"]["Content-Length"][0] == "4"
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
2.13.906 (2024-08-27)
=====================

- Fixed charset transparency setter to not enforce ``charset=utf-8`` in Content-Type anymore due to incompatibilities found
  in widely requested servers that still don't parse HTTP headers appropriately. We saw a 3rd party report that
  a server rejected a request because it expected Content-Type to be exactly "X" and not "X; charset=utf-8".
