### PR TITLE
Release 2.19.905

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.19.905 (2026-04-10)
+=====================
+
+- Added support to convert stdlib ssl.SSLContext to rtls.SSLContext with best effort strategy when ctx passed directly. (#342)
+- Fixed rare DNS frame parsing issues.
+- Fixed web extensions misleading ProxyManager to not being able to decide whether to create tunnel or not.
+
 2.19.904 (2026-04-09)
 =====================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,8 @@ filterwarnings = [
     '''ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning''',
     '''ignore:Exception in thread:pytest.PytestUnhandledThreadExceptionWarning''',
     '''ignore:function _SSLProtocolTransport\.__del__:pytest.PytestUnraisableExceptionWarning''',
+    '''ignore:function StreamWriter.__del__:pytest.PytestUnraisableExceptionWarning''',
+    '''ignore:sock:pytest.PytestUnraisableExceptionWarning''',
     '''ignore:The `hash` argument is deprecated in favor of `unsafe_hash`:DeprecationWarning''',
     '''ignore:ssl\.TLSVersion\.TLSv1 is deprecated:DeprecationWarning''',
     '''ignore:ssl\.TLSVersion\.TLSv1_1 is deprecated:DeprecationWarning''',

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -62,7 +62,7 @@ from ..exceptions import (  # noqa: F401
 from ..util import SKIP_HEADER, SKIPPABLE_HEADERS
 from ..util._async.ssl_ import ssl_wrap_socket
 from ..util.request import body_to_chunks
-from ..util.ssl_ import assert_fingerprint as _assert_fingerprint
+from ..util.ssl_ import assert_fingerprint as _assert_fingerprint, convert_ssl_ctx_rtls
 from ..util.ssl_ import (
     is_capable_for_quic,
     is_ipaddress,
@@ -752,6 +752,9 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
         key_data: str | bytes | None = None,
         ciphers: str | None = None,
     ) -> None:
+        if ssl_context is not None:
+            ssl_context = convert_ssl_ctx_rtls(ssl_context)
+
         if not is_capable_for_quic(ssl_context, ssl_maximum_version):
             if disabled_svn is None:
                 disabled_svn = set()

--- a/src/urllib3/_async/poolmanager.py
+++ b/src/urllib3/_async/poolmanager.py
@@ -330,6 +330,11 @@ class AsyncPoolManager(AsyncRequestMethods):
 
                 request_context["scheme"] = scheme
 
+                if "port" not in request_context or not request_context["port"]:
+                    request_context["port"] = port_by_scheme.get(
+                        request_context["scheme"].lower()
+                    )
+
                 supported_svn = extension.supported_svn()
 
                 disabled_svn = (
@@ -932,7 +937,7 @@ class AsyncProxyManager(AsyncPoolManager):
         scheme: str | None = "http",
         pool_kwargs: dict[str, typing.Any] | None = None,
     ) -> AsyncHTTPConnectionPool:
-        if scheme == "https":
+        if scheme in {"https", "wss", "sse"}:
             return await super().connection_from_host(
                 host, port, scheme, pool_kwargs=pool_kwargs
             )

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.19.904"
+__version__ = "2.19.905"

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -58,7 +58,7 @@ from .exceptions import (
 )
 from .util import SKIP_HEADER, SKIPPABLE_HEADERS
 from .util.request import body_to_chunks
-from .util.ssl_ import assert_fingerprint as _assert_fingerprint
+from .util.ssl_ import assert_fingerprint as _assert_fingerprint, convert_ssl_ctx_rtls
 from .util.ssl_ import (
     is_capable_for_quic,
     is_ipaddress,
@@ -730,6 +730,9 @@ class HTTPSConnection(HTTPConnection):
         key_data: str | bytes | None = None,
         ciphers: str | None = None,
     ) -> None:
+        if ssl_context is not None:
+            ssl_context = convert_ssl_ctx_rtls(ssl_context)
+
         if not is_capable_for_quic(ssl_context, ssl_maximum_version):
             if disabled_svn is None:
                 disabled_svn = set()

--- a/src/urllib3/contrib/resolver/_async/doq/_qh3.py
+++ b/src/urllib3/contrib/resolver/_async/doq/_qh3.py
@@ -362,10 +362,11 @@ class QUICResolver(PlainResolver):
 
                     query_tbr: DomainNameServerQuery | None = None
 
-                    for query_tbr in self._pending:
-                        if query_tbr.id == dns_resp.id:
+                    for pending_q in self._pending:
+                        if pending_q.id == dns_resp.id:
+                            query_tbr = pending_q
                             break
-                    if query_tbr:
+                    if query_tbr is not None:
                         self._pending.remove(query_tbr)
                 else:
                     self._unconsumed.append(dns_resp)

--- a/src/urllib3/contrib/resolver/_async/dou/_socket.py
+++ b/src/urllib3/contrib/resolver/_async/dou/_socket.py
@@ -284,11 +284,12 @@ class PlainResolver(AsyncBaseResolver):
 
                         query_tbr: DomainNameServerQuery | None = None
 
-                        for query_tbr in self._pending:
-                            if query_tbr.id == dns_resp.id:
+                        for pending_q in self._pending:
+                            if pending_q.id == dns_resp.id:
+                                query_tbr = pending_q
                                 break
 
-                        if query_tbr:
+                        if query_tbr is not None:
                             self._pending.remove(query_tbr)
                     else:
                         self._unconsumed.append(dns_resp)

--- a/src/urllib3/contrib/resolver/_async/dou/_socket.py
+++ b/src/urllib3/contrib/resolver/_async/dou/_socket.py
@@ -16,7 +16,6 @@ from ...protocols import (
 from ...utils import (
     is_ipv4,
     is_ipv6,
-    packet_fragment,
     rfc1035_pack,
     rfc1035_should_read,
     rfc1035_unpack,
@@ -267,14 +266,14 @@ class PlainResolver(AsyncBaseResolver):
                     "Got unexpectedly disconnected while waiting for name resolution"
                 )
 
-            pending_raw_identifiers = [_.raw_id for _ in self._pending]
-
             for payload in payloads:
-                #: We can receive two responses at once (or more, concatenated). Let's unwrap them.
+                #: DoT (rfc1035) may carry multiple DNS messages in a single
+                #: length-prefixed stream segment. UDP always delivers one
+                #: datagram = one DNS message (GRO already splits for us).
                 if self._rfc1035_prefix_mandated is True:
                     fragments = rfc1035_unpack(payload)
                 else:
-                    fragments = packet_fragment(payload, *pending_raw_identifiers)
+                    fragments = (payload,)
 
                 for fragment in fragments:
                     dns_resp = DomainNameServerReturn(fragment)

--- a/src/urllib3/contrib/resolver/doq/_qh3.py
+++ b/src/urllib3/contrib/resolver/doq/_qh3.py
@@ -339,10 +339,11 @@ class QUICResolver(PlainResolver):
 
                         query_tbr: DomainNameServerQuery | None = None
 
-                        for query_tbr in self._pending:
-                            if query_tbr.id == dns_resp.id:
+                        for pending_q in self._pending:
+                            if pending_q.id == dns_resp.id:
+                                query_tbr = pending_q
                                 break
-                        if query_tbr:
+                        if query_tbr is not None:
                             self._pending.remove(query_tbr)
                     else:
                         self._unconsumed.append(dns_resp)

--- a/src/urllib3/contrib/resolver/dou/_socket.py
+++ b/src/urllib3/contrib/resolver/dou/_socket.py
@@ -268,11 +268,12 @@ class PlainResolver(BaseResolver):
 
                             query_tbr: DomainNameServerQuery | None = None
 
-                            for query_tbr in self._pending:
-                                if query_tbr.id == dns_resp.id:
+                            for pending_q in self._pending:
+                                if pending_q.id == dns_resp.id:
+                                    query_tbr = pending_q
                                     break
 
-                            if query_tbr:
+                            if query_tbr is not None:
                                 self._pending.remove(query_tbr)
                         else:
                             self._unconsumed.append(dns_resp)

--- a/src/urllib3/contrib/resolver/dou/_socket.py
+++ b/src/urllib3/contrib/resolver/dou/_socket.py
@@ -17,7 +17,6 @@ from ..system import SystemResolver
 from ..utils import (
     is_ipv4,
     is_ipv6,
-    packet_fragment,
     rfc1035_pack,
     rfc1035_should_read,
     rfc1035_unpack,
@@ -251,14 +250,14 @@ class PlainResolver(BaseResolver):
                         "Got unexpectedly disconnected while waiting for name resolution"
                     )
 
-                pending_raw_identifiers = [_.raw_id for _ in self._pending]
-
                 for payload in payloads:
-                    #: We can receive two responses at once (or more, concatenated). Let's unwrap them.
+                    #: DoT (rfc1035) may carry multiple DNS messages in a single
+                    #: length-prefixed stream segment. UDP always delivers one
+                    #: datagram = one DNS message (GRO already splits for us).
                     if self._rfc1035_prefix_mandated is True:
                         fragments = rfc1035_unpack(payload)
                     else:
-                        fragments = packet_fragment(payload, *pending_raw_identifiers)
+                        fragments = (payload,)
 
                     for fragment in fragments:
                         dns_resp = DomainNameServerReturn(fragment)

--- a/src/urllib3/contrib/resolver/protocols.py
+++ b/src/urllib3/contrib/resolver/protocols.py
@@ -18,7 +18,7 @@ from ...exceptions import LocationParseError
 from ...util.connection import _set_socket_options, allowed_gai_family
 from ...util.ssl_match_hostname import CertificateError, match_hostname
 from ...util.timeout import _DEFAULT_TIMEOUT
-from .utils import inet4_ntoa, inet6_ntoa, parse_https_rdata
+from .utils import inet4_ntoa, inet6_ntoa, parse_https_rdata, read_name
 
 if typing.TYPE_CHECKING:
     from .utils import HttpsRecord
@@ -583,51 +583,51 @@ class DomainNameServerReturn:
             self._qd_count = up[2]
             self._an_count = up[3]
 
-            self._rcode = int(f"0x{hex(payload[3])[-1]}", 16)
+            self._rcode = payload[3] & 0x0F
 
-            self._hostname: str = ""
-
-            idx = 12
-
-            while True:
-                c = payload[idx]
-
-                if c == 0:
-                    idx += 1
-                    break
-
-                self._hostname += payload[idx + 1 : idx + 1 + c].decode("ascii") + "."
-
-                idx += c + 1
+            # Parse QNAME using read_name which handles compression pointers (0xC0xx)
+            self._hostname, idx = read_name(payload, 12)
 
             self._records: list[tuple[SupportedQueryType, int, str | HttpsRecord]] = []
 
             if self._an_count:
+                # Skip QTYPE (2 bytes) and QCLASS (2 bytes) after QNAME
                 idx += 4
 
                 while idx < len(payload):
-                    up = struct.unpack("!HHHI", payload[idx : idx + 10])
-                    entry_size = struct.unpack("!H", payload[idx + 10 : idx + 12])[0]
+                    # Parse the answer NAME field (may be a compression pointer or full label)
+                    _, idx = read_name(payload, idx)
 
-                    data = payload[idx + 12 : idx + 12 + entry_size]
+                    # Read TYPE (2), CLASS (2), TTL (4), RDLENGTH (2) = 10 bytes
+                    rr_type, rr_class, rr_ttl = struct.unpack(
+                        "!HHI", payload[idx : idx + 8]
+                    )
+                    entry_size = struct.unpack("!H", payload[idx + 8 : idx + 10])[0]
 
-                    if len(data) == 4:
-                        decoded_data: str | HttpsRecord = inet4_ntoa(data)
-                    elif len(data) == 16:
+                    data = payload[idx + 10 : idx + 10 + entry_size]
+
+                    idx += 10 + entry_size
+
+                    # Dispatch based on the TYPE field, not data length
+                    try:
+                        query_type = SupportedQueryType(rr_type)
+                    except ValueError:
+                        # Unknown/unsupported record type (e.g. CNAME, SOA) -- skip
+                        continue
+
+                    decoded_data: str | HttpsRecord
+                    if query_type == SupportedQueryType.A:
+                        decoded_data = inet4_ntoa(data)
+                    elif query_type == SupportedQueryType.AAAA:
                         decoded_data = inet6_ntoa(data)
-                    elif data:
+                    elif query_type == SupportedQueryType.HTTPS:
+                        if not data:
+                            continue
                         decoded_data = parse_https_rdata(data)
                     else:
                         continue
 
-                    try:
-                        self._records.append(
-                            (SupportedQueryType(up[1]), up[-1], decoded_data)
-                        )
-                    except ValueError:
-                        pass
-
-                    idx += 12 + entry_size
+                    self._records.append((query_type, rr_ttl, decoded_data))
         except (struct.error, IndexError, ValueError, UnicodeDecodeError) as e:
             raise DomainNameServerParseException(
                 "A protocol error occurred while parsing the DNS response payload: "

--- a/src/urllib3/contrib/resolver/utils.py
+++ b/src/urllib3/contrib/resolver/utils.py
@@ -92,54 +92,6 @@ def inet6_ntoa(address: bytes) -> str:
     return thex
 
 
-def packet_fragment(payload: bytes, *identifiers: bytes) -> tuple[bytes, ...]:
-    """Split a coalesced UDP payload into individual DNS messages.
-
-    Each identifier is a 2-byte transaction ID from a pending query.
-    We find message boundaries by locating these IDs at positions where they
-    form the start of a valid DNS header (QDCOUNT == 1).
-    """
-    if len(payload) < 12:
-        raise ValueError(
-            "no identifiable dns message emerged from given payload. "
-            "this should not happen at all. networking issue?"
-        )
-
-    id_set = set(identifiers)
-    # Collect start positions of valid DNS messages
-    boundaries: list[int] = []
-
-    pos = 0
-    while pos <= len(payload) - 12:
-        # Check if the 2-byte ID at this position matches any pending query
-        candidate_id = payload[pos : pos + 2]
-        if candidate_id in id_set:
-            # Validate: QDCOUNT (bytes 4-5) should be 1 for any response to our queries
-            qdcount = struct.unpack("!H", payload[pos + 4 : pos + 6])[0]
-            if qdcount == 1:
-                boundaries.append(pos)
-                # Skip past the header to avoid false matches within this message's body
-                pos += 12
-                continue
-        pos += 1
-
-    if not boundaries:
-        raise ValueError(
-            "no identifiable dns message emerged from given payload. "
-            "this should not happen at all. networking issue?"
-        )
-
-    if len(boundaries) == 1:
-        return (payload,)
-
-    results: list[bytes] = []
-    for i in range(len(boundaries) - 1):
-        results.append(payload[boundaries[i] : boundaries[i + 1]])
-    results.append(payload[boundaries[-1] :])
-
-    return tuple(results)
-
-
 def is_ipv4(addr: str) -> bool:
     try:
         socket.inet_aton(addr)
@@ -275,7 +227,6 @@ def parse_https_rdata(rdata: bytes) -> HttpsRecord:
 __all__ = (
     "inet4_ntoa",
     "inet6_ntoa",
-    "packet_fragment",
     "is_ipv4",
     "is_ipv6",
     "validate_length_of",

--- a/src/urllib3/contrib/resolver/utils.py
+++ b/src/urllib3/contrib/resolver/utils.py
@@ -93,62 +93,49 @@ def inet6_ntoa(address: bytes) -> str:
 
 
 def packet_fragment(payload: bytes, *identifiers: bytes) -> tuple[bytes, ...]:
-    results = []
+    """Split a coalesced UDP payload into individual DNS messages.
 
-    offset = 0
-
-    start_packet_idx = []
-    lead_identifier = None
-
-    for identifier in identifiers:
-        idx = payload[:12].find(identifier)
-
-        if idx == -1:
-            continue
-
-        if idx != 0:
-            offset = idx
-
-        start_packet_idx.append(idx - offset)
-
-        lead_identifier = identifier
-        break
-
-    for identifier in identifiers:
-        if identifier == lead_identifier:
-            continue
-
-        if offset == 0:
-            idx = payload.find(b"\x02" + identifier)
-        else:
-            idx = payload.find(identifier)
-
-        if idx == -1:
-            continue
-
-        start_packet_idx.append(idx - offset)
-
-    if not start_packet_idx:
+    Each identifier is a 2-byte transaction ID from a pending query.
+    We find message boundaries by locating these IDs at positions where they
+    form the start of a valid DNS header (QDCOUNT == 1).
+    """
+    if len(payload) < 12:
         raise ValueError(
             "no identifiable dns message emerged from given payload. "
             "this should not happen at all. networking issue?"
         )
 
-    if len(start_packet_idx) == 1:
+    id_set = set(identifiers)
+    # Collect start positions of valid DNS messages
+    boundaries: list[int] = []
+
+    pos = 0
+    while pos <= len(payload) - 12:
+        # Check if the 2-byte ID at this position matches any pending query
+        candidate_id = payload[pos : pos + 2]
+        if candidate_id in id_set:
+            # Validate: QDCOUNT (bytes 4-5) should be 1 for any response to our queries
+            qdcount = struct.unpack("!H", payload[pos + 4 : pos + 6])[0]
+            if qdcount == 1:
+                boundaries.append(pos)
+                # Skip past the header to avoid false matches within this message's body
+                pos += 12
+                continue
+        pos += 1
+
+    if not boundaries:
+        raise ValueError(
+            "no identifiable dns message emerged from given payload. "
+            "this should not happen at all. networking issue?"
+        )
+
+    if len(boundaries) == 1:
         return (payload,)
 
-    start_packet_idx = sorted(start_packet_idx)
-
-    previous_idx = None
-
-    for idx in start_packet_idx:
-        if previous_idx is None:
-            previous_idx = idx
-            continue
-        results.append(payload[previous_idx:idx])
-        previous_idx = idx
-
-    results.append(payload[previous_idx:])
+    results: list[bytes] = []
+    for i in range(len(boundaries) - 1):
+        results.append(payload[boundaries[i] : boundaries[i + 1]])
+    results.append(payload[boundaries[-1] :])
 
     return tuple(results)
 
@@ -296,4 +283,5 @@ __all__ = (
     "rfc1035_unpack",
     "rfc1035_should_read",
     "parse_https_rdata",
+    "read_name",
 )

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -466,6 +466,11 @@ class PoolManager(RequestMethods):
 
                 request_context["scheme"] = scheme
 
+                if "port" not in request_context or not request_context["port"]:
+                    request_context["port"] = port_by_scheme.get(
+                        request_context["scheme"].lower()
+                    )
+
                 supported_svn = extension.supported_svn()
 
                 disabled_svn = (
@@ -1087,7 +1092,7 @@ class ProxyManager(PoolManager):
         scheme: str | None = "http",
         pool_kwargs: dict[str, typing.Any] | None = None,
     ) -> HTTPConnectionPool:
-        if scheme == "https":
+        if scheme in {"https", "wss", "sse"}:
             return super().connection_from_host(
                 host, port, scheme, pool_kwargs=pool_kwargs
             )

--- a/src/urllib3/util/proxy.py
+++ b/src/urllib3/util/proxy.py
@@ -28,7 +28,7 @@ def connection_requires_http_tunnel(
         return False
 
     # HTTP destinations never require tunneling, we always forward.
-    if destination_scheme == "http":
+    if destination_scheme in {"http", "ws", "psse"}:
         return False
 
     # Support for forwarding with HTTPS proxies and HTTPS destinations.

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -889,3 +889,46 @@ def is_capable_for_quic(
         quic_disable = True
 
     return not quic_disable
+
+
+def convert_ssl_ctx_rtls(ctx: ssl.SSLContext) -> ssl.SSLContext:
+    """Attempt to convert stdlib SSLContext to rtls SSLContext. Best effort only."""
+    if "Rustls" not in ssl.OPENSSL_VERSION or hasattr(ctx, "_builder"):
+        return ctx
+
+    import ssl as stdlib_ssl
+
+    ssl_ctx_have_certs: bool = (
+        "x509_ca" in ctx.cert_store_stats() and ctx.cert_store_stats()["x509_ca"] > 0
+    )
+
+    ca_cert_data: str | None = None
+
+    if ssl_ctx_have_certs:
+        ctx_root_certificates: list[bytes] = ctx.get_ca_certs(True)
+
+        if ctx_root_certificates:
+            ca_cert_data = "\n".join(
+                stdlib_ssl.DER_cert_to_PEM_cert(cert) for cert in ctx_root_certificates
+            )
+
+    rtls_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    rtls_ctx.verify_mode = ssl.VerifyMode(int(ctx.verify_mode))
+
+    if ca_cert_data:
+        rtls_ctx.load_verify_locations(cadata=ca_cert_data)
+    else:
+        rtls_ctx.load_default_certs()
+
+    if stdlib_ssl.OP_NO_TLSv1_3 in ctx.options:
+        rtls_ctx.options |= ssl.OP_NO_TLSv1_3
+    if stdlib_ssl.OP_NO_TLSv1_2 in ctx.options:
+        rtls_ctx.options |= ssl.OP_NO_TLSv1_2
+
+    rtls_ctx.minimum_version = ssl.TLSVersion(int(ctx.minimum_version))
+    rtls_ctx.maximum_version = ssl.TLSVersion(int(ctx.maximum_version))
+
+    if hasattr(ctx, "check_hostname") and ctx.check_hostname is False:
+        rtls_ctx.check_hostname = False
+
+    return rtls_ctx

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -893,7 +893,10 @@ def is_capable_for_quic(
 
 def convert_ssl_ctx_rtls(ctx: ssl.SSLContext) -> ssl.SSLContext:
     """Attempt to convert stdlib SSLContext to rtls SSLContext. Best effort only."""
-    if "Rustls" not in ssl.OPENSSL_VERSION or hasattr(ctx, "_builder"):
+    if "Rustls" not in ssl.OPENSSL_VERSION:
+        return ctx
+
+    if hasattr(ctx, "set_ech_configs"):  # already rtls context, exit early.
         return ctx
 
     import ssl as stdlib_ssl
@@ -920,13 +923,42 @@ def convert_ssl_ctx_rtls(ctx: ssl.SSLContext) -> ssl.SSLContext:
     else:
         rtls_ctx.load_default_certs()
 
-    if stdlib_ssl.OP_NO_TLSv1_3 in ctx.options:
-        rtls_ctx.options |= ssl.OP_NO_TLSv1_3
-    if stdlib_ssl.OP_NO_TLSv1_2 in ctx.options:
-        rtls_ctx.options |= ssl.OP_NO_TLSv1_2
+    opt_match_no_tls: bool = False
 
-    rtls_ctx.minimum_version = ssl.TLSVersion(int(ctx.minimum_version))
-    rtls_ctx.maximum_version = ssl.TLSVersion(int(ctx.maximum_version))
+    try:
+        if stdlib_ssl.OP_NO_TLSv1_3 in ctx.options:
+            rtls_ctx.options |= ssl.OP_NO_TLSv1_3
+            opt_match_no_tls = True
+        if stdlib_ssl.OP_NO_TLSv1_2 in ctx.options:
+            rtls_ctx.options |= ssl.OP_NO_TLSv1_2
+            opt_match_no_tls = True
+    except TypeError:
+        # TODO: Investigate this weird edge case.
+        #       Debug info:
+        #         print(stdlib_ssl.OP_NO_TLSv1_3.__class__ == ssl.Options)  # False
+        #         print(stdlib_ssl.OP_NO_TLSv1_3.__class__ == stdlib_ssl.Options)  # True
+        #         print(ctx.options.__class__ == ssl.Options)  # False
+        #         print(ctx.options.__class__ == stdlib_ssl.Options)  # False
+        #         print(ctx.options.__class__)  # <flag 'Options'>
+        #         print(ctx.options.__module__) # ssl
+        #         print(isinstance(ctx.options, stdlib_ssl.Options))  # False
+        #         print(isinstance(ctx.options, ssl.Options))  # False
+        #         print(isinstance(ctx.options, enum.IntEnum))  # False
+        #         print(isinstance(ctx.options, enum.Enum))  # True
+        #         print(isinstance(ctx.options, int))  # True
+
+        options = ssl.Options(ctx.options)
+
+        if ssl.OP_NO_TLSv1_3 in options:
+            rtls_ctx.options |= ssl.OP_NO_TLSv1_3
+            opt_match_no_tls = True
+        if ssl.OP_NO_TLSv1_2 in options:
+            rtls_ctx.options |= ssl.OP_NO_TLSv1_2
+            opt_match_no_tls = True
+
+    if not opt_match_no_tls:
+        rtls_ctx.minimum_version = ssl.TLSVersion(int(ctx.minimum_version))
+        rtls_ctx.maximum_version = ssl.TLSVersion(int(ctx.maximum_version))
 
     if hasattr(ctx, "check_hostname") and ctx.check_hostname is False:
         rtls_ctx.check_hostname = False

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1598,15 +1598,18 @@ class TestSSL(SocketDummyServerTestCase):
 
         _SSLContextCache.clear()
 
-        with mock.patch("urllib3.util.ssl_.SSLContext", lambda *_, **__: context):
-            self._start_server(socket_handler)
-            with HTTPSConnectionPool(self.host, self.port) as pool:
-                # Without a proper `SSLContext`, this request will fail in some
-                # arbitrary way, but we only want to know if load_default_certs() was
-                # called, which is why we accept any `Exception` here.
-                with pytest.raises(Exception):
-                    pool.request("GET", "/", timeout=SHORT_TIMEOUT)
-                context.load_default_certs.assert_called_with()
+        try:
+            with mock.patch("urllib3.util.ssl_.SSLContext", lambda *_, **__: context):
+                self._start_server(socket_handler)
+                with HTTPSConnectionPool(self.host, self.port) as pool:
+                    # Without a proper `SSLContext`, this request will fail in some
+                    # arbitrary way, but we only want to know if load_default_certs() was
+                    # called, which is why we accept any `Exception` here.
+                    with pytest.raises(Exception):
+                        pool.request("GET", "/", timeout=SHORT_TIMEOUT)
+                    context.load_default_certs.assert_called_with()
+        finally:
+            _SSLContextCache.clear()
 
     def test_ssl_ctx_need_convert_rtls(self, monkeypatch) -> None:  # type: ignore
         def forbidden(ctx, *a, **kw):  # type: ignore
@@ -1652,21 +1655,17 @@ class TestSSL(SocketDummyServerTestCase):
         with pytest.raises(AssertionError):
             context.load_default_certs()
 
-        for kwargs in [
-            {"ca_certs": DEFAULT_CA},
-            {"ssl_context": context},
-        ]:
-            from urllib3.util.ssl_ import _SSLContextCache
+        from urllib3.util.ssl_ import _SSLContextCache
 
-            _SSLContextCache.clear()
+        _SSLContextCache.clear()
 
-            self._start_server(socket_handler)
+        self._start_server(socket_handler)
 
-            with HTTPSConnectionPool(  # type: ignore[arg-type]
-                self.host, self.port, retries=False, **kwargs
-            ) as pool:
-                r = pool.request("GET", "/", timeout=LONG_TIMEOUT)
-                assert r.status == 200
+        with HTTPSConnectionPool(
+            self.host, self.port, retries=False, ssl_context=context
+        ) as pool:
+            r = pool.request("GET", "/", timeout=LONG_TIMEOUT)
+            assert r.status == 200
 
     def test_ssl_dont_load_default_certs_when_given(self, monkeypatch) -> None:  # type: ignore
         def forbidden(ctx, *a, **kw):  # type: ignore

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1608,6 +1608,66 @@ class TestSSL(SocketDummyServerTestCase):
                     pool.request("GET", "/", timeout=SHORT_TIMEOUT)
                 context.load_default_certs.assert_called_with()
 
+    def test_ssl_ctx_need_convert_rtls(self, monkeypatch) -> None:  # type: ignore
+        def forbidden(ctx, *a, **kw):  # type: ignore
+            raise AssertionError(
+                "load_default_certs must not be called in this test run"
+            )
+
+        alt_ssl = pytest.importorskip("rtls")
+
+        monkeypatch.setattr(ssl.SSLContext, "load_default_certs", forbidden)
+        monkeypatch.setattr(alt_ssl.SSLContext, "load_default_certs", forbidden)
+
+        def socket_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+            try:
+                ssl_sock = original_ssl_wrap_socket(
+                    sock,
+                    server_side=True,
+                    keyfile=DEFAULT_CERTS["keyfile"],
+                    certfile=DEFAULT_CERTS["certfile"],
+                    ca_certs=DEFAULT_CA,
+                )
+            except (ssl.SSLError, OSError):
+                return
+
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += ssl_sock.recv(65536)
+
+            ssl_sock.send(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/plain\r\n"
+                b"Content-Length: 5\r\n\r\n"
+                b"Hello"
+            )
+
+            ssl_sock.close()
+            sock.close()
+
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.load_verify_locations(cafile=DEFAULT_CA)
+
+        with pytest.raises(AssertionError):
+            context.load_default_certs()
+
+        for kwargs in [
+            {"ca_certs": DEFAULT_CA},
+            {"ssl_context": context},
+        ]:
+            from urllib3.util.ssl_ import _SSLContextCache
+
+            _SSLContextCache.clear()
+
+            self._start_server(socket_handler)
+
+            with HTTPSConnectionPool(  # type: ignore[arg-type]
+                self.host, self.port, retries=False, **kwargs
+            ) as pool:
+                r = pool.request("GET", "/", timeout=LONG_TIMEOUT)
+                assert r.status == 200
+
     def test_ssl_dont_load_default_certs_when_given(self, monkeypatch) -> None:  # type: ignore
         def forbidden(ctx, *a, **kw):  # type: ignore
             raise AssertionError(


### PR DESCRIPTION
2.19.905 (2026-04-10)
=====================

- Added support to convert stdlib ssl.SSLContext to rtls.SSLContext with best effort strategy when ctx passed directly. (#342)
- Fixed rare DNS frame parsing issues.
- Fixed web extensions misleading ProxyManager to not being able to decide whether to create tunnel or not.
