### PR TITLE
Fix a problem using urllib3.future with SOCK5 proxy.

### DIFF
--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -711,6 +711,7 @@ class HfaceBackend(BaseBackend):
             self.conn_info.certificate_der
             and hasattr(self, "_connect_timings")
             and not self.conn_info.tls_handshake_latency
+            and self._connect_timings
         ):
             self.conn_info.tls_handshake_latency = (
                 datetime.now(tz=timezone.utc) - self._connect_timings[-1]


### PR DESCRIPTION
### Subject
Added check "is not none" before to use _connect_timings

Problem using urllib3.future with SOCK5 proxy.

### Environment

Windows 10 with virtual environment 

Requirements:
```text
translators
requests[socks]
```

List Versions:
```python
>>> import platform
>>> import ssl
>>> import urllib3
>>> 
>>> print("OS", platform.platform())
OS Windows-10-10.0.19045-SP0
>>> print("Python", platform.python_version())
Python 3.9.10
>>> print(ssl.OPENSSL_VERSION)
OpenSSL 1.1.1m  14 Dec 2021
>>> print("urllib3", urllib3.__version__)
urllib3 2.14.900
```

Lib Versions:
```text
urllib3 2.14.900
requests 2.32.5
socks 1.7.1
```

### Steps to Reproduce

Code snippet (VPN connection using mullvad sock5)

```python
import urllib3, requests, socks, json

proxies = {
    "http": "socks5://10.64.0.1:1080",
    "https": "socks5://10.64.0.1:1080",
}
print("urllib3", urllib3.__version__)
print("requests", requests.__version__)
print("socks", socks.__version__)

r = requests.get("https://am.i.mullvad.net/json", proxies=proxies, timeout=10)
print(json.dumps(r.json(), indent=2))
```

### Expected Behavior

No problem during the connection.

### Actual Behavior

```bash
Traceback (most recent call last):
  File "<omitted>\project_x\test.py", line 11, in <module>
    r = requests.get("https://am.i.mullvad.net/json", proxies=proxies, timeout=10)
  File "<omitted>\project_x\.venv\lib\site-packages\requests\api.py", line 
73, in get
    return request("get", url, params=params, **kwargs)
  File "<omitted>\project_x\.venv\lib\site-packages\requests\api.py", line 
59, in request
    return session.request(method=method, url=url, **kwargs)
  File "<omitted>\project_x\.venv\lib\site-packages\requests\sessions.py", 
line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "<omitted>\project_x\.venv\lib\site-packages\requests\sessions.py", 
line 703, in send
    r = adapter.send(request, **kwargs)
  File "<omitted>\project_x\.venv\lib\site-packages\requests\adapters.py", 
line 644, in send
    resp = conn.urlopen(
  File "<omitted>\project_x\.venv\lib\site-packages\urllib3\connectionpool.py", line 1713, in urlopen
    response = self._make_request(  # type: ignore[call-overload,misc]
  File "<omitted>\project_x\.venv\lib\site-packages\urllib3\connectionpool.py", line 1233, in _make_request
    self._validate_conn(conn)
  File "<omitted>\project_x\.venv\lib\site-packages\urllib3\connectionpool.py", line 2296, in _validate_conn
    super()._validate_conn(conn)
  File "<omitted>\project_x\.venv\lib\site-packages\urllib3\connectionpool.py", line 788, in _validate_conn
    conn.connect()
  File "<omitted>\project_x\.venv\lib\site-packages\urllib3\connection.py", line 873, in connect
    self._post_conn()
  File "<omitted>\project_x\.venv\lib\site-packages\urllib3\backend\hface.py", line 716, in _post_conn
    datetime.now(tz=timezone.utc) - self._connect_timings[-1]
TypeError: 'NoneType' object is not subscriptable
```

### Fix / WorkAround

I also found the problem and the possible fix.

It was missed the 'is not None' check in this part of code:
https://github.com/jawah/urllib3.future/blob/c0e786b88018557c64e7660973559877dc3cecdc/src/urllib3/backend/hface.py#L710-L717

In the same file, there is the check before to handling the variable
https://github.com/jawah/urllib3.future/blob/c0e786b88018557c64e7660973559877dc3cecdc/src/urllib3/backend/hface.py#L626-L633

I opened this PR with the fix, but I had problem with docker during the test setup (nox) on my Windows PC.

I hope you appreciate that I spent about two hours debugging the problem 
(tried to understand why in urllib3 repo the backend folder was not present and why the versioning was higher and found after 20 tests that 'translators' used the urllib3.future instand urllib3) and another hour trying to run nox before opening this issue 

Bye :)
