### PR TITLE
Release 2.20.902

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.20.902 (2026-05-11)
+=====================
+
+- Fixed webextensions (e.g. sse/websocket) not forwarded in retries.
+- Fixed retries in high pressure (i.e. many stream unresolved in multiplexed context) while remote peer abruptly interrupt the connection.
+
 2.20.901 (2026-05-10)
 =====================
 

--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -322,6 +322,39 @@ class TestingApp(RequestHandler):
     def chunked(self, request: httputil.HTTPServerRequest) -> Response:
         return Response(["123"] * 4)
 
+    def flaky_sse(self, request: httputil.HTTPServerRequest) -> Response:
+        """First request returns 500, subsequent requests return a valid SSE
+        event-stream. Used to validate that retries (with status_forcelist)
+        work correctly when the target URL uses the sse:// (or psse://)
+        scheme/extension.
+        """
+        test_name = request.headers.get("test-name", None)
+        if not test_name:
+            return Response("test-name header not set", status="400 Bad Request")
+
+        RETRY_TEST_NAMES[test_name] += 1
+
+        if RETRY_TEST_NAMES[test_name] < 2:
+            return Response(
+                "flaky failure",
+                status="500 Internal Server Error",
+            )
+
+        body = (
+            "event: message\n"
+            'data: {"timestamp": 1, "msg": "hello"}\n\n'
+            "event: message\n"
+            'data: {"timestamp": 2, "msg": "world"}\n\n'
+        )
+
+        return Response(
+            body,
+            headers=[
+                ("Content-Type", "text/event-stream"),
+                ("Cache-Control", "no-store"),
+            ],
+        )
+
     def chunked_gzip(self, request: httputil.HTTPServerRequest) -> Response:
         chunks = []
         compressor = zlib.compressobj(6, zlib.DEFLATED, 16 + zlib.MAX_WBITS)

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -1051,6 +1051,7 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
                 preload_content=preload_content,
                 decode_content=decode_content,
                 multiplexed=True,
+                extension=from_promise.get_parameter("extension"),
                 **response_kw,
             )
 
@@ -1116,6 +1117,7 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
                 preload_content=preload_content,
                 decode_content=decode_content,
                 multiplexed=True,
+                extension=from_promise.get_parameter("extension"),
                 **response_kw,
             )
 
@@ -1973,6 +1975,7 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
                 on_upload_body=on_upload_body,
                 on_post_connection=on_post_connection,
                 multiplexed=multiplexed,
+                extension=extension,
                 **response_kw,
             )
 
@@ -2034,6 +2037,7 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
                 preload_content=preload_content,
                 decode_content=decode_content,
                 multiplexed=False,
+                extension=extension,
                 **response_kw,
             )
 
@@ -2067,6 +2071,7 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
                 preload_content=preload_content,
                 decode_content=decode_content,
                 multiplexed=False,
+                extension=extension,
                 **response_kw,
             )
 

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -1872,10 +1872,6 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
             release_this_conn = False
             raise
 
-        except UnavailableTraffic:
-            clean_exit = False
-            release_this_conn = False
-
         except (
             TimeoutError,
             OSError,
@@ -1885,6 +1881,7 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
             CertificateError,
             ProxyError,
             RecoverableError,
+            UnavailableTraffic,
         ) as e:
             # Discard the connection for these exceptions. It will be
             # replaced during the next _get_conn() call.

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -1872,6 +1872,10 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
             release_this_conn = False
             raise
 
+        except UnavailableTraffic:
+            clean_exit = False
+            release_this_conn = False
+
         except (
             TimeoutError,
             OSError,

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.20.901"
+__version__ = "2.20.902"

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1847,6 +1847,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             release_this_conn = False
             raise
 
+        except UnavailableTraffic:
+            clean_exit = False
+            release_this_conn = False
+
         except (
             TimeoutError,
             OSError,

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1052,6 +1052,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 preload_content=preload_content,
                 decode_content=decode_content,
                 multiplexed=True,
+                extension=from_promise.get_parameter("extension"),
                 **response_kw,
             )
 
@@ -1116,6 +1117,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 preload_content=preload_content,
                 decode_content=decode_content,
                 multiplexed=True,
+                extension=from_promise.get_parameter("extension"),
                 **response_kw,
             )
 
@@ -1946,6 +1948,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 on_upload_body=on_upload_body,
                 on_post_connection=on_post_connection,
                 multiplexed=multiplexed,
+                extension=extension,
                 **response_kw,
             )
 
@@ -2010,6 +2013,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 preload_content=preload_content,
                 decode_content=decode_content,
                 multiplexed=False,
+                extension=extension,
                 **response_kw,
             )
 
@@ -2043,6 +2047,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 preload_content=preload_content,
                 decode_content=decode_content,
                 multiplexed=False,
+                extension=extension,
                 **response_kw,
             )
 

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1847,10 +1847,6 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             release_this_conn = False
             raise
 
-        except UnavailableTraffic:
-            clean_exit = False
-            release_this_conn = False
-
         except (
             TimeoutError,
             OSError,
@@ -1860,6 +1856,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             CertificateError,
             ProxyError,
             RecoverableError,
+            UnavailableTraffic,
         ) as e:
             # Discard the connection for these exceptions. It will be
             # replaced during the next _get_conn() call.

--- a/src/urllib3/util/_async/traffic_police.py
+++ b/src/urllib3/util/_async/traffic_police.py
@@ -1086,7 +1086,7 @@ class AsyncTrafficPolice(typing.Generic[T]):
         timeout: float | None = None,
         not_idle_only: bool = False,
     ) -> typing.AsyncGenerator[T, None]:
-        conn_or_pool = None
+        clean_exit = True
         try:
             if traffic_indicator:
                 if isinstance(traffic_indicator, type):
@@ -1134,14 +1134,14 @@ class AsyncTrafficPolice(typing.Generic[T]):
                     )
                 raise UnavailableTraffic("No connection are available")
             yield conn_or_pool
+        except Exception:
+            clean_exit = False
+            raise
         finally:
             # do not release back to the pool a broken connection
             # we need kill_cursor() to take over soon.
-            if conn_or_pool is not None and not getattr(
-                conn_or_pool, "is_closed", False
-            ):
-                if self.release():
-                    await asyncio.sleep(0)
+            if clean_exit and self.release():
+                await asyncio.sleep(0)
 
     def release(self) -> bool:
         active_cursor = self._cursor

--- a/src/urllib3/util/_async/traffic_police.py
+++ b/src/urllib3/util/_async/traffic_police.py
@@ -256,10 +256,7 @@ class AsyncSignals(typing.Generic[T]):
                 awoken_signals.append(signal)
 
         for awoken_signal in awoken_signals:
-            if awoken_signal in self._priority_signals:
-                self._priority_signals.remove(awoken_signal)
-            else:
-                self._furthest_signals.remove(awoken_signal)
+            self._furthest_signals.remove(awoken_signal)
 
         del self._cursors[current_task]
 
@@ -568,17 +565,17 @@ class AsyncTrafficPolice(typing.Generic[T]):
 
         del self._registry[active_cursor.obj_id]
 
+        if not self.concurrency:
+            if self._signals.kill():
+                await asyncio.sleep(0)
+        else:
+            del self._container[active_cursor.obj_id]
+            self._unset_cursor()
+
         try:
             await active_cursor.conn_or_pool.close()
         except Exception:
             pass
-
-        if not self.concurrency:
-            self._signals.kill()
-            await asyncio.sleep(0)
-        else:
-            del self._container[active_cursor.obj_id]
-            self._unset_cursor()
 
     async def _sacrifice_first_idle(self, block: bool = True) -> None:
         """When trying to fill the bag, arriving at the maxsize, we may want to remove an item.
@@ -1067,6 +1064,12 @@ class AsyncTrafficPolice(typing.Generic[T]):
             except asyncio.CancelledError:
                 self._signals.unregister(signal)
                 raise
+
+            if (
+                signal.conn_or_pool is None
+                or signal.target_obj_id not in self._registry
+            ):
+                raise UnavailableTraffic("Connection was killed in flight")
         else:
             self._cursors[_current_task_or_die()] = ActiveCursor(obj_id, conn_or_pool)
 
@@ -1083,6 +1086,7 @@ class AsyncTrafficPolice(typing.Generic[T]):
         timeout: float | None = None,
         not_idle_only: bool = False,
     ) -> typing.AsyncGenerator[T, None]:
+        conn_or_pool = None
         try:
             if traffic_indicator:
                 if isinstance(traffic_indicator, type):
@@ -1131,8 +1135,13 @@ class AsyncTrafficPolice(typing.Generic[T]):
                 raise UnavailableTraffic("No connection are available")
             yield conn_or_pool
         finally:
-            if self.release():
-                await asyncio.sleep(0)
+            # do not release back to the pool a broken connection
+            # we need kill_cursor() to take over soon.
+            if conn_or_pool is not None and not getattr(
+                conn_or_pool, "is_closed", False
+            ):
+                if self.release():
+                    await asyncio.sleep(0)
 
     def release(self) -> bool:
         active_cursor = self._cursor

--- a/src/urllib3/util/traffic_police.py
+++ b/src/urllib3/util/traffic_police.py
@@ -864,7 +864,7 @@ class TrafficPolice(typing.Generic[T]):
                 "Timed out while waiting for conn_or_pool to become available"
             )
 
-        if signal.conn_or_pool is None:
+        if signal.conn_or_pool is None or obj_id not in self._registry:
             raise UnavailableTraffic(
                 "The signal was awaken without conn_or_pool assignment. "
                 "This means that a connection was broken, presumably in another thread."
@@ -880,6 +880,7 @@ class TrafficPolice(typing.Generic[T]):
         timeout: float | None = None,
         not_idle_only: bool = False,
     ) -> typing.Generator[T, None, None]:
+        conn_or_pool = None
         try:
             cursor_key = get_ident()
 
@@ -936,7 +937,12 @@ class TrafficPolice(typing.Generic[T]):
                 raise UnavailableTraffic("No connection are available")
             yield conn_or_pool
         finally:
-            self.release()
+            # do not release back to the pool a broken connection
+            # we need kill_cursor() to take over soon.
+            if conn_or_pool is not None and not getattr(
+                conn_or_pool, "is_closed", False
+            ):
+                self.release()
 
     def release(self) -> None:
         with self._lock:

--- a/src/urllib3/util/traffic_police.py
+++ b/src/urllib3/util/traffic_police.py
@@ -880,7 +880,7 @@ class TrafficPolice(typing.Generic[T]):
         timeout: float | None = None,
         not_idle_only: bool = False,
     ) -> typing.Generator[T, None, None]:
-        conn_or_pool = None
+        clean_exit = True
         try:
             cursor_key = get_ident()
 
@@ -936,12 +936,13 @@ class TrafficPolice(typing.Generic[T]):
                     )
                 raise UnavailableTraffic("No connection are available")
             yield conn_or_pool
+        except Exception:
+            clean_exit = False
+            raise
         finally:
             # do not release back to the pool a broken connection
             # we need kill_cursor() to take over soon.
-            if conn_or_pool is not None and not getattr(
-                conn_or_pool, "is_closed", False
-            ):
+            if clean_exit:
                 self.release()
 
     def release(self) -> None:

--- a/test/with_dummyserver/asynchronous/test_poolmanager.py
+++ b/test/with_dummyserver/asynchronous/test_poolmanager.py
@@ -808,6 +808,57 @@ class TestAsyncPoolManager(HTTPDummyServerTestCase):
             )
 
 
+@pytest.mark.asyncio
+class TestAsyncPoolManagerSSERetry(HTTPDummyServerTestCase):
+    @classmethod
+    def setup_class(cls) -> None:
+        super().setup_class()
+        cls.base_url = f"http://{cls.host}:{cls.port}"
+
+    async def test_sse_retry_on_status_forcelist(self) -> None:
+        """Async counterpart of TestPoolManagerSSERetry.
+
+        A request to an sse:// (psse:// over HTTP) URL must respect retries
+        configured with status_forcelist. The flaky_sse endpoint returns 500
+        on the first call and a valid event-stream on the second.
+        """
+        from urllib3.contrib.webextensions._async import (
+            AsyncServerSideEventExtensionFromHTTP,
+        )
+
+        retry = Retry(total=2, status_forcelist=[500])
+
+        sse_url = self.base_url.replace("http://", "psse://") + "/flaky_sse"
+
+        async with AsyncPoolManager(retries=retry) as http:
+            resp = await http.urlopen(
+                "GET",
+                sse_url,
+                headers={"test-name": "async_test_sse_retry_on_status_forcelist"},
+            )
+
+            # the second attempt should have succeeded
+            assert resp.status == 200
+
+            # the SSE extension must be auto-attached
+            assert resp.extension is not None
+            assert isinstance(resp.extension, AsyncServerSideEventExtensionFromHTTP)
+
+            events = []
+            while resp.extension.closed is False:
+                ev = await resp.extension.next_payload()
+                if ev is not None:
+                    events.append(ev)
+
+            assert len(events) == 2
+            assert resp.extension.closed is True
+
+            for event in events:
+                payload = event.json()  # type: ignore[attr-defined]
+                assert "timestamp" in payload
+                assert "msg" in payload
+
+
 @pytest.mark.skipif(not HAS_IPV6, reason="IPv6 is not supported on this system")
 @pytest.mark.asyncio
 class TestIPv6AsyncPoolManager(IPv6HTTPDummyServerTestCase):

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -792,6 +792,54 @@ class TestPoolManager(HTTPDummyServerTestCase):
         )
 
 
+class TestPoolManagerSSERetry(HTTPDummyServerTestCase):
+    @classmethod
+    def setup_class(cls) -> None:
+        super().setup_class()
+        cls.base_url = f"http://{cls.host}:{cls.port}"
+
+    def test_sse_retry_on_status_forcelist(self) -> None:
+        """A request to an sse:// (psse:// over HTTP) URL must respect retries
+        configured with status_forcelist. The flaky_sse endpoint returns 500
+        on the first call and a valid event-stream on the second. With
+        retries=2 and status_forcelist=[500] we expect to obtain a 200 and a
+        usable ServerSideEventExtensionFromHTTP attached to the response.
+        """
+        from urllib3.contrib.webextensions import ServerSideEventExtensionFromHTTP
+
+        retry = Retry(total=2, status_forcelist=[500])
+
+        sse_url = self.base_url.replace("http://", "psse://") + "/flaky_sse"
+
+        with PoolManager(retries=retry) as http:
+            resp = http.urlopen(
+                "GET",
+                sse_url,
+                headers={"test-name": "test_sse_retry_on_status_forcelist"},
+            )
+
+            # the second attempt should have succeeded
+            assert resp.status == 200
+
+            # the SSE extension must be auto-attached
+            assert resp.extension is not None
+            assert isinstance(resp.extension, ServerSideEventExtensionFromHTTP)
+
+            events = []
+            while resp.extension.closed is False:
+                ev = resp.extension.next_payload()
+                if ev is not None:
+                    events.append(ev)
+
+            assert len(events) == 2
+            assert resp.extension.closed is True
+
+            for event in events:
+                payload = event.json()  # type: ignore[attr-defined]
+                assert "timestamp" in payload
+                assert "msg" in payload
+
+
 @pytest.mark.skipif(not HAS_IPV6, reason="IPv6 is not supported on this system")
 class TestIPv6PoolManager(IPv6HTTPDummyServerTestCase):
     @classmethod


### PR DESCRIPTION
2.20.902 (2026-05-11)
=====================

- Fixed webextensions (e.g. sse/websocket) not forwarded in retries.
- Fixed retries in high pressure (i.e. many stream unresolved in multiplexed context) while remote peer abruptly interrupt the connection.
