### PR TITLE
Release 2.19.904

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.19.904 (2026-04-09)
+=====================
+
+- Fixed race condition where asyncio transport is closed and freed (via asyncio internals) before our own procedure. (https://github.com/jawah/niquests/issues/368)
+
 2.19.903 (2026-04-08)
 =====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.19.903"
+__version__ = "2.19.904"

--- a/src/urllib3/contrib/ssa/__init__.py
+++ b/src/urllib3/contrib/ssa/__init__.py
@@ -131,8 +131,16 @@ class AsyncSocket:
             pass
 
     def close(self) -> None:
+        """The closing procedure is a real challenge. There's a ton of edge cases. Act carefully around this method."""
         if self._writer is not None:
-            self._writer.close()
+            try:
+                self._writer.close()
+            except AttributeError:  # Defensive: rare racing condition where transport is freed but writer isn't fully freed yet.
+                self._connect_called = False
+                self._established.clear()
+                self._writer = None
+                self._reader = None
+                return  # see https://github.com/jawah/niquests/issues/368 to learn more
 
         edge_case_close_bug_exist = _CPYTHON_SELECTOR_CLOSE_BUG_EXIST
 


### PR DESCRIPTION
2.19.904 (2026-04-09)
=====================

- Fixed race condition where asyncio transport is closed and freed (via asyncio internals) before our own procedure. (https://github.com/jawah/niquests/issues/368)
