### PR TITLE
Release 2.19.903

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.19.903 (2026-04-08)
+=====================
+
+- Reverted user-supplied headers now take precedence over extension defaults. (#333)
+- Fixed WebSocket ``next_payload()`` to correctly reassemble fragmented messages by buffering intermediate frames until ``message_finished`` is received.
+- Allowed overriding ``Accept`` header as a compromise to the revert of #333.
+
 2.19.902 (2026-04-04)
 =====================
 

--- a/changelog/335.bugfix.rst
+++ b/changelog/335.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed WebSocket ``next_payload()`` to correctly reassemble fragmented messages by buffering intermediate frames until ``message_finished`` is received.

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -1311,9 +1311,19 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
             and conn.conn_info is not None
             and conn.conn_info.http_version is not None
         ):
-            extension_headers = extension.headers(conn.conn_info.http_version)
+            extension_headers = HTTPHeaderDict(
+                extension.headers(conn.conn_info.http_version)
+            )
 
             if extension_headers:
+                # allow overriding "Accept"
+                # see https://github.com/jawah/urllib3.future/pull/333
+                if (
+                    headers is not None
+                    and "Accept" in headers
+                    and "Accept" in extension_headers
+                ):
+                    extension_headers["Accept"] = headers["Accept"]
                 if headers is None:
                     headers = extension_headers
                 elif hasattr(headers, "copy"):

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.19.902"
+__version__ = "2.19.903"

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1281,9 +1281,20 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             and conn.conn_info is not None
             and conn.conn_info.http_version is not None
         ):
-            extension_headers = extension.headers(conn.conn_info.http_version)
+            extension_headers = HTTPHeaderDict(
+                extension.headers(conn.conn_info.http_version)
+            )
 
             if extension_headers:
+                # allow overriding "Accept"
+                # see https://github.com/jawah/urllib3.future/pull/333
+                if (
+                    headers is not None
+                    and "Accept" in headers
+                    and "Accept" in extension_headers
+                ):
+                    extension_headers["Accept"] = headers["Accept"]
+
                 if headers is None:
                     headers = extension_headers
                 elif hasattr(headers, "copy"):


### PR DESCRIPTION
2.19.903 (2026-04-08)
=====================

- Reverted user-supplied headers now take precedence over extension defaults. (#333)
- Fixed WebSocket ``next_payload()`` to correctly reassemble fragmented messages by buffering intermediate frames until ``message_finished`` is received.
- Allowed overriding ``Accept`` header as a compromise to the revert of #333.

