### PR TITLE
Release 2.20.903

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@
   kept looping forever once any tail bytes remained. The ``read(amt=-1)`` fast path now drains the decoder before
   issuing another raw read, with the decoded chunk bounded by a reasonable growth factor of the most recent raw read so
   the original bomb safeguard is preserved. (#364)
+- Fixed accidental override of user defined ``SO_KEEPALIVE`` when remote only support HTTP/1.
 
 2.20.902 (2026-05-11)
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+2.20.903 (2026-05-12)
+=====================
+
+- Fixed an infinite loop in ``HTTPResponse.stream(amt=-1)`` (and ``AsyncHTTPResponse.stream(amt=-1)``) when iterating a
+  compressed (gzip / deflate / brotli / zstd) response body. Regression introduced by the decompression-bomb safeguards
+  backport: the decoder's internal unconsumed tail was never drained on the negative amt path, so the stream loop
+  kept looping forever once any tail bytes remained. The ``read(amt=-1)`` fast path now drains the decoder before
+  issuing another raw read, with the decoded chunk bounded by a reasonable growth factor of the most recent raw read so
+  the original bomb safeguard is preserved. (#364)
+
 2.20.902 (2026-05-11)
 =====================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,7 @@ filterwarnings = [
     '''ignore:function StreamWriter.__del__:pytest.PytestUnraisableExceptionWarning''',
     '''ignore:An exception occurred during teardown of an asyncio\.Runner:RuntimeWarning''',
     '''ignore:sock:pytest.PytestUnraisableExceptionWarning''',
+    '''ignore:.*<socket\.socket.*:pytest.PytestUnraisableExceptionWarning''',
     '''ignore:The `hash` argument is deprecated in favor of `unsafe_hash`:DeprecationWarning''',
     '''ignore:ssl\.TLSVersion\.TLSv1 is deprecated:DeprecationWarning''',
     '''ignore:ssl\.TLSVersion\.TLSv1_1 is deprecated:DeprecationWarning''',

--- a/src/urllib3/_async/response.py
+++ b/src/urllib3/_async/response.py
@@ -10,7 +10,12 @@ from socket import timeout as SocketTimeout
 
 from .._collections import HTTPHeaderDict
 from .._typing import _TYPE_BODY
-from .._constant import C_INT_MAX, CHUNK_AMT_MAX
+from .._constant import (
+    C_INT_MAX,
+    CHUNK_AMT_MAX,
+    DECODE_GROWTH_FACTOR,
+    DECODE_MIN_RAW_REFERENCE,
+)
 from ..backend._async import AsyncLowLevelResponse
 from ..exceptions import (
     BaseSSLError,
@@ -123,6 +128,11 @@ class AsyncHTTPResponse(HTTPResponse):
 
         # Used to return the correct amount of bytes for partial read()s
         self._decoded_buffer = BytesQueueBuffer()
+
+        # Tracks the size of the last successful raw read so that
+        # ``read(amt=-1)`` can bound how much it drains from the decoder's
+        # internal buffer per call (issue #364, GHSA-mf9v-mfxr-j63j).
+        self._last_raw_read_size: int = 0
 
         self._police_officer: AsyncTrafficPolice[AsyncHTTPConnection] | None = (
             police_officer  # type: ignore[assignment]
@@ -375,6 +385,9 @@ class AsyncHTTPResponse(HTTPResponse):
             if self.length_remaining is not None:
                 self.length_remaining -= data_len
 
+        if isinstance(data, (bytes, bytearray)) and data:
+            self._last_raw_read_size = len(data)
+
         return data
 
     async def read1(  # type: ignore[override]
@@ -421,8 +434,37 @@ class AsyncHTTPResponse(HTTPResponse):
             if amt is not None:
                 cache_content = False
 
-                if amt < 0 and len(self._decoded_buffer):
-                    return self._decoded_buffer.get(len(self._decoded_buffer))
+                if amt < 0:
+                    # Drain any pending data already buffered inside the
+                    # decoder before triggering another raw read. Without
+                    # this, ``stream(amt=-1)`` would loop forever on
+                    # ``_decoder.has_unconsumed_tail`` whenever the decoder
+                    # retains bytes (e.g., gzip body whose decoded output
+                    # exceeded the previous ``max_length`` cap). The
+                    # decoded chunk is bounded by a reasonable growth
+                    # factor of the most recent raw read so a single recv
+                    # carrying many HTTP/2/3 frames cannot expand into
+                    # arbitrarily large memory (issue #364, see also
+                    # GHSA-mf9v-mfxr-j63j).
+                    if self._decoder and self._decoder.has_unconsumed_tail:
+                        cap = (
+                            max(
+                                self._last_raw_read_size,
+                                DECODE_MIN_RAW_REFERENCE,
+                            )
+                            * DECODE_GROWTH_FACTOR
+                        )
+                        decoded_data = self._decode(
+                            b"",
+                            decode_content,
+                            flush_decoder=False,
+                            max_length=cap,
+                        )
+                        if decoded_data:
+                            self._decoded_buffer.put(decoded_data)
+
+                    if len(self._decoded_buffer):
+                        return self._decoded_buffer.get(len(self._decoded_buffer))
 
                 if amt > 0:
                     # Drain any pending data already buffered inside the

--- a/src/urllib3/_constant.py
+++ b/src/urllib3/_constant.py
@@ -259,6 +259,22 @@ DEFAULT_TCP_KEEPALIVE_ATTEMPT_COUNT: int = 2
 C_INT_MAX = 2**31 - 1
 CHUNK_AMT_MAX = 2**28
 
+# Bound the amount of decompressed bytes a single ``read(amt=-1)`` (or one
+# iteration of ``stream(amt=-1)``) is allowed to drain from the decoder's
+# internal buffer at once. The cap is expressed as a multiple of the most
+# recent raw read size so that small frames still produce usable chunks while
+# pathological "decompression-bomb" payloads cannot expand a single recv into
+# arbitrarily large memory allocations. See GHSA-mf9v-mfxr-j63j and
+# https://github.com/jawah/urllib3.future/issues/364
+DECODE_GROWTH_FACTOR: int = 128
+# Floor used as the reference raw size before any raw read has occurred (or
+# when the last raw read returned an unusually small amount of body bytes).
+# This is a safety net only: in practice ``_last_raw_read_size`` is already
+# populated by the time the drain path runs (the decoder only has an
+# unconsumed tail because a previous raw read fed it). 1 KiB combined with
+# ``DECODE_GROWTH_FACTOR`` still yields a sensible minimum decoded chunk.
+DECODE_MIN_RAW_REFERENCE: int = 1024
+
 HTTP1_ONLY_HEADERS = frozenset(
     {
         b"transfer-encoding",

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.20.902"
+__version__ = "2.20.903"

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -40,7 +40,12 @@ except (AttributeError, ImportError, ValueError):  # Defensive:
 
 from ._collections import HTTPHeaderDict
 from ._typing import _TYPE_BODY
-from ._constant import C_INT_MAX, CHUNK_AMT_MAX
+from ._constant import (
+    C_INT_MAX,
+    CHUNK_AMT_MAX,
+    DECODE_GROWTH_FACTOR,
+    DECODE_MIN_RAW_REFERENCE,
+)
 from .backend import LowLevelResponse, ResponsePromise
 from .exceptions import (
     BaseSSLError,
@@ -535,6 +540,11 @@ class HTTPResponse(io.IOBase):
         # Used to return the correct amount of bytes for partial read()s
         self._decoded_buffer = BytesQueueBuffer()
 
+        # Tracks the size of the last successful raw read so that
+        # ``read(amt=-1)`` can bound how much it drains from the decoder's
+        # internal buffer per call (issue #364, GHSA-mf9v-mfxr-j63j).
+        self._last_raw_read_size: int = 0
+
         self._police_officer: TrafficPolice[HTTPConnection] | None = police_officer
 
         if self._police_officer is not None:
@@ -975,6 +985,9 @@ class HTTPResponse(io.IOBase):
             if self.length_remaining is not None:
                 self.length_remaining -= data_len
 
+        if isinstance(data, (bytes, bytearray)) and data:
+            self._last_raw_read_size = len(data)
+
         return data
 
     def read1(
@@ -1041,8 +1054,37 @@ class HTTPResponse(io.IOBase):
             if amt is not None:
                 cache_content = False
 
-                if amt < 0 and len(self._decoded_buffer):
-                    return self._decoded_buffer.get(len(self._decoded_buffer))
+                if amt < 0:
+                    # Drain any pending data already buffered inside the
+                    # decoder before triggering another raw read. Without
+                    # this, ``stream(amt=-1)`` would loop forever on
+                    # ``_decoder.has_unconsumed_tail`` whenever the decoder
+                    # retains bytes (e.g., gzip body whose decoded output
+                    # exceeded the previous ``max_length`` cap). The
+                    # decoded chunk is bounded by a reasonable growth
+                    # factor of the most recent raw read so a single recv
+                    # carrying many HTTP/2/3 frames cannot expand into
+                    # arbitrarily large memory (issue #364, see also
+                    # GHSA-mf9v-mfxr-j63j).
+                    if self._decoder and self._decoder.has_unconsumed_tail:
+                        cap = (
+                            max(
+                                self._last_raw_read_size,
+                                DECODE_MIN_RAW_REFERENCE,
+                            )
+                            * DECODE_GROWTH_FACTOR
+                        )
+                        decoded_data = self._decode(
+                            b"",
+                            decode_content,
+                            flush_decoder=False,
+                            max_length=cap,
+                        )
+                        if decoded_data:
+                            self._decoded_buffer.put(decoded_data)
+
+                    if len(self._decoded_buffer):
+                        return self._decoded_buffer.get(len(self._decoded_buffer))
 
                 if amt > 0:
                     # Drain any pending data already buffered inside the

--- a/src/urllib3/util/socket_state.py
+++ b/src/urllib3/util/socket_state.py
@@ -275,7 +275,18 @@ def enable_keepalive(
     Per-platform timer tuning is best-effort and silently skipped on failure.
     Do not use outside an HTTP/1.1 connection. Ping frame is the recommended
     alternative.
+
+    If the end user already enabled tcp keepalive on the socket (e.g. via
+    ``socket_options``), this function is a no-op: their configuration prime.
     """
+
+    try:
+        already_enabled = bool(sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE))
+    except OSError:  # Defensive: edge OSes
+        return
+
+    if already_enabled:
+        return
 
     try:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)

--- a/test/test_async_response.py
+++ b/test/test_async_response.py
@@ -603,6 +603,58 @@ class TestAsyncResponse:
         with pytest.raises(StopAsyncIteration):
             await stream.__anext__()
 
+    async def test_gzipped_streaming_amt_negative_one_does_not_hang(self) -> None:
+        # Async mirror of the regression test for issue #364.
+        uncompressed = b"abcdefghij" * 4096
+        compressor = zlib.compressobj(6, zlib.DEFLATED, 16 + zlib.MAX_WBITS)
+        data = compressor.compress(uncompressed) + compressor.flush()
+
+        fp = _make_async_fp(data)
+        resp = AsyncHTTPResponse(
+            fp,
+            headers={"content-encoding": "gzip"},
+            preload_content=False,
+        )
+
+        chunks: list[bytes] = []
+        async for chunk in resp.stream(amt=-1):
+            chunks.append(chunk)
+            assert len(chunks) < 64, "stream(amt=-1) iterates too many times"
+
+        assert b"".join(chunks) == uncompressed
+
+    async def test_gzipped_stream_amt_negative_one_bounds_decoded_chunk(
+        self,
+    ) -> None:
+        # Bomb-safety regression in async path.
+        from urllib3._constant import (
+            DECODE_GROWTH_FACTOR,
+            DECODE_MIN_RAW_REFERENCE,
+        )
+
+        uncompressed = b"\x00" * (DECODE_MIN_RAW_REFERENCE * DECODE_GROWTH_FACTOR * 4)
+        compressor = zlib.compressobj(9, zlib.DEFLATED, 16 + zlib.MAX_WBITS)
+        data = compressor.compress(uncompressed) + compressor.flush()
+        assert len(uncompressed) > len(data) * DECODE_GROWTH_FACTOR
+
+        fp = _make_async_fp(data)
+        resp = AsyncHTTPResponse(
+            fp,
+            headers={"content-encoding": "gzip"},
+            preload_content=False,
+        )
+
+        stream = resp.stream(amt=-1)
+        first_chunk = await stream.__anext__()
+        assert (
+            len(first_chunk)
+            <= max(len(data), DECODE_MIN_RAW_REFERENCE) * DECODE_GROWTH_FACTOR
+        )
+        rest = b""
+        async for chunk in stream:
+            rest += chunk
+        assert first_chunk + rest == uncompressed
+
     async def test_gzipped_streaming_tell(self) -> None:
         compress = zlib.compressobj(6, zlib.DEFLATED, 16 + zlib.MAX_WBITS)
         uncompressed_data = b"foo"

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -685,6 +685,61 @@ class TestResponse:
         with pytest.raises(StopIteration):
             next(stream)
 
+    def test_gzipped_streaming_amt_negative_one_does_not_hang(self) -> None:
+        # Regression test for https://github.com/jawah/urllib3.future/issues/364
+        # ``stream(amt=-1)`` used to loop forever when the gzip decoder still
+        # had unconsumed tail bytes (which always happens when the bomb-safe
+        # ``max_length`` cap was reached on the first decode call). The
+        # iterator must terminate and yield the full payload.
+        uncompressed = b"abcdefghij" * 4096  # 40 KiB, very compressible
+        compressor = zlib.compressobj(6, zlib.DEFLATED, 16 + zlib.MAX_WBITS)
+        data = compressor.compress(uncompressed) + compressor.flush()
+
+        fp = BytesIO(data)
+        resp = HTTPResponse(
+            fp, headers={"content-encoding": "gzip"}, preload_content=False
+        )
+
+        chunks = list(resp.stream(amt=-1))
+        # Joined payload must equal original uncompressed bytes.
+        assert b"".join(chunks) == uncompressed
+        # Must terminate in a bounded number of iterations.
+        assert 0 < len(chunks) < 64
+
+    def test_gzipped_stream_amt_negative_one_bounds_decoded_chunk(self) -> None:
+        # Bomb-safety regression: even when raw input is tiny, a single
+        # ``read(amt=-1)`` must not return an unbounded amount of decoded
+        # bytes. We craft a payload that compresses extremely well and
+        # verify the first decoded chunk size is bounded by the configured
+        # growth factor relative to the most recent raw read size.
+        from urllib3._constant import (
+            DECODE_GROWTH_FACTOR,
+            DECODE_MIN_RAW_REFERENCE,
+        )
+
+        uncompressed = b"\x00" * (DECODE_MIN_RAW_REFERENCE * DECODE_GROWTH_FACTOR * 4)
+        compressor = zlib.compressobj(9, zlib.DEFLATED, 16 + zlib.MAX_WBITS)
+        data = compressor.compress(uncompressed) + compressor.flush()
+        # Sanity: ratio is high enough for the test to be meaningful.
+        assert len(uncompressed) > len(data) * DECODE_GROWTH_FACTOR
+
+        fp = BytesIO(data)
+        resp = HTTPResponse(
+            fp, headers={"content-encoding": "gzip"}, preload_content=False
+        )
+
+        stream = resp.stream(amt=-1)
+        first_chunk = next(stream)
+        # First chunk is bounded by raw_size * growth_factor (raw_size here
+        # is at least DECODE_MIN_RAW_REFERENCE due to the floor applied).
+        assert (
+            len(first_chunk)
+            <= max(len(data), DECODE_MIN_RAW_REFERENCE) * DECODE_GROWTH_FACTOR
+        )
+        # And the iterator still terminates with the full payload.
+        rest = b"".join(stream)
+        assert first_chunk + rest == uncompressed
+
     def test_gzipped_streaming_tell(self) -> None:
         compress = zlib.compressobj(6, zlib.DEFLATED, 16 + zlib.MAX_WBITS)
         uncompressed_data = b"foo"

--- a/test/with_dummyserver/asynchronous/test_connectionpool.py
+++ b/test/with_dummyserver/asynchronous/test_connectionpool.py
@@ -926,6 +926,23 @@ class TestConnectionPool(HTTPDummyServerTestCase):
 
             assert b"123" * 4 == await response.read()
 
+    async def test_chunked_gzip_stream_amt_negative_one(self) -> None:
+        # Async mirror of the regression test for issue #364.
+        async with AsyncHTTPConnectionPool(self.host, self.port) as pool:
+            response = await pool.request(
+                "GET",
+                "/chunked_gzip",
+                preload_content=False,
+                decode_content=True,
+            )
+
+            chunks: list[bytes] = []
+            async for chunk in response.stream(amt=-1):
+                chunks.append(chunk)
+                assert len(chunks) < 64
+
+            assert b"".join(chunks) == b"123" * 4
+
     async def test_cleanup_on_connection_error(self) -> None:
         """
         Test that connections are recycled to the pool on

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -821,6 +821,24 @@ class TestConnectionPool(HTTPDummyServerTestCase):
 
             assert b"123" * 4 == response.read()
 
+    def test_chunked_gzip_stream_amt_negative_one(self) -> None:
+        # Regression test for https://github.com/jawah/urllib3.future/issues/364
+        # ``stream(amt=-1)`` over a chunked gzip body must terminate.
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            response = pool.request(
+                "GET",
+                "/chunked_gzip",
+                preload_content=False,
+                decode_content=True,
+            )
+
+            chunks: list[bytes] = []
+            for chunk in response.stream(amt=-1):
+                chunks.append(chunk)
+                assert len(chunks) < 64
+
+            assert b"".join(chunks) == b"123" * 4
+
     def test_cleanup_on_connection_error(self) -> None:
         """
         Test that connections are recycled to the pool on

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import socket
+import sys
 import time
 import typing
 import warnings
@@ -357,6 +358,50 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             finally:
                 conn.close()
                 s.close()
+
+    @pytest.mark.skipif(
+        not sys.platform.startswith("linux"),
+        reason="TCP_KEEPIDLE introspection is Linux-specific",
+    )
+    def test_user_keepalive_settings_are_preserved(self) -> None:
+        """Regression: ``enable_keepalive`` must not override SO_KEEPALIVE
+        timers when the end user already enabled keepalive via
+        ``socket_options`` (e.g. with custom TCP_KEEPIDLE)."""
+        sentinel_idle = 4242  # distinct from DEFAULT_KEEPALIVE_IDLE_WINDOW (60)
+        # Sanity check: the value really differs from our default so that the
+        # assertion below would catch an accidental override.
+        from urllib3._constant import DEFAULT_KEEPALIVE_IDLE_WINDOW
+
+        assert sentinel_idle != int(DEFAULT_KEEPALIVE_IDLE_WINDOW)
+
+        user_socket_options = [
+            (socket.IPPROTO_TCP, socket.TCP_NODELAY, 1),
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+            (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, sentinel_idle),
+        ]
+
+        with HTTPConnectionPool(
+            self.host, self.port, socket_options=user_socket_options
+        ) as pool:
+            conn = pool._get_conn()
+            try:
+                # Issue a real request so that the backend's
+                # ``enable_keepalive`` path actually runs.
+                pool._make_request(conn, "GET", "/")
+                assert conn.sock is not None
+                using_keepalive = (
+                    conn.sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE) > 0
+                )
+                tcp_keepidle = conn.sock.getsockopt(
+                    socket.IPPROTO_TCP, socket.TCP_KEEPIDLE
+                )
+                assert using_keepalive
+                assert tcp_keepidle == sentinel_idle, (
+                    f"enable_keepalive overrode user TCP_KEEPIDLE "
+                    f"(expected {sentinel_idle}, got {tcp_keepidle})"
+                )
+            finally:
+                conn.close()
 
     def test_connection_error_retries(self) -> None:
         """ECONNREFUSED error should raise a connection error, with retries"""

--- a/test/with_traefik/asynchronous/test_stream.py
+++ b/test/with_traefik/asynchronous/test_stream.py
@@ -71,6 +71,34 @@ class TestStreamResponse(TraefikTestCase):
                     f"HTTP/{resp.version / 10} stream failure"
                 )
 
+    async def test_h2n3_stream_gzip_amt_negative_one(self) -> None:
+        # Async mirror of the regression test for issue #364.
+        async with AsyncHTTPSConnectionPool(
+            self.host,
+            self.https_port,
+            ca_certs=self.ca_authority,
+            resolver=self.test_async_resolver.new(),
+        ) as p:
+            resp = await p.request("GET", "/gzip", preload_content=False)
+            assert resp.status == 200
+            assert resp.headers.get("Content-Encoding", "").lower() == "gzip"
+
+            chunks: list[bytes] = []
+            async for chunk in resp.stream(amt=-1):
+                chunks.append(chunk)
+                assert len(chunks) < 256, (
+                    f"stream(amt=-1) iterates too many times (HTTP/{resp.version / 10})"
+                )
+
+            try:
+                payload = loads(b"".join(chunks))
+            except JSONDecodeError as e:
+                pytest.fail(
+                    f"HTTP/{resp.version / 10} gzip stream(amt=-1) "
+                    f"did not yield decodable JSON: {e}"
+                )
+            assert payload.get("gzipped") is True
+
     async def test_read_zero(self) -> None:
         async with AsyncHTTPSConnectionPool(
             self.host,

--- a/test/with_traefik/test_stream.py
+++ b/test/with_traefik/test_stream.py
@@ -70,6 +70,39 @@ class TestStreamResponse(TraefikTestCase):
                     f"HTTP/{resp.version / 10} stream failure"
                 )
 
+    def test_h2n3_stream_gzip_amt_negative_one(self) -> None:
+        # Regression test for https://github.com/jawah/urllib3.future/issues/364
+        # ``stream(amt=-1)`` over an HTTP/2 (or HTTP/3) gzip-encoded response
+        # used to loop forever when the decoder still had unconsumed tail
+        # bytes after the bomb-safe ``max_length`` cap was reached.
+        with HTTPSConnectionPool(
+            self.host,
+            self.https_port,
+            ca_certs=self.ca_authority,
+            resolver=[self.test_resolver_raw],
+        ) as p:
+            resp = p.request("GET", "/gzip", preload_content=False)
+            assert resp.status == 200
+            assert resp.headers.get("Content-Encoding", "").lower() == "gzip"
+
+            chunks: list[bytes] = []
+            for chunk in resp.stream(amt=-1):
+                chunks.append(chunk)
+                # Defensive: at the time of writing /gzip returns < 1 KiB
+                # decoded; allow ample slack but never an infinite loop.
+                assert len(chunks) < 256, (
+                    f"stream(amt=-1) iterates too many times (HTTP/{resp.version / 10})"
+                )
+
+            try:
+                payload = loads(b"".join(chunks))
+            except JSONDecodeError as e:
+                pytest.fail(
+                    f"HTTP/{resp.version / 10} gzip stream(amt=-1) "
+                    f"did not yield decodable JSON: {e}"
+                )
+            assert payload.get("gzipped") is True
+
     def test_read_zero(self) -> None:
         with HTTPSConnectionPool(
             self.host,


### PR DESCRIPTION
2.20.903 (2026-05-12)
=====================

- Fixed an infinite loop in ``HTTPResponse.stream(amt=-1)`` (and ``AsyncHTTPResponse.stream(amt=-1)``) when iterating a
  compressed (gzip / deflate / brotli / zstd) response body. Regression introduced by the decompression-bomb safeguards
  backport: the decoder's internal unconsumed tail was never drained on the negative amt path, so the stream loop
  kept looping forever once any tail bytes remained. The ``read(amt=-1)`` fast path now drains the decoder before
  issuing another raw read, with the decoded chunk bounded by a reasonable growth factor of the most recent raw read so
  the original bomb safeguard is preserved. (#364)
- Fixed accidental override of user defined ``SO_KEEPALIVE`` when remote only support HTTP/1.
