### PR TITLE
Release 2.13.908

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.13.908 (2024-09-10)
+=====================
+
+- Fixed an edge case where a server would interrupt a SSE without error by closing the connection instead of using the FIN bit
+  on the last data chunk.
+
 2.13.907 (2024-09-09)
 =====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.13.907"
+__version__ = "2.13.908"

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -982,6 +982,25 @@ class HfaceBackend(BaseBackend):
                     if event.error_code == 0 and self._response is not None:
                         self._protocol = None
                         self.close()
+                        # A server may end the transmission without error
+                        # to mark the end of SSE for example. While it's not ideal
+                        # it's not forbidden either.
+                        if stream_id is not None and (
+                            event_type is DataReceived
+                            or (
+                                isinstance(event_type, tuple)
+                                and DataReceived in event_type
+                            )
+                        ):
+                            events.append(
+                                DataReceived(
+                                    stream_id,
+                                    b"",
+                                    end_stream=True,
+                                )
+                            )
+                            return events
+
                         raise MustRedialError(
                             f"Remote peer just closed our connection, probably for not answering to unsolicited packet. ({event.message})"
                         )


### PR DESCRIPTION
2.13.908 (2024-09-10)
=====================

- Fixed an edge case where a server would interrupt a SSE without error by closing the connection instead of using the FIN bit
  on the last data chunk.
