### PR TITLE
Release 2.19.911

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.19.911 (2026-04-24)
+=====================
+
+- Fixed exception raised when asyncio TLS-in-TLS (start_tls) silently fail under Python < 3.11 (https://github.com/jawah/niquests/issues/383)
+
 2.19.910 (2026-04-23)
 =====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.19.910"
+__version__ = "2.19.911"

--- a/src/urllib3/contrib/ssa/__init__.py
+++ b/src/urllib3/contrib/ssa/__init__.py
@@ -349,6 +349,13 @@ class AsyncSocket:
                 ssl_handshake_timeout=ssl_handshake_timeout,
             )
 
+            if new_transport is None:
+                # Python < 3.11 only
+                # https://github.com/jawah/niquests/issues/383
+                raise OSError(
+                    "asyncio TLS-in-TLS tunnel failed. start_tls did not create a new transport."
+                )
+
             self._writer._transport = new_transport  # type: ignore[attr-defined]
 
             transport = self._writer.transport

--- a/src/urllib3/contrib/ssa/__init__.py
+++ b/src/urllib3/contrib/ssa/__init__.py
@@ -350,10 +350,10 @@ class AsyncSocket:
             )
 
             if new_transport is None:
-                # Python < 3.11 only
+                # Most likely Python < 3.11 only.
                 # https://github.com/jawah/niquests/issues/383
                 raise OSError(
-                    "asyncio TLS-in-TLS tunnel failed. start_tls did not create a new transport."
+                    "Asyncio start TLS failed. The transport failed silently during TLS handshake."
                 )
 
             self._writer._transport = new_transport  # type: ignore[attr-defined]


### PR DESCRIPTION
2.19.911 (2026-04-24)
=====================

- Fixed exception raised when asyncio TLS-in-TLS (start_tls) silently fail under Python < 3.11 (https://github.com/jawah/niquests/issues/383)
