### PR TITLE
Release 2.19.910

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.19.910 (2026-04-22)
+=====================
+
+- Fixed support for custom CPython build against FIPS OpenSSL.
+- Fixed HTTP/3 over QUIC conformance on pacing/ACKs.
+- Fixed handling of forcibly closed UDP socket by remote peer. Now raises proper ``ProtocolError("Remote end closed connection without response")``. (https://github.com/jawah/niquests/issues/380)
+- Fixed support for ECH when enabling happy eyeballs. ech_config_list was not propagated to concurrent connections. (https://github.com/jawah/niquests/issues/381)
+
 2.19.909 (2026-04-17)
 =====================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,11 @@
-2.19.910 (2026-04-22)
+2.19.910 (2026-04-23)
 =====================
 
 - Fixed support for custom CPython build against FIPS OpenSSL.
 - Fixed HTTP/3 over QUIC conformance on pacing/ACKs.
 - Fixed handling of forcibly closed UDP socket by remote peer. Now raises proper ``ProtocolError("Remote end closed connection without response")``. (https://github.com/jawah/niquests/issues/380)
 - Fixed support for ECH when enabling happy eyeballs. ech_config_list was not propagated to concurrent connections. (https://github.com/jawah/niquests/issues/381)
+- Removed the superfluous warning about "Received server switch protocol event without a pending proposal." with HTTP/1.
 
 2.19.909 (2026-04-17)
 =====================

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -580,6 +580,12 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
                         else self.happy_eyeballs
                     )
 
+                    ech_config_hex = ""
+                    for ip_addr in ip_addresses:
+                        if isinstance(ip_addr[3], bytes) and ip_addr[3]:
+                            ech_config_hex = ip_addr[3].hex()
+                            break
+
                     for ip_address in ip_addresses[:max_task]:
                         conn_kw = self.conn_kw.copy()
                         target_solo_addr = (
@@ -587,8 +593,13 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
                             if ip_address[0] == socket.AF_INET6
                             else ip_address[-1][0]
                         )
-                        conn_kw["resolver"] = AsyncResolverDescription.from_url(
+                        inmemory_url = (
                             f"in-memory://default?hosts={self.host}:{target_solo_addr}"
+                        )
+                        if ech_config_hex:
+                            inmemory_url += f"&ech_config={ech_config_hex}"
+                        conn_kw["resolver"] = AsyncResolverDescription.from_url(
+                            inmemory_url
                         ).new()
                         conn_kw["socket_family"] = ip_address[0]
 
@@ -2291,6 +2302,12 @@ class AsyncHTTPSConnectionPool(AsyncHTTPConnectionPool):
                         else self.happy_eyeballs
                     )
 
+                    ech_config_hex = ""
+                    for ip_addr in ip_addresses:
+                        if isinstance(ip_addr[3], bytes) and ip_addr[3]:
+                            ech_config_hex = ip_addr[3].hex()
+                            break
+
                     for ip_address in ip_addresses[:max_task]:
                         conn_kw = self.conn_kw.copy()
                         target_solo_addr = (
@@ -2298,8 +2315,13 @@ class AsyncHTTPSConnectionPool(AsyncHTTPConnectionPool):
                             if ip_address[0] == socket.AF_INET6
                             else ip_address[-1][0]
                         )
-                        conn_kw["resolver"] = AsyncResolverDescription.from_url(
+                        inmemory_url = (
                             f"in-memory://default?hosts={self.host}:{target_solo_addr}"
+                        )
+                        if ech_config_hex:
+                            inmemory_url += f"&ech_config={ech_config_hex}"
+                        conn_kw["resolver"] = AsyncResolverDescription.from_url(
+                            inmemory_url
                         ).new()
                         conn_kw["socket_family"] = ip_address[0]
                         conn_kw["preemptive_quic_cache"] = target_pqc

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.19.909"
+__version__ = "2.19.910"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -893,7 +893,11 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                 try:
                     async with sub:
                         data_in = await sock.recv(blocksize)
-                except (ConnectionAbortedError, ConnectionResetError) as e:
+                except (
+                    ConnectionAbortedError,
+                    ConnectionResetError,
+                    ConnectionRefusedError,
+                ) as e:
                     if isinstance(e, ConnectionResetError) and (
                         event_type is HandshakeCompleted
                         or (

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -66,6 +66,7 @@ from ...exceptions import (
     SSLError,
 )
 from ...util import parse_alt_svc, resolve_cert_reqs, parse_url
+from ...util.sub_timeout import AsyncSubTimeout
 from .._base import (
     ConnectionInfo,
     HttpVersion,
@@ -842,11 +843,29 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         Can be used for the initial handshake for instance."""
         assert self.sock is not None and self._protocol is not None
 
+        protocol = self._protocol
+        sock = self.sock
+        blocksize = self.blocksize
+        is_h3 = self._svn is HttpVersion.h3
+        _has_next_timer = hasattr(protocol, "next_timer")
+
+        async def send_pending() -> None:
+            tbs: list[bytes] = []
+            while True:
+                data_out = protocol.bytes_to_send()
+                if not data_out:
+                    break
+                tbs.append(data_out)
+            if is_h3 and len(tbs) > 1:
+                await sock.sendall(tbs)
+            else:
+                for chunk in tbs:
+                    await sock.sendall(chunk)
+
         if maximal_data_in_read is not None:
             if not (maximal_data_in_read >= 0 or maximal_data_in_read == -1):
                 maximal_data_in_read = None
 
-        data_out: bytes
         data_in: bytes | list[bytes]
 
         data_in_len: int = 0
@@ -865,26 +884,15 @@ class AsyncHfaceBackend(AsyncBaseBackend):
 
         while True:
             reach_socket: bool = False
-            if not self._protocol.has_pending_event(stream_id=stream_id):
+            if not protocol.has_pending_event(stream_id=stream_id):
                 if receive_first is False:
-                    tbs = []
+                    await send_pending()
 
-                    while True:
-                        data_out = self._protocol.bytes_to_send()
-
-                        if not data_out:
-                            break
-
-                        tbs.append(data_out)
-
-                    if self._svn is HttpVersion.h3 and len(tbs) > 1:
-                        await self.sock.sendall(tbs)
-                    else:
-                        for chunk in tbs:
-                            await self.sock.sendall(chunk)
-
+                next_timer = protocol.next_timer() if _has_next_timer else None  # type: ignore[union-attr]
+                sub = AsyncSubTimeout(sock, next_timer, send_pending)
                 try:
-                    data_in = await self.sock.recv(self.blocksize)
+                    async with sub:
+                        data_in = await sock.recv(blocksize)
                 except (ConnectionAbortedError, ConnectionResetError) as e:
                     if isinstance(e, ConnectionResetError) and (
                         event_type is HandshakeCompleted
@@ -896,6 +904,9 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                         raise e
                     data_in = b""
 
+                if sub.timer_fired:
+                    continue
+
                 reach_socket = True
 
                 if not data_in:
@@ -905,16 +916,16 @@ class AsyncHfaceBackend(AsyncBaseBackend):
 
                     # must have at least one event received, otherwise we can't declare a proper eof.
                     if (events or self._response is not None) and hasattr(
-                        self._protocol, "eof_received"
+                        protocol, "eof_received"
                     ):
                         try:
-                            self._protocol.eof_received()
-                        except self._protocol.exceptions() as e:  # Defensive:
+                            protocol.eof_received()
+                        except protocol.exceptions() as e:  # Defensive:
                             # overly protective, we hide exception that are behind urllib3.
                             # should not happen, but one truly never known.
                             raise ProtocolError(e) from e  # Defensive:
                     else:
-                        self._protocol.connection_lost()
+                        protocol.connection_lost()
                 else:
                     if isinstance(data_in, list):
                         for udp_gro_segment in data_in:
@@ -922,8 +933,8 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                                 data_in_len += len(udp_gro_segment)
 
                             try:
-                                self._protocol.bytes_received(udp_gro_segment)
-                            except self._protocol.exceptions() as e:
+                                protocol.bytes_received(udp_gro_segment)
+                            except protocol.exceptions() as e:
                                 # h2 has a dedicated exception for IncompleteRead (InvalidBodyLengthError)
                                 # we convert the exception to our "IncompleteRead" instead.
                                 if hasattr(e, "expected_length") and hasattr(
@@ -944,8 +955,8 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                             data_in_len += incoming_buffer_size
 
                         try:
-                            self._protocol.bytes_received(data_in)
-                        except self._protocol.exceptions() as e:
+                            protocol.bytes_received(data_in)
+                        except protocol.exceptions() as e:
                             # h2 has a dedicated exception for IncompleteRead (InvalidBodyLengthError)
                             # we convert the exception to our "IncompleteRead" instead.
                             if hasattr(e, "expected_length") and hasattr(
@@ -957,23 +968,9 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                             raise ProtocolError(e) from e  # Defensive:
 
                 if receive_first is True:
-                    tbs = []
+                    await send_pending()
 
-                    while True:
-                        data_out = self._protocol.bytes_to_send()
-
-                        if not data_out:
-                            break
-
-                        tbs.append(data_out)
-
-                    if self._svn is HttpVersion.h3 and len(tbs) > 1:
-                        await self.sock.sendall(tbs)
-                    else:
-                        for chunk in tbs:
-                            await self.sock.sendall(chunk)
-
-            for event in self._protocol.events(stream_id=stream_id):  # type: Event
+            for event in protocol.events(stream_id=stream_id):  # type: Event
                 stream_related_event: bool = hasattr(event, "stream_id")
 
                 if not stream_related_event and isinstance(event, ConnectionTerminated):
@@ -1114,12 +1111,12 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                     ):
                         if event.end_stream is True:  # type: ignore[attr-defined]
                             if reshelve_events:
-                                self._protocol.reshelve(*reshelve_events)
+                                protocol.reshelve(*reshelve_events)
                             return events
                         continue
 
                     if reshelve_events:
-                        self._protocol.reshelve(*reshelve_events)
+                        protocol.reshelve(*reshelve_events)
                     return events
                 elif (
                     stream_related_event
@@ -1127,7 +1124,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                     and respect_end_stream_signal is True
                 ):
                     if reshelve_events:
-                        self._protocol.reshelve(*reshelve_events)
+                        protocol.reshelve(*reshelve_events)
                     return events
                 elif (
                     stream_related_event
@@ -1137,7 +1134,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                     and stream_id == event.stream_id  # type: ignore[attr-defined]
                 ):
                     if reshelve_events:
-                        self._protocol.reshelve(*reshelve_events)
+                        protocol.reshelve(*reshelve_events)
                     return events
 
     def putrequest(

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -1381,11 +1381,26 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         assert self._protocol is not None
         assert self.sock is not None
 
+        _has_next_timer = hasattr(self._protocol, "next_timer")
+
+        async def send_pending() -> None:
+            while True:
+                data_out = self._protocol.bytes_to_send()  # type: ignore[union-attr]
+                if not data_out:
+                    break
+                await self.sock.sendall(data_out)  # type: ignore[union-attr]
+
         while (
             self._protocol.should_wait_remote_flow_control(__stream_id, len(__buf))
             is True
         ):
-            data_in = await self.sock.recv(self.blocksize)
+            next_timer = self._protocol.next_timer() if _has_next_timer else None  # type: ignore[union-attr]
+            sub = AsyncSubTimeout(self.sock, next_timer, send_pending)
+            async with sub:
+                data_in = await self.sock.recv(self.blocksize)
+
+            if sub.timer_fired:
+                continue
 
             if isinstance(data_in, list):
                 for gro_segment in data_in:
@@ -1393,13 +1408,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
             else:
                 self._protocol.bytes_received(data_in)
 
-            while True:
-                data_out = self._protocol.bytes_to_send()
-
-                if not data_out:
-                    break
-
-                await self.sock.sendall(data_out)
+            await send_pending()
 
         self._protocol.submit_data(
             __stream_id,
@@ -1702,6 +1711,15 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         ):
             self.__remaining_body_length = self.__expected_body_length
 
+        _has_next_timer = hasattr(self._protocol, "next_timer")
+
+        async def send_pending() -> None:
+            while True:
+                data_out = self._protocol.bytes_to_send()  # type: ignore[union-attr]
+                if not data_out:
+                    break
+                await self.sock.sendall(data_out)  # type: ignore[union-attr]
+
         try:
             while (
                 self._protocol.should_wait_remote_flow_control(
@@ -1709,7 +1727,13 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                 )
                 is True
             ):
-                data_in = await self.sock.recv(self.blocksize)
+                next_timer = self._protocol.next_timer() if _has_next_timer else None  # type: ignore[union-attr]
+                sub = AsyncSubTimeout(self.sock, next_timer, send_pending)
+                async with sub:
+                    data_in = await self.sock.recv(self.blocksize)
+
+                if sub.timer_fired:
+                    continue
 
                 if not isinstance(data_in, list):
                     self._protocol.bytes_received(data_in)
@@ -1732,13 +1756,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
 
                     raise EarlyResponse(promise=rp)
 
-                while True:
-                    data_out = self._protocol.bytes_to_send()
-
-                    if not data_out:
-                        break
-
-                    await self.sock.sendall(data_out)
+                await send_pending()
 
             if self.__remaining_body_length:
                 self.__remaining_body_length -= len(data)

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -983,7 +983,11 @@ class HfaceBackend(BaseBackend):
                             data_in = sync_recv_gro(sock, blocksize)
                         else:
                             data_in = sock.recv(blocksize)
-                except (ConnectionAbortedError, ConnectionResetError) as e:
+                except (
+                    ConnectionAbortedError,
+                    ConnectionResetError,
+                    ConnectionRefusedError,
+                ) as e:
                     if isinstance(e, ConnectionResetError) and (
                         event_type is HandshakeCompleted
                         or (

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -76,6 +76,7 @@ from ..exceptions import (
     SSLError,
 )
 from ..util import parse_alt_svc, resolve_cert_reqs, parse_url
+from ..util.sub_timeout import SubTimeout
 from ._base import (
     BaseBackend,
     ConnectionInfo,
@@ -922,11 +923,36 @@ class HfaceBackend(BaseBackend):
         Can be used for the initial handshake for instance."""
         assert self.sock is not None and self._protocol is not None
 
+        protocol = self._protocol
+        sock = self.sock
+        gso_enabled = self._dgram_gso_enabled
+        gro_enabled = self._dgram_gro_enabled
+        blocksize = self.blocksize
+        _has_next_timer = hasattr(protocol, "next_timer")
+
+        def send_pending() -> None:
+            if gso_enabled:
+                tbs: list[bytes] = []
+                while True:
+                    data_out = protocol.bytes_to_send()
+                    if not data_out:
+                        break
+                    tbs.append(data_out)
+                if len(tbs) > 1:
+                    sync_sendmsg_gso(sock, tbs)
+                elif tbs:
+                    sock.sendall(tbs[0])
+            else:
+                while True:
+                    data_out = protocol.bytes_to_send()
+                    if not data_out:
+                        break
+                    sock.sendall(data_out)
+
         if maximal_data_in_read is not None:
             if not (maximal_data_in_read >= 0 or maximal_data_in_read == -1):
                 maximal_data_in_read = None
 
-        data_out: bytes
         data_in: bytes | list[bytes]
 
         data_in_len: int = 0
@@ -945,33 +971,18 @@ class HfaceBackend(BaseBackend):
 
         while True:
             reach_socket: bool = False
-            if not self._protocol.has_pending_event(stream_id=stream_id):
+            if not protocol.has_pending_event(stream_id=stream_id):
                 if receive_first is False:
-                    if self._dgram_gso_enabled:
-                        tbs = []
-                        while True:
-                            data_out = self._protocol.bytes_to_send()
-                            if not data_out:
-                                break
-                            tbs.append(data_out)
-                        if len(tbs) > 1:
-                            sync_sendmsg_gso(self.sock, tbs)
-                        elif tbs:
-                            self.sock.sendall(tbs[0])
-                    else:
-                        while True:
-                            data_out = self._protocol.bytes_to_send()
+                    send_pending()
 
-                            if not data_out:
-                                break
-
-                            self.sock.sendall(data_out)
-
+                next_timer = protocol.next_timer() if _has_next_timer else None  # type: ignore[union-attr]
+                sub = SubTimeout(sock, next_timer, send_pending)
                 try:
-                    if self._dgram_gro_enabled:
-                        data_in = sync_recv_gro(self.sock, self.blocksize)
-                    else:
-                        data_in = self.sock.recv(self.blocksize)
+                    with sub:
+                        if gro_enabled:
+                            data_in = sync_recv_gro(sock, blocksize)
+                        else:
+                            data_in = sock.recv(blocksize)
                 except (ConnectionAbortedError, ConnectionResetError) as e:
                     if isinstance(e, ConnectionResetError) and (
                         event_type is HandshakeCompleted
@@ -986,7 +997,7 @@ class HfaceBackend(BaseBackend):
                     # Windows raises OSError target does not listen on given addr:port
                     # when using UDP sock. We want to translate the OSError into ConnResetError
                     # so that we can properly trigger the downgrade procedure anyway. (QUIC -> TCP)
-                    if self.sock.type is socket.SOCK_DGRAM and (
+                    if sock.type is socket.SOCK_DGRAM and (
                         event_type is HandshakeCompleted
                         or (
                             isinstance(event_type, tuple)
@@ -995,6 +1006,9 @@ class HfaceBackend(BaseBackend):
                     ):
                         raise ConnectionResetError() from e
                     raise
+
+                if sub.timer_fired:
+                    continue
 
                 reach_socket = True
 
@@ -1005,16 +1019,16 @@ class HfaceBackend(BaseBackend):
 
                     # must have at least one event received, otherwise we can't declare a proper eof.
                     if (events or self._response is not None) and hasattr(
-                        self._protocol, "eof_received"
+                        protocol, "eof_received"
                     ):
                         try:
-                            self._protocol.eof_received()
-                        except self._protocol.exceptions() as e:  # Defensive:
+                            protocol.eof_received()
+                        except protocol.exceptions() as e:  # Defensive:
                             # overly protective, we hide exception that are behind urllib3.
                             # should not happen, but one truly never known.
                             raise ProtocolError(e) from e  # Defensive:
                     else:
-                        self._protocol.connection_lost()
+                        protocol.connection_lost()
                 else:
                     if isinstance(data_in, list):
                         for udp_gro_segment in data_in:
@@ -1022,8 +1036,8 @@ class HfaceBackend(BaseBackend):
                                 data_in_len += len(udp_gro_segment)
 
                             try:
-                                self._protocol.bytes_received(udp_gro_segment)
-                            except self._protocol.exceptions() as e:
+                                protocol.bytes_received(udp_gro_segment)
+                            except protocol.exceptions() as e:
                                 if hasattr(e, "expected_length") and hasattr(
                                     e, "actual_length"
                                 ):
@@ -1037,8 +1051,8 @@ class HfaceBackend(BaseBackend):
                             data_in_len += len(data_in)
 
                         try:
-                            self._protocol.bytes_received(data_in)
-                        except self._protocol.exceptions() as e:
+                            protocol.bytes_received(data_in)
+                        except protocol.exceptions() as e:
                             # h2 has a dedicated exception for IncompleteRead (InvalidBodyLengthError)
                             # we convert the exception to our "IncompleteRead" instead.
                             if hasattr(e, "expected_length") and hasattr(
@@ -1050,27 +1064,9 @@ class HfaceBackend(BaseBackend):
                             raise ProtocolError(e) from e  # Defensive:
 
                 if receive_first is True:
-                    if self._dgram_gso_enabled:
-                        tbs = []
-                        while True:
-                            data_out = self._protocol.bytes_to_send()
-                            if not data_out:
-                                break
-                            tbs.append(data_out)
-                        if len(tbs) > 1:
-                            sync_sendmsg_gso(self.sock, tbs)
-                        elif tbs:
-                            self.sock.sendall(tbs[0])
-                    else:
-                        while True:
-                            data_out = self._protocol.bytes_to_send()
+                    send_pending()
 
-                            if not data_out:
-                                break
-
-                            self.sock.sendall(data_out)
-
-            for event in self._protocol.events(stream_id=stream_id):  # type: Event
+            for event in protocol.events(stream_id=stream_id):  # type: Event
                 stream_related_event: bool = hasattr(event, "stream_id")
 
                 if not stream_related_event and isinstance(event, ConnectionTerminated):
@@ -1216,12 +1212,12 @@ class HfaceBackend(BaseBackend):
                     ):
                         if event.end_stream is True:  # type: ignore[attr-defined]
                             if reshelve_events:
-                                self._protocol.reshelve(*reshelve_events)
+                                protocol.reshelve(*reshelve_events)
                             return events
                         continue
 
                     if reshelve_events:
-                        self._protocol.reshelve(*reshelve_events)
+                        protocol.reshelve(*reshelve_events)
                     return events
                 elif (
                     stream_related_event
@@ -1229,7 +1225,7 @@ class HfaceBackend(BaseBackend):
                     and respect_end_stream_signal is True
                 ):
                     if reshelve_events:
-                        self._protocol.reshelve(*reshelve_events)
+                        protocol.reshelve(*reshelve_events)
                     return events
                 elif (
                     stream_related_event
@@ -1239,7 +1235,7 @@ class HfaceBackend(BaseBackend):
                     and stream_id == event.stream_id  # type: ignore[attr-defined]
                 ):
                     if reshelve_events:
-                        self._protocol.reshelve(*reshelve_events)
+                        protocol.reshelve(*reshelve_events)
                     return events
 
     def putrequest(

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -1485,14 +1485,29 @@ class HfaceBackend(BaseBackend):
         assert self._protocol is not None
         assert self.sock is not None
 
+        _has_next_timer = hasattr(self._protocol, "next_timer")
+
+        def send_pending() -> None:
+            while True:
+                data_out = self._protocol.bytes_to_send()  # type: ignore[union-attr]
+                if not data_out:
+                    break
+                self.sock.sendall(data_out)  # type: ignore[union-attr]
+
         while (
             self._protocol.should_wait_remote_flow_control(__stream_id, len(__buf))
             is True
         ):
-            if self._dgram_gro_enabled:
-                data_in = sync_recv_gro(self.sock, self.blocksize)
-            else:
-                data_in = self.sock.recv(self.blocksize)
+            next_timer = self._protocol.next_timer() if _has_next_timer else None  # type: ignore[union-attr]
+            sub = SubTimeout(self.sock, next_timer, send_pending)
+            with sub:
+                if self._dgram_gro_enabled:
+                    data_in = sync_recv_gro(self.sock, self.blocksize)
+                else:
+                    data_in = self.sock.recv(self.blocksize)
+
+            if sub.timer_fired:
+                continue
 
             if isinstance(data_in, list):
                 for gro_segment in data_in:
@@ -1500,13 +1515,7 @@ class HfaceBackend(BaseBackend):
             else:
                 self._protocol.bytes_received(data_in)
 
-            while True:
-                data_out = self._protocol.bytes_to_send()
-
-                if not data_out:
-                    break
-
-                self.sock.sendall(data_out)
+            send_pending()
 
         self._protocol.submit_data(
             __stream_id,
@@ -1810,6 +1819,15 @@ class HfaceBackend(BaseBackend):
         ):
             self.__remaining_body_length = self.__expected_body_length
 
+        _has_next_timer = hasattr(self._protocol, "next_timer")
+
+        def send_pending() -> None:
+            while True:
+                data_out = self._protocol.bytes_to_send()  # type: ignore[union-attr]
+                if not data_out:
+                    break
+                self.sock.sendall(data_out)  # type: ignore[union-attr]
+
         try:
             while (
                 self._protocol.should_wait_remote_flow_control(
@@ -1817,10 +1835,16 @@ class HfaceBackend(BaseBackend):
                 )
                 is True
             ):
-                if self._dgram_gro_enabled:
-                    data_in = sync_recv_gro(self.sock, self.blocksize)
-                else:
-                    data_in = self.sock.recv(self.blocksize)
+                next_timer = self._protocol.next_timer() if _has_next_timer else None  # type: ignore[union-attr]
+                sub = SubTimeout(self.sock, next_timer, send_pending)
+                with sub:
+                    if self._dgram_gro_enabled:
+                        data_in = sync_recv_gro(self.sock, self.blocksize)
+                    else:
+                        data_in = self.sock.recv(self.blocksize)
+
+                if sub.timer_fired:
+                    continue
 
                 if not isinstance(data_in, list):
                     self._protocol.bytes_received(data_in)
@@ -1844,13 +1868,7 @@ class HfaceBackend(BaseBackend):
 
                     raise EarlyResponse(promise=rp)
 
-                while True:
-                    data_out = self._protocol.bytes_to_send()
-
-                    if not data_out:
-                        break
-
-                    self.sock.sendall(data_out)
+                send_pending()
 
             if self.__remaining_body_length:
                 self.__remaining_body_length -= len(data)

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -560,6 +560,12 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                         else 5.0
                     )
 
+                    ech_config_hex = ""
+                    for ip_addr in ip_addresses:
+                        if isinstance(ip_addr[3], bytes) and ip_addr[3]:
+                            ech_config_hex = ip_addr[3].hex()
+                            break
+
                     for ip_address in ip_addresses[:max_task]:
                         conn_kw = self.conn_kw.copy()
                         target_solo_addr = (
@@ -567,8 +573,13 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                             if ip_address[0] == socket.AF_INET6
                             else ip_address[-1][0]
                         )
-                        conn_kw["resolver"] = ResolverDescription.from_url(
+                        inmemory_url = (
                             f"in-memory://default?hosts={self.host}:{target_solo_addr}"
+                        )
+                        if ech_config_hex:
+                            inmemory_url += f"&ech_config={ech_config_hex}"
+                        conn_kw["resolver"] = ResolverDescription.from_url(
+                            inmemory_url
                         ).new()
                         conn_kw["socket_family"] = ip_address[0]
 
@@ -2216,6 +2227,12 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                         else 5.0
                     )
 
+                    ech_config_hex = ""
+                    for ip_addr in ip_addresses:
+                        if isinstance(ip_addr[3], bytes) and ip_addr[3]:
+                            ech_config_hex = ip_addr[3].hex()
+                            break
+
                     for ip_address in ip_addresses[:max_task]:
                         conn_kw = self.conn_kw.copy()
                         target_solo_addr = (
@@ -2223,8 +2240,13 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                             if ip_address[0] == socket.AF_INET6
                             else ip_address[-1][0]
                         )
-                        conn_kw["resolver"] = ResolverDescription.from_url(
+                        inmemory_url = (
                             f"in-memory://default?hosts={self.host}:{target_solo_addr}"
+                        )
+                        if ech_config_hex:
+                            inmemory_url += f"&ech_config={ech_config_hex}"
+                        conn_kw["resolver"] = ResolverDescription.from_url(
+                            inmemory_url
                         ).new()
                         conn_kw["socket_family"] = ip_address[0]
                         conn_kw["preemptive_quic_cache"] = target_pqc

--- a/src/urllib3/contrib/hface/protocols/_protocols.py
+++ b/src/urllib3/contrib/hface/protocols/_protocols.py
@@ -89,6 +89,12 @@ class OverUDPProtocol(BaseProtocol, metaclass=ABCMeta):
 
 
 class OverQUICProtocol(OverUDPProtocol):
+    def next_timer(self) -> float | None:
+        """Return the absolute monotonic time of the next QUIC timer event.
+        Returns None when no timer is currently scheduled.
+        """
+        raise NotImplementedError
+
     @property
     @abstractmethod
     def connection_ids(self) -> Sequence[bytes]:

--- a/src/urllib3/contrib/hface/protocols/http3/_qh3.py
+++ b/src/urllib3/contrib/hface/protocols/http3/_qh3.py
@@ -168,19 +168,13 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
         if not self._terminated and not self._goaway_to_honor:
             now = monotonic()
             self._quic.handle_timer(now)
-            self._packets.extend(
-                map(lambda e: e[0], self._quic.datagrams_to_send(now=now))
-            )
             if self._quic._state in {
                 QuicConnectionState.CLOSING,
                 QuicConnectionState.TERMINATED,
             }:
                 self._terminated = True
-            if (
-                hasattr(self._quic, "_close_event")
-                and self._quic._close_event is not None
-            ):
-                self._events.extend(self._map_quic_event(self._quic._close_event))
+            if getattr(self._quic, "_close_event", None) is not None:
+                self._events.extend(self._map_quic_event(self._quic._close_event))  # type: ignore[arg-type]
                 self._terminated = True
         return (
             self._terminated or self._goaway_to_honor
@@ -212,7 +206,7 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
         assert self._http is not None
         self._open_stream_count += 1
         self._total_stream_count += 1
-        self._http.send_headers(stream_id, list(headers), end_stream)
+        self._http.send_headers(stream_id, headers, end_stream)  # type: ignore[arg-type]
 
     def submit_data(
         self, stream_id: int, data: bytes, end_stream: bool = False
@@ -292,9 +286,7 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
             # the QUIC state machine returns datagrams (addr, packet)
             # the client never have to worry about the destination
             # unless server yield a preferred address?
-            self._packets.extend(
-                map(lambda e: e[0], self._quic.datagrams_to_send(now=now))
-            )
+            self._packets.extend(e[0] for e in self._quic.datagrams_to_send(now=now))
             self._next_timer = self._quic.get_timer()
 
         if not self._packets:

--- a/src/urllib3/contrib/hface/protocols/http3/_qh3.py
+++ b/src/urllib3/contrib/hface/protocols/http3/_qh3.py
@@ -144,6 +144,9 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
         self._max_frame_size: int | None = None
         self._next_timer: float | None = None
 
+    def next_timer(self) -> float | None:
+        return self._quic.get_timer()
+
     @staticmethod
     def exceptions() -> tuple[type[BaseException], ...]:
         return ProtocolError, H3Error, QuicConnectionError, AssertionError
@@ -305,8 +308,8 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
             for h3_event in self._http.handle_event(quic_event):
                 self._events.extend(self._map_h3_event(h3_event))
 
-        if hasattr(self._quic, "_close_event") and self._quic._close_event is not None:
-            self._events.extend(self._map_quic_event(self._quic._close_event))
+        if getattr(self._quic, "_close_event", None) is not None:
+            self._events.extend(self._map_quic_event(self._quic._close_event))  # type: ignore[arg-type]
 
     def _map_quic_event(self, quic_event: quic_events.QuicEvent) -> Iterable[Event]:
         ev_type = quic_event.__class__
@@ -359,6 +362,29 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
     def should_wait_remote_flow_control(
         self, stream_id: int, amt: int | None = None
     ) -> bool | None:
+        # accessing our QUIC loss detector
+        # yes, we now, it's private, and we
+        # also maintain qh3, so we're aware.
+        loss = self._quic._loss
+
+        # At least 2 ack-eliciting packets outstanding.
+        # RFC 9000 section 13.2.1
+        # - ACK after the peer receives <= 2 ack-eliciting packets.
+        # - ACK within the peer's negotiated max_ack_delay (<= 25 ms by default).
+        n_outstanding = sum(s.ack_eliciting_in_flight for s in loss.spaces)
+
+        if n_outstanding >= 2:
+            return True
+
+        now = monotonic()
+
+        # Or max_ack_delay elapsed since the last ack-eliciting send.
+        # Yes, we know, it's approximative, borderline heuristic
+        if n_outstanding >= 1:
+            deadline = loss._time_of_last_sent_ack_eliciting_packet + loss.max_ack_delay
+            if now >= deadline:
+                return True
+
         return False
 
     @typing.overload

--- a/src/urllib3/contrib/resolver/_async/doq/_qh3.py
+++ b/src/urllib3/contrib/resolver/_async/doq/_qh3.py
@@ -27,6 +27,7 @@ from qh3.quic.events import (
 )
 
 from .....util.ssl_ import IS_FIPS, resolve_cert_reqs
+from .....util.sub_timeout import AsyncSubTimeout
 from ...protocols import (
     COMMON_RCODE_LABEL,
     DomainNameServerQuery,
@@ -484,24 +485,45 @@ class QUICResolver(PlainResolver):
     ) -> list[QuicEvent]:
         assert self._socket is not None
 
+        quic = self._quic
+        sock = self._socket
+
+        async def send_pending() -> None:
+            now = monotonic()
+            quic.handle_timer(now)
+            while True:
+                datagrams = quic.datagrams_to_send(now)
+                if not datagrams:
+                    break
+                for datagram in datagrams:
+                    await sock.sendall(datagram[0])
+
         while True:
             if receive_first is False:
                 now = monotonic()
                 while True:
-                    datagrams = self._quic.datagrams_to_send(now)
+                    datagrams = quic.datagrams_to_send(now)
 
                     if not datagrams:
                         break
 
                     for datagram in datagrams:
                         data, addr = datagram
-                        await self._socket.sendall(data)
+                        await sock.sendall(data)
 
             events = []
 
             while True:
-                if not self._quic._events:
-                    data_in = await self._socket.recv(1500)
+                if not quic._events:
+                    sub = AsyncSubTimeout(
+                        sock,
+                        quic.get_timer(),
+                        send_pending,
+                    )
+                    async with sub:
+                        data_in = await sock.recv(1500)
+                    if sub.timer_fired:
+                        continue
 
                     if not data_in:
                         break
@@ -509,26 +531,24 @@ class QUICResolver(PlainResolver):
                     now = monotonic()
 
                     if not isinstance(data_in, list):
-                        self._quic.receive_datagram(
-                            data_in, (self._server, self._port), now
-                        )
+                        quic.receive_datagram(data_in, (self._server, self._port), now)
                     else:
                         for gro_segment in data_in:
-                            self._quic.receive_datagram(
+                            quic.receive_datagram(
                                 gro_segment, (self._server, self._port), now
                             )
 
                     while True:
-                        datagrams = self._quic.datagrams_to_send(now)
+                        datagrams = quic.datagrams_to_send(now)
 
                         if not datagrams:
                             break
 
                         for datagram in datagrams:
                             data, addr = datagram
-                            await self._socket.sendall(data)
+                            await sock.sendall(data)
 
-                for ev in iter(self._quic.next_event, None):
+                for ev in iter(quic.next_event, None):
                     if isinstance(ev, ConnectionTerminated):
                         if ev.error_code == 298:
                             raise SSLError(

--- a/src/urllib3/contrib/resolver/_async/in_memory/_dict.py
+++ b/src/urllib3/contrib/resolver/_async/in_memory/_dict.py
@@ -18,10 +18,19 @@ class InMemoryResolver(AsyncBaseResolver):
             kwargs.pop("server")
         if "port" in kwargs:
             kwargs.pop("port")
+
+        ech_config = kwargs.pop("ech_config", None)
+
         super().__init__(None, None, *patterns, **kwargs)
 
         self._maxsize = 65535 if "maxsize" not in kwargs else int(kwargs["maxsize"])
         self._hosts: dict[str, list[tuple[socket.AddressFamily, str]]] = {}
+
+        self._ech_config_list: bytes | None = None
+        if isinstance(ech_config, str) and ech_config:
+            self._ech_config_list = bytes.fromhex(ech_config)
+        elif isinstance(ech_config, bytes) and ech_config:
+            self._ech_config_list = ech_config
 
         if self._host_patterns:
             for record in self._host_patterns:
@@ -92,7 +101,7 @@ class InMemoryResolver(AsyncBaseResolver):
             socket.AddressFamily,
             socket.SocketKind,
             int,
-            str,
+            str | bytes,
             tuple[str, int] | tuple[str, int, int, int],
         ]
     ]:
@@ -153,10 +162,14 @@ class InMemoryResolver(AsyncBaseResolver):
                 socket.AddressFamily,
                 socket.SocketKind,
                 int,
-                str,
+                str | bytes,
                 tuple[str, int] | tuple[str, int, int, int],
             ]
         ] = []
+
+        canonname: str | bytes = (
+            self._ech_config_list if self._ech_config_list is not None else ""
+        )
 
         if host not in self._hosts:
             raise socket.gaierror(f"no records found for hostname {host} in-memory")
@@ -173,7 +186,7 @@ class InMemoryResolver(AsyncBaseResolver):
                     addr_type,
                     type,
                     6 if type == socket.SOCK_STREAM else 17,
-                    "",
+                    canonname,
                     (addr_target, port)
                     if addr_type == socket.AF_INET
                     else (addr_target, port, 0, 0),

--- a/src/urllib3/contrib/resolver/doq/_qh3.py
+++ b/src/urllib3/contrib/resolver/doq/_qh3.py
@@ -26,6 +26,7 @@ from qh3.quic.events import (
 )
 
 from ....util.ssl_ import IS_FIPS, resolve_cert_reqs
+from ....util.sub_timeout import SubTimeout
 from ...ssa._gro import _sock_has_gro, _sock_has_gso, sync_recv_gro, sync_sendmsg_gso
 from ..dou import PlainResolver
 from ..protocols import (
@@ -460,29 +461,55 @@ class QUICResolver(PlainResolver):
         | None = None,
         respect_end_stream_signal: bool = True,
     ) -> list[QuicEvent]:
+        quic = self._quic
+        sock = self._socket
+        gso_enabled = self._dgram_gso_enabled
+        gro_enabled = self._dgram_gro_enabled
+
+        def send_pending() -> None:
+            now = monotonic()
+            quic.handle_timer(now)
+            while True:
+                datagrams = quic.datagrams_to_send(now)
+                if not datagrams:
+                    break
+                if gso_enabled and len(datagrams) > 1:
+                    sync_sendmsg_gso(sock, [d[0] for d in datagrams])
+                else:
+                    for datagram in datagrams:
+                        sock.sendall(datagram[0])
+
         while True:
             if receive_first is False:
                 now = monotonic()
                 while True:
-                    datagrams = self._quic.datagrams_to_send(now)
+                    datagrams = quic.datagrams_to_send(now)
 
                     if not datagrams:
                         break
 
-                    if self._dgram_gso_enabled and len(datagrams) > 1:
-                        sync_sendmsg_gso(self._socket, [d[0] for d in datagrams])
+                    if gso_enabled and len(datagrams) > 1:
+                        sync_sendmsg_gso(sock, [d[0] for d in datagrams])
                     else:
                         for datagram in datagrams:
-                            self._socket.sendall(datagram[0])
+                            sock.sendall(datagram[0])
 
             events = []
 
             while True:
-                if not self._quic._events:
-                    if self._dgram_gro_enabled:
-                        data_in = sync_recv_gro(self._socket, 65535)
-                    else:
-                        data_in = self._socket.recv(1500)
+                if not quic._events:
+                    sub = SubTimeout(
+                        sock,
+                        quic.get_timer(),
+                        send_pending,
+                    )
+                    with sub:
+                        if gro_enabled:
+                            data_in = sync_recv_gro(sock, 65535)
+                        else:
+                            data_in = sock.recv(1500)
+                    if sub.timer_fired:
+                        continue
 
                     if not data_in:
                         break
@@ -491,28 +518,26 @@ class QUICResolver(PlainResolver):
 
                     if isinstance(data_in, list):
                         for gro_segment in data_in:
-                            self._quic.receive_datagram(
+                            quic.receive_datagram(
                                 gro_segment, (self._server, self._port), now
                             )
                     else:
-                        self._quic.receive_datagram(
-                            data_in, (self._server, self._port), now
-                        )
+                        quic.receive_datagram(data_in, (self._server, self._port), now)
 
                     while True:
                         now = monotonic()
-                        datagrams = self._quic.datagrams_to_send(now)
+                        datagrams = quic.datagrams_to_send(now)
 
                         if not datagrams:
                             break
 
-                        if self._dgram_gso_enabled and len(datagrams) > 1:
-                            sync_sendmsg_gso(self._socket, [d[0] for d in datagrams])
+                        if gso_enabled and len(datagrams) > 1:
+                            sync_sendmsg_gso(sock, [d[0] for d in datagrams])
                         else:
                             for datagram in datagrams:
-                                self._socket.sendall(datagram[0])
+                                sock.sendall(datagram[0])
 
-                for ev in iter(self._quic.next_event, None):
+                for ev in iter(quic.next_event, None):
                     if isinstance(ev, ConnectionTerminated):
                         if ev.error_code == 298:
                             raise SSLError(

--- a/src/urllib3/contrib/resolver/in_memory/_dict.py
+++ b/src/urllib3/contrib/resolver/in_memory/_dict.py
@@ -17,10 +17,19 @@ class InMemoryResolver(BaseResolver):
             kwargs.pop("server")
         if "port" in kwargs:
             kwargs.pop("port")
+
+        ech_config = kwargs.pop("ech_config", None)
+
         super().__init__(None, None, *patterns, **kwargs)
 
         self._maxsize = 65535 if "maxsize" not in kwargs else int(kwargs["maxsize"])
         self._hosts: dict[str, list[tuple[socket.AddressFamily, str]]] = {}
+
+        self._ech_config_list: bytes | None = None
+        if isinstance(ech_config, str) and ech_config:
+            self._ech_config_list = bytes.fromhex(ech_config)
+        elif isinstance(ech_config, bytes) and ech_config:
+            self._ech_config_list = ech_config
 
         if self._host_patterns:
             for record in self._host_patterns:
@@ -163,6 +172,10 @@ class InMemoryResolver(BaseResolver):
             ]
         ] = []
 
+        canonname: str | bytes = (
+            self._ech_config_list if self._ech_config_list is not None else ""
+        )
+
         with self._lock:
             if host not in self._hosts:
                 raise socket.gaierror(f"no records found for hostname {host} in-memory")
@@ -179,7 +192,7 @@ class InMemoryResolver(BaseResolver):
                         addr_type,
                         type,
                         6 if type == socket.SOCK_STREAM else 17,
-                        "",
+                        canonname,
                         (addr_target, port)
                         if addr_type == socket.AF_INET
                         else (addr_target, port, 0, 0),

--- a/src/urllib3/util/sub_timeout.py
+++ b/src/urllib3/util/sub_timeout.py
@@ -59,7 +59,7 @@ class SubTimeout:
         self._original_timeout = self.sock.gettimeout()
 
         if self.next_timer is not None:
-            time_to_timer = self.next_timer - time.monotonic()
+            time_to_timer = self.next_timer - time.time()
             # Clamp to a tiny positive value so the socket stays in
             # blocking-with-timeout mode.  settimeout(0.0) would switch
             # to non-blocking and raise BlockingIOError instead of
@@ -122,7 +122,7 @@ class AsyncSubTimeout:
         self._original_timeout = self.sock.gettimeout()
 
         if self.next_timer is not None:
-            time_to_timer = self.next_timer - time.monotonic()
+            time_to_timer = self.next_timer - time.time()
             time_to_timer = max(time_to_timer, 1e-6)
 
             if self._original_timeout is None or time_to_timer < self._original_timeout:

--- a/src/urllib3/util/sub_timeout.py
+++ b/src/urllib3/util/sub_timeout.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import time
+import typing
+from socket import timeout as SocketTimeout
+
+if typing.TYPE_CHECKING:
+    from socket import socket as _sync_socket
+
+    from ..contrib.ssa import AsyncSocket as _async_socket
+
+
+class SubTimeout:
+    """Context manager that temporarily lowers a socket's timeout to honor
+    a secondary deadline (e.g. a QUIC state-machine timer).
+
+    When the secondary deadline expires before the primary timeout, the
+    *on_timer* callback is invoked and the ``SocketTimeout`` exception is
+    suppressed.  The caller can inspect :attr:`timer_fired` after the
+    ``with`` block to decide whether to retry the I/O operation.
+
+    When *next_timer* is ``None`` or falls after the primary timeout the
+    context manager is a lightweight no-op, the original socket timeout
+    is left untouched and any ``SocketTimeout`` raised inside the block
+    propagates as a regular user timeout.
+
+    Usage::
+
+        sub = SubTimeout(sock, protocol.next_timer(), send_pending)
+        with sub:
+            data = sock.recv(blocksize)
+        if sub.timer_fired:
+            continue  # timer was handled, retry
+    """
+
+    __slots__ = (
+        "sock",
+        "next_timer",
+        "on_timer",
+        "timer_fired",
+        "_original_timeout",
+        "_adjusted",
+    )
+
+    def __init__(
+        self,
+        sock: _sync_socket,
+        next_timer: float | None,
+        on_timer: typing.Callable[[], None],
+    ) -> None:
+        self.sock = sock
+        self.next_timer = next_timer
+        self.on_timer = on_timer
+        self.timer_fired: bool = False
+        self._original_timeout: float | None = None
+        self._adjusted: bool = False
+
+    def __enter__(self) -> SubTimeout:
+        self._original_timeout = self.sock.gettimeout()
+
+        if self.next_timer is not None:
+            time_to_timer = self.next_timer - time.monotonic()
+            # Clamp to a tiny positive value so the socket stays in
+            # blocking-with-timeout mode.  settimeout(0.0) would switch
+            # to non-blocking and raise BlockingIOError instead of
+            # SocketTimeout.
+            time_to_timer = max(time_to_timer, 1e-6)
+
+            if self._original_timeout is None or time_to_timer < self._original_timeout:
+                self.sock.settimeout(time_to_timer)
+                self._adjusted = True
+            # When the existing timeout is shorter than time_to_timer we
+            # intentionally leave the socket untouched so the user
+            # timeout fires normally and is never mistaken for a timer
+            # event.
+
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: typing.Any,
+    ) -> bool:
+        if self._adjusted:
+            self.sock.settimeout(self._original_timeout)
+
+        if exc_type is SocketTimeout and self._adjusted:
+            self.timer_fired = True
+            self.on_timer()
+            return True  # suppress the timeout exception
+
+        return False
+
+
+class AsyncSubTimeout:
+    """Async counterpart of :class:`SubTimeout`."""
+
+    __slots__ = (
+        "sock",
+        "next_timer",
+        "on_timer",
+        "timer_fired",
+        "_original_timeout",
+        "_adjusted",
+    )
+
+    def __init__(
+        self,
+        sock: _async_socket,
+        next_timer: float | None,
+        on_timer: typing.Callable[[], typing.Awaitable[None]],
+    ) -> None:
+        self.sock = sock
+        self.next_timer = next_timer
+        self.on_timer = on_timer
+        self.timer_fired: bool = False
+        self._original_timeout: float | None = None
+        self._adjusted: bool = False
+
+    async def __aenter__(self) -> AsyncSubTimeout:
+        self._original_timeout = self.sock.gettimeout()
+
+        if self.next_timer is not None:
+            time_to_timer = self.next_timer - time.monotonic()
+            time_to_timer = max(time_to_timer, 1e-6)
+
+            if self._original_timeout is None or time_to_timer < self._original_timeout:
+                self.sock.settimeout(time_to_timer)
+                self._adjusted = True
+
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: typing.Any,
+    ) -> bool:
+        if self._adjusted:
+            self.sock.settimeout(self._original_timeout)
+
+        if exc_type is SocketTimeout and self._adjusted:
+            self.timer_fired = True
+            await self.on_timer()
+            return True
+
+        return False

--- a/test/contrib/asynchronous/test_resolver.py
+++ b/test/contrib/asynchronous/test_resolver.py
@@ -30,6 +30,21 @@ from urllib3.contrib.resolver._async.null import NullResolver  # noqa: E402
 from urllib3.contrib.resolver._async.system import SystemResolver  # noqa: E402
 from urllib3.exceptions import InsecureRequestWarning  # noqa: E402
 
+_DOQ_PARAM = pytest.param(
+    "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+    marks=[
+        pytest.mark.skipif(
+            QUICResolver is _MISSING_QUIC_SENTINEL,
+            reason="Test requires qh3 installed",
+        ),
+        pytest.mark.xfail(
+            condition=bool(os.environ.get("CI")),
+            reason="DoQ unreliable in CI (adguard unreachable)",
+            strict=False,
+        ),
+    ],
+)
+
 
 @pytest.mark.parametrize(
     "hostname, expect_error",
@@ -69,7 +84,21 @@ async def test_null_resolver(hostname: str, expect_error: bool) -> None:
         ("dou://1.1.1.1", PlainResolver),
         ("dox://ooooo.com", None),
         ("doh://dns.google/resolve", HTTPSResolver),
-        ("doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0", QUICResolver),
+        pytest.param(
+            "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+            QUICResolver,
+            marks=[
+                pytest.mark.skipif(
+                    QUICResolver is _MISSING_QUIC_SENTINEL,
+                    reason="Test requires qh3 installed",
+                ),
+                pytest.mark.xfail(
+                    condition=bool(os.environ.get("CI")),
+                    reason="DoQ unreliable in CI (adguard unreachable)",
+                    strict=False,
+                ),
+            ],
+        ),
         ("dns://dns.adguard-dns.com", None),
         ("null://default", NullResolver),
         ("default://null", None),
@@ -83,9 +112,20 @@ async def test_null_resolver(hostname: str, expect_error: bool) -> None:
         ("dot://1.1.1.1/?implementation=nonexistent", None),
         ("system://", SystemResolver),
         ("dot://", None),
-        (
+        pytest.param(
             "doq://dns.adguard-dns.com/?implementation=qh3&timeout=1&cert_reqs=0",
             QUICResolver,
+            marks=[
+                pytest.mark.skipif(
+                    QUICResolver is _MISSING_QUIC_SENTINEL,
+                    reason="Test requires qh3 installed",
+                ),
+                pytest.mark.xfail(
+                    condition=bool(os.environ.get("CI")),
+                    reason="DoQ unreliable in CI (adguard unreachable)",
+                    strict=False,
+                ),
+            ],
         ),
     ],
 )
@@ -93,9 +133,6 @@ async def test_null_resolver(hostname: str, expect_error: bool) -> None:
 async def test_url_resolver(
     url: str, expected_resolver_class: type[AsyncBaseResolver] | None
 ) -> None:
-    if expected_resolver_class is _MISSING_QUIC_SENTINEL:
-        pytest.skip("Test requires qh3 installed")
-
     if expected_resolver_class is None:
         with pytest.raises(
             (
@@ -125,19 +162,13 @@ async def test_url_resolver(
         "system://default",
         "dot://dns.google",
         "dot://one.one.one.one",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
         "doh+google://",
         "doh+cloudflare://default",
     ],
 )
 @pytest.mark.asyncio
 async def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     res = await resolver.getaddrinfo(
@@ -163,7 +194,7 @@ async def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
         "doh://dns.google",
         "dot://dns.google",
         "dot://one.one.one.one",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
     ],
 )
 @pytest.mark.parametrize(
@@ -178,12 +209,6 @@ async def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
 async def test_dnssec_exception(
     dns_url: str, hostname: str, expected_failure: bool
 ) -> None:
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     if expected_failure:
@@ -301,19 +326,13 @@ async def test_many_resolver_host_constraint_distribution() -> None:
     [
         "doh+google://default/?timeout=1",
         "doh+cloudflare://",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
 )
 @pytest.mark.asyncio
 async def test_short_endurance_sprint(dns_url: str) -> None:
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     for host in [
@@ -390,19 +409,13 @@ async def test_doh_rfc8484(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
 )
 @pytest.mark.asyncio
 async def test_task_safe_resolver(dns_url: str) -> None:
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     tasks = []
@@ -477,19 +490,13 @@ async def test_many_resolver_task_safe() -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
 )
 @pytest.mark.asyncio
 async def test_resolver_recycle(dns_url: str) -> None:
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     await resolver.close()
@@ -516,19 +523,13 @@ async def test_resolver_recycle(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
 )
 @pytest.mark.asyncio
 async def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     with pytest.raises(RuntimeError):
@@ -543,7 +544,7 @@ async def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -551,12 +552,6 @@ async def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
 @pytest.mark.asyncio
 async def test_ipv6_always_preferred(dns_url: str) -> None:
     """Our resolvers must place IPV6 address in the beginning of returned list."""
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     inet_classes = []
@@ -584,7 +579,7 @@ async def test_ipv6_always_preferred(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
@@ -592,12 +587,6 @@ async def test_ipv6_always_preferred(dns_url: str) -> None:
 @pytest.mark.asyncio
 async def test_dgram_upgrade(dns_url: str) -> None:
     """www.cloudflare.com records HTTPS exist, we know it. This verify that we are able to propose a DGRAM upgrade."""
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = AsyncResolverDescription.from_url(dns_url).new()
 
     sock_types = []

--- a/test/contrib/test_resolver.py
+++ b/test/contrib/test_resolver.py
@@ -31,6 +31,21 @@ from urllib3.contrib.resolver.null import NullResolver  # noqa: E402
 from urllib3.contrib.resolver.system import SystemResolver  # noqa: E402
 from urllib3.exceptions import InsecureRequestWarning  # noqa: E402
 
+_DOQ_PARAM = pytest.param(
+    "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+    marks=[
+        pytest.mark.skipif(
+            QUICResolver is _MISSING_QUIC_SENTINEL,
+            reason="Test requires qh3 installed",
+        ),
+        pytest.mark.xfail(
+            condition=bool(os.environ.get("CI")),
+            reason="DoQ unreliable in CI (adguard unreachable)",
+            strict=False,
+        ),
+    ],
+)
+
 
 @pytest.mark.parametrize(
     "hostname, expect_error",
@@ -69,7 +84,21 @@ def test_null_resolver(hostname: str, expect_error: bool) -> None:
         ("dou://1.1.1.1", PlainResolver),
         ("dox://ooooo.com", None),
         ("doh://dns.google/resolve", HTTPSResolver),
-        ("doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0", QUICResolver),
+        pytest.param(
+            "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+            QUICResolver,
+            marks=[
+                pytest.mark.skipif(
+                    QUICResolver is _MISSING_QUIC_SENTINEL,
+                    reason="Test requires qh3 installed",
+                ),
+                pytest.mark.xfail(
+                    condition=bool(os.environ.get("CI")),
+                    reason="DoQ unreliable in CI (adguard unreachable)",
+                    strict=False,
+                ),
+            ],
+        ),
         ("dns://dns.adguard-dns.com", None),
         ("null://default", NullResolver),
         ("default://null", None),
@@ -83,21 +112,26 @@ def test_null_resolver(hostname: str, expect_error: bool) -> None:
         ("dot://1.1.1.1/?implementation=nonexistent", None),
         ("system://", SystemResolver),
         ("dot://", None),
-        (
+        pytest.param(
             "doq://dns.adguard-dns.com/?implementation=qh3&timeout=1&cert_reqs=0",
             QUICResolver,
+            marks=[
+                pytest.mark.skipif(
+                    QUICResolver is _MISSING_QUIC_SENTINEL,
+                    reason="Test requires qh3 installed",
+                ),
+                pytest.mark.xfail(
+                    condition=bool(os.environ.get("CI")),
+                    reason="DoQ unreliable in CI (adguard unreachable)",
+                    strict=False,
+                ),
+            ],
         ),
     ],
 )
 def test_url_resolver(
     url: str, expected_resolver_class: type[BaseResolver] | None
 ) -> None:
-    if expected_resolver_class is _MISSING_QUIC_SENTINEL:
-        pytest.skip("Test requires qh3 installed")
-
-    if url.startswith("doq://") and os.environ.get("CI", None) is not None:
-        pytest.skip("Adguard unreachable in CI")
-
     if expected_resolver_class is None:
         with pytest.raises(
             (
@@ -127,18 +161,12 @@ def test_url_resolver(
         "system://default",
         "dot://dns.google",
         "dot://one.one.one.one",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
         "doh+google://",
         "doh+cloudflare://default",
     ],
 )
 def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = ResolverDescription.from_url(dns_url).new()
 
     res = resolver.getaddrinfo(
@@ -163,7 +191,7 @@ def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
         "doh://dns.google",
         "dot://dns.google",
         "dot://one.one.one.one",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
     ],
 )
 @pytest.mark.parametrize(
@@ -175,12 +203,6 @@ def test_1_1_1_1_ipv4_resolution_across_protocols(dns_url: str) -> None:
     ],
 )
 def test_dnssec_exception(dns_url: str, hostname: str, expected_failure: bool) -> None:
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = ResolverDescription.from_url(dns_url).new()
 
     if expected_failure:
@@ -296,18 +318,12 @@ def test_many_resolver_host_constraint_distribution() -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
 )
 def test_short_endurance_sprint(dns_url: str) -> None:
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = ResolverDescription.from_url(dns_url).new()
 
     for host in [
@@ -383,18 +399,12 @@ def test_doh_rfc8484(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
 )
 def test_thread_safe_resolver(dns_url: str) -> None:
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = ResolverDescription.from_url(dns_url).new()
 
     def _run(
@@ -488,18 +498,12 @@ def test_many_resolver_thread_safe() -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
 )
 def test_resolver_recycle(dns_url: str) -> None:
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = ResolverDescription.from_url(dns_url).new()
 
     resolver.close()
@@ -526,18 +530,12 @@ def test_resolver_recycle(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
 )
 def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = ResolverDescription.from_url(dns_url).new()
 
     with pytest.raises(RuntimeError):
@@ -552,19 +550,13 @@ def test_resolve_cannot_recycle_when_available(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
 )
 def test_ipv6_always_preferred(dns_url: str) -> None:
     """Our resolvers must place IPV6 address in the beginning of returned list."""
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = ResolverDescription.from_url(dns_url).new()
 
     inet_classes = []
@@ -592,19 +584,13 @@ def test_ipv6_always_preferred(dns_url: str) -> None:
     [
         "doh+google://",
         "doh+cloudflare://",
-        "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",
+        _DOQ_PARAM,
         "dot://one.one.one.one",
         "dou://one.one.one.one",
     ],
 )
 def test_dgram_upgrade(dns_url: str) -> None:
     """www.cloudflare.com records HTTPS exist, we know it. This verify that we are able to propose a DGRAM upgrade."""
-    if dns_url.startswith("doq"):
-        if QUICResolver is _MISSING_QUIC_SENTINEL:
-            pytest.skip("Test requires qh3 installed")
-        if os.environ.get("CI"):
-            pytest.skip("DoQ unreliable in CI (adguard unreachable)")
-
     resolver = ResolverDescription.from_url(dns_url).new()
 
     sock_types = []

--- a/test/test_ech.py
+++ b/test/test_ech.py
@@ -32,7 +32,7 @@ def test_sync_ech_accepted(happy_eyeballs: bool, http_version: int) -> None:
         pytest.skip("Test requires HTTP/3 support")
     if http_version != 30:
         try:
-            import rtls
+            import rtls  # noqa
         except ImportError:
             pytest.skip("Test requires rtls for ECH at TCP level")
 
@@ -61,7 +61,7 @@ def test_sync_ech_accepted(happy_eyeballs: bool, http_version: int) -> None:
     }
 
     with PoolManager(**pm_kwargs) as pm:
-        resp = pm.urlopen(
+        pm.urlopen(
             "GET",
             "https://encryptedsni.com/",
             redirect=False,
@@ -89,7 +89,7 @@ async def test_async_ech_accepted(happy_eyeballs: bool, http_version: int) -> No
         pytest.skip("Test requires HTTP/3 support")
     if http_version != 30:
         try:
-            import rtls
+            import rtls  # noqa
         except ImportError:
             pytest.skip("Test requires rtls for ECH at TCP level")
 

--- a/test/test_ech.py
+++ b/test/test_ech.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import typing
+
+from test import requires_network
+
+import pytest
+
+from urllib3 import (
+    AsyncPoolManager,
+    ConnectionInfo,
+    HttpVersion,
+    PoolManager,
+)
+from urllib3.backend._async.hface import _HAS_HTTP3_SUPPORT as _ASYNC_HAS_HTTP3_SUPPORT  # type: ignore[attr-defined]
+from urllib3.backend.hface import _HAS_HTTP3_SUPPORT as _SYNC_HAS_HTTP3_SUPPORT
+
+
+@requires_network()
+@pytest.mark.parametrize(
+    "happy_eyeballs",
+    [False, True],
+    ids=["heb_off", "heb_on"],
+)
+@pytest.mark.parametrize(
+    "http_version",
+    [11, 20, 30],
+    ids=["h1", "h2", "h3"],
+)
+def test_sync_ech_accepted(happy_eyeballs: bool, http_version: int) -> None:
+    if http_version == 30 and not _SYNC_HAS_HTTP3_SUPPORT():
+        pytest.skip("Test requires HTTP/3 support")
+    if http_version != 30:
+        try:
+            import rtls
+        except ImportError:
+            pytest.skip("Test requires rtls for ECH at TCP level")
+
+    disabled_svn: set[HttpVersion] = set()
+
+    if http_version == 11:
+        disabled_svn.add(HttpVersion.h3)
+        disabled_svn.add(HttpVersion.h2)
+    elif http_version == 20:
+        disabled_svn.add(HttpVersion.h11)
+        disabled_svn.add(HttpVersion.h3)
+    elif http_version == 30:
+        disabled_svn.add(HttpVersion.h11)
+        disabled_svn.add(HttpVersion.h2)
+
+    conn_info_ref: ConnectionInfo | None = None
+
+    def on_post_connection(conn_info: ConnectionInfo) -> None:
+        nonlocal conn_info_ref
+        conn_info_ref = conn_info
+
+    pm_kwargs: dict[str, typing.Any] = {
+        "resolver": "doh+google://",
+        "disabled_svn": disabled_svn,
+        "happy_eyeballs": happy_eyeballs,
+    }
+
+    with PoolManager(**pm_kwargs) as pm:
+        resp = pm.urlopen(
+            "GET",
+            "https://encryptedsni.com/",
+            redirect=False,
+            on_post_connection=on_post_connection,
+        )
+
+    assert conn_info_ref is not None
+    assert conn_info_ref.tls_ech_accepted is True
+
+
+@requires_network()
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "happy_eyeballs",
+    [False, True],
+    ids=["heb_off", "heb_on"],
+)
+@pytest.mark.parametrize(
+    "http_version",
+    [11, 20, 30],
+    ids=["h1", "h2", "h3"],
+)
+async def test_async_ech_accepted(happy_eyeballs: bool, http_version: int) -> None:
+    if http_version == 30 and not _ASYNC_HAS_HTTP3_SUPPORT():
+        pytest.skip("Test requires HTTP/3 support")
+    if http_version != 30:
+        try:
+            import rtls
+        except ImportError:
+            pytest.skip("Test requires rtls for ECH at TCP level")
+
+    disabled_svn: set[HttpVersion] = set()
+
+    if http_version == 11:
+        disabled_svn.add(HttpVersion.h3)
+        disabled_svn.add(HttpVersion.h2)
+    elif http_version == 20:
+        disabled_svn.add(HttpVersion.h11)
+        disabled_svn.add(HttpVersion.h3)
+    elif http_version == 30:
+        disabled_svn.add(HttpVersion.h11)
+        disabled_svn.add(HttpVersion.h2)
+
+    conn_info_ref: ConnectionInfo | None = None
+
+    async def on_post_connection(conn_info: ConnectionInfo) -> None:
+        nonlocal conn_info_ref
+        conn_info_ref = conn_info
+
+    pm_kwargs: dict[str, typing.Any] = {
+        "resolver": "doh+google://",
+        "disabled_svn": disabled_svn,
+        "happy_eyeballs": happy_eyeballs,
+    }
+
+    async with AsyncPoolManager(**pm_kwargs) as pm:
+        await pm.urlopen(
+            "GET",
+            "https://encryptedsni.com/",
+            redirect=False,
+            on_post_connection=on_post_connection,
+        )
+
+    assert conn_info_ref is not None
+    assert conn_info_ref.tls_ech_accepted is True


### PR DESCRIPTION
2.19.910 (2026-04-22)
=====================

- Fixed support for custom CPython build against FIPS OpenSSL.
- Fixed HTTP/3 over QUIC conformance on pacing/ACKs.
- Fixed handling of forcibly closed UDP socket by remote peer. Now raises proper ``ProtocolError("Remote end closed connection without response")``. (https://github.com/jawah/niquests/issues/380)
- Fixed support for ECH when enabling happy eyeballs. ech_config_list was not propagated to concurrent connections. (https://github.com/jawah/niquests/issues/381)
