### PR TITLE
Release 2.13.907

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.13.907 (2024-09-09)
+=====================
+
+- Fixed unhandled error in HTTP/3 upgrade (TCP+TLS to QUIC) procedure that mainly affect Windows users.
+  If your network silently filter QUIC packets or UDP is unreliable outside of your local network the
+  upgrade procedure could raise an exception instead of silently giving up on QUIC.
+- Fixed the accidental leaking of ``MustRedialException`` error in the consumption of the response (including WS or SEE).
+
 2.13.906 (2024-08-27)
 =====================
 

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -2371,10 +2371,6 @@ class AsyncHTTPSConnectionPool(AsyncHTTPConnectionPool):
         """
         await super()._validate_conn(conn)
 
-        # Force connect early to allow us to validate the connection.
-        if conn.is_closed:
-            await conn.connect()
-
         if not conn.is_verified and not conn.proxy_is_verified:
             warnings.warn(
                 (

--- a/src/urllib3/_async/response.py
+++ b/src/urllib3/_async/response.py
@@ -19,6 +19,7 @@ from ..exceptions import (
     ReadTimeoutError,
     ResponseNotReady,
     SSLError,
+    MustRedialError,
 )
 from ..response import ContentDecoder, HTTPResponse
 from ..util.response import is_fp_closed, BytesQueueBuffer
@@ -169,7 +170,7 @@ class AsyncHTTPResponse(HTTPResponse):
 
                 raise ReadTimeoutError(self._pool, None, "Read timed out.") from e  # type: ignore[arg-type]
 
-            except OSError as e:
+            except (OSError, MustRedialError) as e:
                 # This includes IncompleteRead.
                 raise ProtocolError(f"Connection broken: {e!r}", e) from e
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.13.906"
+__version__ = "2.13.907"

--- a/src/urllib3/contrib/webextensions/_async/protocol.py
+++ b/src/urllib3/contrib/webextensions/_async/protocol.py
@@ -11,7 +11,13 @@ if typing.TYPE_CHECKING:
     from ....backend._async._base import AsyncDirectStreamAccess
     from ....util._async.traffic_police import AsyncTrafficPolice
 
-from ....exceptions import BaseSSLError, ProtocolError, ReadTimeoutError, SSLError
+from ....exceptions import (
+    BaseSSLError,
+    ProtocolError,
+    ReadTimeoutError,
+    SSLError,
+    MustRedialError,
+)
 
 
 class AsyncExtensionFromHTTP(metaclass=ABCMeta):
@@ -60,7 +66,7 @@ class AsyncExtensionFromHTTP(metaclass=ABCMeta):
                 )
                 raise ReadTimeoutError(pool, None, "Read timed out.") from e  # type: ignore[arg-type]
 
-            except OSError as e:
+            except (OSError, MustRedialError) as e:
                 # This includes IncompleteRead.
                 raise ProtocolError(f"Connection broken: {e!r}", e) from e
 

--- a/src/urllib3/contrib/webextensions/protocol.py
+++ b/src/urllib3/contrib/webextensions/protocol.py
@@ -11,7 +11,13 @@ if typing.TYPE_CHECKING:
     from ...response import HTTPResponse
     from ...util.traffic_police import TrafficPolice
 
-from ...exceptions import BaseSSLError, ProtocolError, ReadTimeoutError, SSLError
+from ...exceptions import (
+    BaseSSLError,
+    ProtocolError,
+    ReadTimeoutError,
+    SSLError,
+    MustRedialError,
+)
 
 
 class ExtensionFromHTTP(metaclass=ABCMeta):
@@ -60,7 +66,7 @@ class ExtensionFromHTTP(metaclass=ABCMeta):
                 )
                 raise ReadTimeoutError(pool, None, "Read timed out.") from e  # type: ignore[arg-type]
 
-            except OSError as e:
+            except (OSError, MustRedialError) as e:
                 # This includes IncompleteRead.
                 raise ProtocolError(f"Connection broken: {e!r}", e) from e
 

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -51,6 +51,7 @@ from .exceptions import (
     ReadTimeoutError,
     ResponseNotReady,
     SSLError,
+    MustRedialError,
 )
 from .util.response import is_fp_closed, BytesQueueBuffer
 from .util.retry import Retry
@@ -662,7 +663,7 @@ class HTTPResponse(io.IOBase):
 
                 raise ReadTimeoutError(self._pool, None, "Read timed out.") from e  # type: ignore[arg-type]
 
-            except OSError as e:
+            except (OSError, MustRedialError) as e:
                 # This includes IncompleteRead.
                 raise ProtocolError(f"Connection broken: {e!r}", e) from e
 

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -5,6 +5,9 @@ import io
 import re
 import typing
 
+if typing.TYPE_CHECKING:
+    import http.client as httplib
+
 
 def is_fp_closed(obj: object) -> bool:
     """
@@ -105,3 +108,74 @@ class BytesQueueBuffer:
                 break
 
         return ret.getvalue()
+
+
+def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
+    """
+    Asserts whether all headers have been successfully parsed.
+    Extracts encountered errors from the result of parsing headers.
+
+    Only works on Python 3.
+
+    :param http.client.HTTPMessage headers: Headers to verify.
+
+    :raises urllib3.exceptions.HeaderParsingError:
+        If parsing errors are found.
+    """
+    from email.errors import (
+        MultipartInvariantViolationDefect,
+        StartBoundaryNotFoundDefect,
+    )
+    from ..exceptions import HeaderParsingError
+
+    import http.client as httplib
+
+    # This will fail silently if we pass in the wrong kind of parameter.
+    # To make debugging easier add an explicit check.
+    if not isinstance(headers, httplib.HTTPMessage):
+        raise TypeError(f"expected httplib.Message, got {type(headers)}.")
+
+    unparsed_data = None
+
+    # get_payload is actually email.message.Message.get_payload;
+    # we're only interested in the result if it's not a multipart message
+    if not headers.is_multipart():
+        payload = headers.get_payload()
+
+        if isinstance(payload, (bytes, str)):
+            unparsed_data = payload
+
+    # httplib is assuming a response body is available
+    # when parsing headers even when httplib only sends
+    # header data to parse_headers() This results in
+    # defects on multipart responses in particular.
+    # See: https://github.com/urllib3/urllib3/issues/800
+
+    # So we ignore the following defects:
+    # - StartBoundaryNotFoundDefect:
+    #     The claimed start boundary was never found.
+    # - MultipartInvariantViolationDefect:
+    #     A message claimed to be a multipart but no subparts were found.
+    defects = [
+        defect
+        for defect in headers.defects
+        if not isinstance(
+            defect, (StartBoundaryNotFoundDefect, MultipartInvariantViolationDefect)
+        )
+    ]
+
+    if defects or unparsed_data:
+        raise HeaderParsingError(defects=defects, unparsed_data=unparsed_data)
+
+
+def is_response_to_head(response: httplib.HTTPResponse) -> bool:
+    """
+    Checks whether the request of a response has been a HEAD-request.
+
+    :param http.client.HTTPResponse response:
+        Response to check if the originating request
+        used 'HEAD' as a method.
+    """
+    # FIXME: Can we do this somehow without accessing private httplib _method?
+    method_str = response._method  # type: str  # type: ignore[attr-defined]
+    return method_str.upper() == "HEAD"


### PR DESCRIPTION
2.13.907 (2024-09-09)
=====================

- Fixed unhandled error in HTTP/3 upgrade (TCP+TLS to QUIC) procedure that mainly affect Windows users.
  If your network silently filter QUIC packets or UDP is unreliable outside of your local network the
  upgrade procedure could raise an exception instead of silently giving up on QUIC.
- Fixed the accidental leaking of ``MustRedialException`` error in the consumption of the response (including WS or SEE).
