### PR TITLE
Release 2.17.903

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,9 @@
-2.17.903 (2026-03-17)
+2.17.903 (2026-03-19)
 =====================
 
 - Fixed segfault when leveraging in memory certificate against build of Python using statically linked ssl lib.
 - Added support for in memory certificate through FIFO as a last resort in MacOS when facing bellow issue.
+- Fixed IMCC support on Linux when using a Freethreaded build of CPython.
 
 2.17.902 (2026-03-16)
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.17.903 (2026-03-17)
+=====================
+
+- Fixed segfault when leveraging in memory certificate against MacOS build of Python using statically linked ssl implementation.
+- Added support for in memory certificate through FIFO as a last resort in MacOS when facing bellow issue.
+
 2.17.902 (2026-03-16)
 =====================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 2.17.903 (2026-03-17)
 =====================
 
-- Fixed segfault when leveraging in memory certificate against MacOS build of Python using statically linked ssl implementation.
+- Fixed segfault when leveraging in memory certificate against build of Python using statically linked ssl lib.
 - Added support for in memory certificate through FIFO as a last resort in MacOS when facing bellow issue.
 
 2.17.902 (2026-03-16)

--- a/StaticOpenSSL.Dockerfile
+++ b/StaticOpenSSL.Dockerfile
@@ -46,4 +46,3 @@ CMD ["python", "-m", "pytest", "-v", "--cov=urllib3", "--cov-report=", \
     "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password_ctypes_only", \
     "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password_shm_only", \
     "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password_fifo_only"]
-

--- a/StaticOpenSSL.Dockerfile
+++ b/StaticOpenSSL.Dockerfile
@@ -42,4 +42,4 @@ ENV TERM=xterm-256color
 
 CMD ["python", "-m", "pytest", "-v", \
     "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_intermediate", \
-    "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password"]
+    "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password", "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password_ctypes_only", "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password_shm_only", "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password_fifo_only"]

--- a/StaticOpenSSL.Dockerfile
+++ b/StaticOpenSSL.Dockerfile
@@ -40,6 +40,10 @@ ENV TRAEFIK_HTTPBIN_ENABLE=false
 ENV CI=true
 ENV TERM=xterm-256color
 
-CMD ["python", "-m", "pytest", "-v", \
+CMD ["python", "-m", "pytest", "-v", "--cov=urllib3", "--cov-report=", \
     "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_intermediate", \
-    "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password", "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password_ctypes_only", "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password_shm_only", "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password_fifo_only"]
+    "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password", \
+    "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password_ctypes_only", \
+    "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password_shm_only", \
+    "test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_in_memory_client_key_password_fifo_only"]
+

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.17.902"
+__version__ = "2.17.903"

--- a/src/urllib3/contrib/imcc/__init__.py
+++ b/src/urllib3/contrib/imcc/__init__.py
@@ -8,6 +8,7 @@ if typing.TYPE_CHECKING:
 
 from ._ctypes import load_cert_chain as _ctypes_load_cert_chain
 from ._shm import load_cert_chain as _shm_load_cert_chain
+from ._fifo import load_cert_chain as _fifo_load_cert_chain
 
 SUPPORTED_METHODS: list[
     typing.Callable[
@@ -22,6 +23,7 @@ SUPPORTED_METHODS: list[
 ] = [
     _ctypes_load_cert_chain,
     _shm_load_cert_chain,
+    _fifo_load_cert_chain,  # MacOS last resort(...)
 ]
 
 

--- a/src/urllib3/contrib/imcc/_ctypes.py
+++ b/src/urllib3/contrib/imcc/_ctypes.py
@@ -210,8 +210,6 @@ class _OpenSSL:
 
 
 _IS_GIL_DISABLED = hasattr(sys, "_is_gil_enabled") and sys._is_gil_enabled() is False
-_IS_LINUX = sys.platform == "linux"
-_FT_HEAD_ADDITIONAL_OFFSET = 1 if _IS_LINUX else 2
 
 _head_extra_fields = []
 
@@ -221,6 +219,36 @@ if sys.flags.debug:
     # two pointers (_ob_next, _ob_prev).
     _head_extra_fields = [("_ob_next", ctypes.c_void_p), ("_ob_prev", ctypes.c_void_p)]
 
+# PyObject_HEAD layout differs between GIL and free-threaded builds.
+#
+# GIL build (16 bytes):
+#   Py_ssize_t ob_refcnt;      // 8 bytes
+#   PyTypeObject *ob_type;     // 8 bytes
+#
+# Free-threaded build (32 bytes):
+#   uintptr_t ob_tid;          // 8 bytes
+#   uint16_t  ob_flags;        // 2 bytes  (called _padding in 3.13)
+#   PyMutex   ob_mutex;        // 1 byte   (uint8_t)
+#   uint8_t   ob_gc_bits;      // 1 byte
+#   uint32_t  ob_ref_local;    // 4 bytes
+#   Py_ssize_t ob_ref_shared;  // 8 bytes
+#   PyTypeObject *ob_type;     // 8 bytes
+if _IS_GIL_DISABLED:
+    _pyobject_head_fields = [
+        ("ob_tid", ctypes.c_size_t),
+        ("ob_flags", ctypes.c_uint16),
+        ("ob_mutex", ctypes.c_uint8),
+        ("ob_gc_bits", ctypes.c_uint8),
+        ("ob_ref_local", ctypes.c_uint32),
+        ("ob_ref_shared", ctypes.c_ssize_t),
+        ("ob_type", ctypes.c_void_p),
+    ]
+else:
+    _pyobject_head_fields = [
+        ("ob_refcnt", ctypes.c_ssize_t),
+        ("ob_type", ctypes.c_void_p),
+    ]
+
 
 # Define the PySSLContext C structure using ctypes.
 # This definition assumes that 'SSL_CTX *ctx' is the first member
@@ -229,7 +257,7 @@ if sys.flags.debug:
 #
 # CPython's Modules/_ssl.c (simplified):
 # typedef struct {
-#     PyObject_HEAD  // Expands to _PyObject_HEAD_EXTRA (if debug) + ob_refcnt + ob_type
+#     PyObject_HEAD
 #     SSL_CTX *ctx;
 #     // ... other members ...
 # } PySSLContextObject;
@@ -237,15 +265,7 @@ if sys.flags.debug:
 class PySSLContextStruct(ctypes.Structure):
     _fields_ = (
         _head_extra_fields  # type: ignore[assignment]
-        + [
-            ("ob_refcnt", ctypes.c_ssize_t),  # Py_ssize_t ob_refcnt;
-            ("ob_type", ctypes.c_void_p),  # PyTypeObject *ob_type;
-        ]
-        + (
-            [(f"_ob_ft{i}", ctypes.c_void_p) for i in range(_FT_HEAD_ADDITIONAL_OFFSET)]
-            if _IS_GIL_DISABLED
-            else []
-        )
+        + _pyobject_head_fields
         + [
             ("ssl_ctx", ctypes.c_void_p),  # SSL_CTX *ctx; (this is the pointer we want)
             # If there were other C members between ob_type and ssl_ctx,

--- a/src/urllib3/contrib/imcc/_ctypes.py
+++ b/src/urllib3/contrib/imcc/_ctypes.py
@@ -85,42 +85,16 @@ class _OpenSSL:
                 self._ssl = ctypes.CDLL(ssl._ssl.__file__)
             else:
                 # _ssl is statically linked into the interpreter
-                # (e.g. python-build-standalone via uv). OpenSSL symbols
-                # are in the main process image; ctypes.CDLL(None) exposes them.
-                # see https://github.com/jawah/urllib3.future/issues/325 for more
-                # details.
-                self._ssl = ctypes.CDLL(None)
-
-                # On some platforms (e.g. macOS), ctypes.CDLL(None) may resolve
-                # SSL symbols from a different library than what _ssl was built
-                # against (e.g. system LibreSSL vs statically-linked OpenSSL).
-                # Calling functions from the wrong library on SSL_CTX* structs
-                # created by the real _ssl module will segfault due to ABI mismatch.
-                # We must verify the ctypes-resolved library matches before proceeding.
-                _ctypes_version: str | None = None
-
-                if hasattr(self._ssl, "OpenSSL_version"):
-                    self._ssl.OpenSSL_version.argtypes = [ctypes.c_int]
-                    self._ssl.OpenSSL_version.restype = ctypes.c_char_p
-                    _ctypes_version = self._ssl.OpenSSL_version(0).decode()
-                elif hasattr(self._ssl, "SSLeay_version"):
-                    self._ssl.SSLeay_version.argtypes = [ctypes.c_int]
-                    self._ssl.SSLeay_version.restype = ctypes.c_char_p
-                    _ctypes_version = self._ssl.SSLeay_version(0).decode()
-
-                if _ctypes_version is None:
-                    raise UnsupportedOperation(
-                        "Unable to verify the SSL library resolved via ctypes.CDLL(None). "
-                        "Neither OpenSSL_version nor SSLeay_version symbols are available."
-                    )
-
-                if _ctypes_version != ssl.OPENSSL_VERSION:
-                    raise UnsupportedOperation(
-                        f"SSL library mismatch: Python's _ssl is built against "
-                        f"'{ssl.OPENSSL_VERSION}' but ctypes.CDLL(None) resolved "
-                        f"'{_ctypes_version}'. The statically-linked SSL symbols "
-                        f"are not exported in the process symbol table."
-                    )
+                # (e.g. python-build-standalone via uv). The symbols are NOT
+                # exported in the dynamic symbol table, and loading a system
+                # libssl would be a different library instance whose functions
+                # cannot safely operate on SSL_CTX* pointers created by the
+                # statically-linked copy (segfault due to separate global state).
+                # see https://github.com/jawah/urllib3.future/issues/325
+                raise UnsupportedOperation(
+                    "Unable to use ctypes: _ssl is statically linked into "
+                    "the interpreter. Falling back to alternate methods."
+                )
 
             self._crypto = self._ssl
 

--- a/src/urllib3/contrib/imcc/_ctypes.py
+++ b/src/urllib3/contrib/imcc/_ctypes.py
@@ -90,6 +90,38 @@ class _OpenSSL:
                 # see https://github.com/jawah/urllib3.future/issues/325 for more
                 # details.
                 self._ssl = ctypes.CDLL(None)
+
+                # On some platforms (e.g. macOS), ctypes.CDLL(None) may resolve
+                # SSL symbols from a different library than what _ssl was built
+                # against (e.g. system LibreSSL vs statically-linked OpenSSL).
+                # Calling functions from the wrong library on SSL_CTX* structs
+                # created by the real _ssl module will segfault due to ABI mismatch.
+                # We must verify the ctypes-resolved library matches before proceeding.
+                _ctypes_version: str | None = None
+
+                if hasattr(self._ssl, "OpenSSL_version"):
+                    self._ssl.OpenSSL_version.argtypes = [ctypes.c_int]
+                    self._ssl.OpenSSL_version.restype = ctypes.c_char_p
+                    _ctypes_version = self._ssl.OpenSSL_version(0).decode()
+                elif hasattr(self._ssl, "SSLeay_version"):
+                    self._ssl.SSLeay_version.argtypes = [ctypes.c_int]
+                    self._ssl.SSLeay_version.restype = ctypes.c_char_p
+                    _ctypes_version = self._ssl.SSLeay_version(0).decode()
+
+                if _ctypes_version is None:
+                    raise UnsupportedOperation(
+                        "Unable to verify the SSL library resolved via ctypes.CDLL(None). "
+                        "Neither OpenSSL_version nor SSLeay_version symbols are available."
+                    )
+
+                if _ctypes_version != ssl.OPENSSL_VERSION:
+                    raise UnsupportedOperation(
+                        f"SSL library mismatch: Python's _ssl is built against "
+                        f"'{ssl.OPENSSL_VERSION}' but ctypes.CDLL(None) resolved "
+                        f"'{_ctypes_version}'. The statically-linked SSL symbols "
+                        f"are not exported in the process symbol table."
+                    )
+
             self._crypto = self._ssl
 
         # we want to ensure a minimal set of symbols

--- a/src/urllib3/contrib/imcc/_fifo.py
+++ b/src/urllib3/contrib/imcc/_fifo.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import os
+import stat
+import tempfile
+import threading
+import typing
+from io import UnsupportedOperation
+
+if typing.TYPE_CHECKING:
+    import ssl
+
+def load_cert_chain(
+    ctx: ssl.SSLContext,
+    certdata: str | bytes,
+    keydata: str | bytes | None = None,
+    password: typing.Callable[[], str | bytes] | str | bytes | None = None,
+) -> None:
+    """Load cert chain using named pipes (FIFOs) instead of shm (linux).
+
+    Creates temporary FIFOs, feeds PEM data through background threads,
+    and lets ssl.SSLContext.load_cert_chain read from them. Data flows
+    through kernel pipe buffers without ever touching disk.
+
+    A single FIFO would deadlock on the second open.
+
+    The idea came from https://github.com/jawah/urllib3.future/issues/325#issuecomment-4069433443
+
+    :raise UnsupportedOperation: If anything goes wrong in the process.
+    """
+    if not hasattr(os, "mkfifo"):
+        raise UnsupportedOperation(
+            "Unable to provide support for in-memory client certificate: "
+            "os.mkfifo is not available on this platform."
+        )
+
+    if isinstance(certdata, str):
+        certdata = certdata.encode("ascii")
+    if keydata is not None and isinstance(keydata, str):
+        keydata = keydata.encode("ascii")
+
+    tmpdir = tempfile.mkdtemp(prefix="urllib3_imcc_")
+    cert_fifo = os.path.join(tmpdir, "cert.fifo")
+    key_fifo = os.path.join(tmpdir, "key.fifo") if keydata is not None else None
+
+    try:
+        os.mkfifo(cert_fifo, stat.S_IRUSR | stat.S_IWUSR)
+
+        if key_fifo is not None:
+            os.mkfifo(key_fifo, stat.S_IRUSR | stat.S_IWUSR)
+
+        writer_exc: BaseException | None = None
+
+        def _write_fifo(path: str, data: bytes) -> None:
+            nonlocal writer_exc
+            try:
+                with open(path, "wb") as f:
+                    f.write(data)
+            except BaseException as e:
+                writer_exc = e
+
+        cert_thread = threading.Thread(
+            target=_write_fifo, args=(cert_fifo, certdata), daemon=True
+        )
+        cert_thread.start()
+
+        key_thread: threading.Thread | None = None
+
+        if key_fifo is not None and keydata is not None:
+            key_thread = threading.Thread(
+                target=_write_fifo, args=(key_fifo, keydata), daemon=True
+            )
+            key_thread.start()
+
+        ctx.load_cert_chain(cert_fifo, keyfile=key_fifo, password=password)
+
+        cert_thread.join(timeout=1.)
+
+        if key_thread is not None:
+            key_thread.join(timeout=1.)
+
+        if writer_exc is not None:
+            raise UnsupportedOperation(
+                "Unable to provide support for in-memory client certificate: "
+                f"FIFO writer failed: {writer_exc}"
+            )
+    finally:
+        for p in (cert_fifo, key_fifo):
+            if p is not None:
+                try:
+                    os.unlink(p)
+                except OSError:  # Defensive:
+                    pass
+        try:
+            os.rmdir(tmpdir)
+        except OSError:  # Defensive:
+            pass

--- a/src/urllib3/contrib/imcc/_fifo.py
+++ b/src/urllib3/contrib/imcc/_fifo.py
@@ -10,6 +10,7 @@ from io import UnsupportedOperation
 if typing.TYPE_CHECKING:
     import ssl
 
+
 def load_cert_chain(
     ctx: ssl.SSLContext,
     certdata: str | bytes,
@@ -74,10 +75,10 @@ def load_cert_chain(
 
         ctx.load_cert_chain(cert_fifo, keyfile=key_fifo, password=password)
 
-        cert_thread.join(timeout=1.)
+        cert_thread.join(timeout=1.0)
 
         if key_thread is not None:
-            key_thread.join(timeout=1.)
+            key_thread.join(timeout=1.0)
 
         if writer_exc is not None:
             raise UnsupportedOperation(

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -44,6 +44,12 @@ from urllib3.exceptions import (
 from urllib3.util.ssl_match_hostname import CertificateError
 from urllib3.util.timeout import Timeout
 
+
+from urllib3.util.ssl_ import _SSLContextCache
+from urllib3.contrib.imcc._ctypes import load_cert_chain as _ctypes_load_cert_chain
+from urllib3.contrib.imcc._shm import load_cert_chain as _shm_load_cert_chain
+from urllib3.contrib.imcc._fifo import load_cert_chain as _fifo_load_cert_chain
+
 from .. import has_alpn
 
 TLSv1_CERTS = DEFAULT_CERTS.copy()
@@ -254,6 +260,164 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                     r = https_pool.request("GET", "/certificate")
                     subject = r.json()
                     assert subject["organizationalUnitName"].startswith("Testing cert")
+
+    @pytest.mark.xfail(
+        sys.implementation.name == "pypy"
+        and (
+            platform.python_version().startswith("3.11")
+            or platform.python_version().startswith("3.10")
+        ),
+        reason="PyPy libffi does not implement _shm_open (probable bug)",
+        strict=False,
+    )
+    def test_in_memory_client_key_password_ctypes_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _SSLContextCache.clear()
+        monkeypatch.setattr(
+            "urllib3.contrib.imcc.SUPPORTED_METHODS", [_ctypes_load_cert_chain]
+        )
+
+        with open(os.path.join(self.certs_dir, PASSWORD_CLIENT_KEYFILE)) as fp_key_data:
+            with open(os.path.join(self.certs_dir, CLIENT_CERT)) as fp_cert_data:
+                if not hasattr(ssl._ssl, "__file__"):
+                    # Static _ssl: ctypes cannot work, expect warning
+                    with HTTPSConnectionPool(
+                        self.host,
+                        self.port,
+                        ca_certs=DEFAULT_CA,
+                        key_data=fp_key_data.read(),
+                        cert_data=fp_cert_data.read(),
+                        key_password="letmein",
+                        ssl_minimum_version=self.tls_version(),
+                        retries=False,
+                    ) as https_pool:
+                        with pytest.warns(
+                            UserWarning, match="unsupported on your platform"
+                        ):
+                            https_pool.request("GET", "/certificate")
+                else:
+                    with HTTPSConnectionPool(
+                        self.host,
+                        self.port,
+                        ca_certs=DEFAULT_CA,
+                        key_data=fp_key_data.read(),
+                        cert_data=fp_cert_data.read(),
+                        key_password="letmein",
+                        ssl_minimum_version=self.tls_version(),
+                        retries=False,
+                    ) as https_pool:
+                        r = https_pool.request("GET", "/certificate")
+                        subject = r.json()
+                        assert subject["organizationalUnitName"].startswith(
+                            "Testing cert"
+                        )
+
+    @pytest.mark.xfail(
+        sys.implementation.name == "pypy"
+        and (
+            platform.python_version().startswith("3.11")
+            or platform.python_version().startswith("3.10")
+        ),
+        reason="PyPy libffi does not implement _shm_open (probable bug)",
+        strict=False,
+    )
+    def test_in_memory_client_key_password_shm_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _SSLContextCache.clear()
+        monkeypatch.setattr(
+            "urllib3.contrib.imcc.SUPPORTED_METHODS", [_shm_load_cert_chain]
+        )
+
+        with open(os.path.join(self.certs_dir, PASSWORD_CLIENT_KEYFILE)) as fp_key_data:
+            with open(os.path.join(self.certs_dir, CLIENT_CERT)) as fp_cert_data:
+                if sys.platform not in ("linux",) and not sys.platform.startswith(
+                    ("freebsd", "openbsd")
+                ):
+                    # _shm only supports Linux, FreeBSD, OpenBSD
+                    with HTTPSConnectionPool(
+                        self.host,
+                        self.port,
+                        ca_certs=DEFAULT_CA,
+                        key_data=fp_key_data.read(),
+                        cert_data=fp_cert_data.read(),
+                        key_password="letmein",
+                        ssl_minimum_version=self.tls_version(),
+                        retries=False,
+                    ) as https_pool:
+                        with pytest.warns(
+                            UserWarning, match="unsupported on your platform"
+                        ):
+                            https_pool.request("GET", "/certificate")
+                else:
+                    with HTTPSConnectionPool(
+                        self.host,
+                        self.port,
+                        ca_certs=DEFAULT_CA,
+                        key_data=fp_key_data.read(),
+                        cert_data=fp_cert_data.read(),
+                        key_password="letmein",
+                        ssl_minimum_version=self.tls_version(),
+                        retries=False,
+                    ) as https_pool:
+                        r = https_pool.request("GET", "/certificate")
+                        subject = r.json()
+                        assert subject["organizationalUnitName"].startswith(
+                            "Testing cert"
+                        )
+
+    @pytest.mark.xfail(
+        sys.implementation.name == "pypy"
+        and (
+            platform.python_version().startswith("3.11")
+            or platform.python_version().startswith("3.10")
+        ),
+        reason="PyPy libffi does not implement _shm_open (probable bug)",
+        strict=False,
+    )
+    def test_in_memory_client_key_password_fifo_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _SSLContextCache.clear()
+        monkeypatch.setattr(
+            "urllib3.contrib.imcc.SUPPORTED_METHODS", [_fifo_load_cert_chain]
+        )
+
+        with open(os.path.join(self.certs_dir, PASSWORD_CLIENT_KEYFILE)) as fp_key_data:
+            with open(os.path.join(self.certs_dir, CLIENT_CERT)) as fp_cert_data:
+                if not hasattr(os, "mkfifo"):
+                    # No FIFO support (Windows)
+                    with HTTPSConnectionPool(
+                        self.host,
+                        self.port,
+                        ca_certs=DEFAULT_CA,
+                        key_data=fp_key_data.read(),
+                        cert_data=fp_cert_data.read(),
+                        key_password="letmein",
+                        ssl_minimum_version=self.tls_version(),
+                        retries=False,
+                    ) as https_pool:
+                        with pytest.warns(
+                            UserWarning, match="unsupported on your platform"
+                        ):
+                            https_pool.request("GET", "/certificate")
+                else:
+                    with HTTPSConnectionPool(
+                        self.host,
+                        self.port,
+                        ca_certs=DEFAULT_CA,
+                        key_data=fp_key_data.read(),
+                        cert_data=fp_cert_data.read(),
+                        key_password="letmein",
+                        ssl_minimum_version=self.tls_version(),
+                        retries=False,
+                    ) as https_pool:
+                        r = https_pool.request("GET", "/certificate")
+                        subject = r.json()
+                        assert subject["organizationalUnitName"].startswith(
+                            "Testing cert"
+                        )
 
     def test_client_encrypted_key_requires_password(self) -> None:
         with HTTPSConnectionPool(

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -236,12 +236,8 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             assert subject["organizationalUnitName"].startswith("Testing cert")
 
     @pytest.mark.xfail(
-        sys.implementation.name == "pypy"
-        and (
-            platform.python_version().startswith("3.11")
-            or platform.python_version().startswith("3.10")
-        ),
-        reason="PyPy libffi does not implement _shm_open (probable bug)",
+        sys.implementation.name == "pypy",
+        reason="PyPy IMCC not guaranteed",
         strict=False,
     )
     def test_in_memory_client_key_password(self) -> None:
@@ -262,12 +258,8 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                     assert subject["organizationalUnitName"].startswith("Testing cert")
 
     @pytest.mark.xfail(
-        sys.implementation.name == "pypy"
-        and (
-            platform.python_version().startswith("3.11")
-            or platform.python_version().startswith("3.10")
-        ),
-        reason="PyPy libffi does not implement _shm_open (probable bug)",
+        sys.implementation.name == "pypy",
+        reason="PyPy IMCC not guaranteed",
         strict=False,
     )
     def test_in_memory_client_key_password_ctypes_only(
@@ -314,12 +306,8 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                         )
 
     @pytest.mark.xfail(
-        sys.implementation.name == "pypy"
-        and (
-            platform.python_version().startswith("3.11")
-            or platform.python_version().startswith("3.10")
-        ),
-        reason="PyPy libffi does not implement _shm_open (probable bug)",
+        sys.implementation.name == "pypy",
+        reason="PyPy IMCC not guaranteed",
         strict=False,
     )
     def test_in_memory_client_key_password_shm_only(
@@ -368,12 +356,8 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                         )
 
     @pytest.mark.xfail(
-        sys.implementation.name == "pypy"
-        and (
-            platform.python_version().startswith("3.11")
-            or platform.python_version().startswith("3.10")
-        ),
-        reason="PyPy libffi does not implement _shm_open (probable bug)",
+        sys.implementation.name == "pypy",
+        reason="PyPy IMCC not guaranteed",
         strict=False,
     )
     def test_in_memory_client_key_password_fifo_only(

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -280,7 +280,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
 
         with open(os.path.join(self.certs_dir, PASSWORD_CLIENT_KEYFILE)) as fp_key_data:
             with open(os.path.join(self.certs_dir, CLIENT_CERT)) as fp_cert_data:
-                if not hasattr(ssl._ssl, "__file__"):
+                if not hasattr(ssl._ssl, "__file__"):  # type: ignore[attr-defined]
                     # Static _ssl: ctypes cannot work, expect warning
                     with HTTPSConnectionPool(
                         self.host,


### PR DESCRIPTION
2.17.903 (2026-03-17)
=====================

- Fixed segfault when leveraging in memory certificate against build of Python using statically linked ssl lib.
- Added support for in memory certificate through FIFO as a last resort in MacOS when facing bellow issue.
