### PR TITLE
2.20.904

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.20.904 (2026-05-13)
+=====================
+
+- Fixed ``PoolManager.get_response`` (and ``AsyncPoolManager.get_response``) crashing with ``AssertionError`` when a
+  (manual) multiplexed request reached the retry-on-status branch (e.g. ``Retry(status_forcelist=[503])``). The branch
+  erroneously looked up a redirect ``Location`` header and ``assert isinstance(redirect_location, str)`` failed.
+- Fixed withholding of non broken connection in read phase after one non fatal exception. (#366)
+
 2.20.903 (2026-05-12)
 =====================
 

--- a/src/urllib3/_async/poolmanager.py
+++ b/src/urllib3/_async/poolmanager.py
@@ -624,9 +624,6 @@ class AsyncPoolManager(AsyncRequestMethods):
             body_pos = typing.cast(
                 _TYPE_BODY_POSITION, from_promise.get_parameter("body_pos")
             )
-            redirect_location = response.get_redirect_location()
-            assert isinstance(redirect_location, str)
-
             try:
                 retries = retries.increment(
                     method, url, response=response, _pool=response._pool
@@ -642,7 +639,7 @@ class AsyncPoolManager(AsyncRequestMethods):
             log.debug("Retry: %s", url)
             new_promise = await self.urlopen(
                 method,
-                urljoin(url, redirect_location),
+                url,
                 True,
                 body=body,
                 headers=headers,

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.20.903"
+__version__ = "2.20.904"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -293,13 +293,16 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                     self._max_tolerable_delay_for_upgrade += (
                         self.conn_info.tls_handshake_latency.total_seconds()
                     )
-                self._max_tolerable_delay_for_upgrade *= 10.0
-                # we can, in rare case get self._max_tolerable_delay_for_upgrade <= 0.001
-                # we want to avoid this at all cost.
-                if self._max_tolerable_delay_for_upgrade <= 0.01:
-                    self._max_tolerable_delay_for_upgrade = 3.0
-            else:  # by default (safe/conservative fallback) to 3000ms
-                self._max_tolerable_delay_for_upgrade = 3.0
+                # initial rtt for HTTP/3 is set to 333ms
+                # we need to let the QUIC state machine
+                # to start loss detector at least once or
+                # two before giving up.
+                self._max_tolerable_delay_for_upgrade = max(
+                    self._max_tolerable_delay_for_upgrade,
+                    1.0,
+                )
+            else:  # by default (safe/conservative fallback) to 1000ms (3x 333ms rtt)
+                self._max_tolerable_delay_for_upgrade = 1.0
 
             if upgradable_svn == HttpVersion.h3:
                 if self._preemptive_quic_cache is not None:

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -318,13 +318,16 @@ class HfaceBackend(BaseBackend):
                     self._max_tolerable_delay_for_upgrade += (
                         self.conn_info.tls_handshake_latency.total_seconds()
                     )
-                self._max_tolerable_delay_for_upgrade *= 10.0
-                # we can, in rare case get self._max_tolerable_delay_for_upgrade == 0.0
-                # we want to avoid this at all cost.
-                if self._max_tolerable_delay_for_upgrade <= 0.01:
-                    self._max_tolerable_delay_for_upgrade = 3.0
-            else:  # by default (safe/conservative fallback) to 3000ms
-                self._max_tolerable_delay_for_upgrade = 3.0
+                # initial rtt for HTTP/3 is set to 333ms
+                # we need to let the QUIC state machine
+                # to start loss detector at least once or
+                # two before giving up.
+                self._max_tolerable_delay_for_upgrade = max(
+                    self._max_tolerable_delay_for_upgrade,
+                    1.0,
+                )
+            else:  # by default (safe/conservative fallback) to 1000ms (3x 333ms rrt initial)
+                self._max_tolerable_delay_for_upgrade = 1.0
 
             if upgradable_svn == HttpVersion.h3:
                 if self._preemptive_quic_cache is not None:

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -766,9 +766,6 @@ class PoolManager(RequestMethods):
                 _TYPE_BODY_POSITION, from_promise.get_parameter("body_pos")
             )
 
-            redirect_location = response.get_redirect_location()
-            assert isinstance(redirect_location, str)
-
             try:
                 retries = retries.increment(
                     method, url, response=response, _pool=response._pool
@@ -784,7 +781,7 @@ class PoolManager(RequestMethods):
             log.debug("Retry: %s", url)
             new_promise = self.urlopen(
                 method,
-                urljoin(url, redirect_location),
+                url,
                 True,
                 body=body,
                 headers=headers,

--- a/src/urllib3/util/_async/traffic_police.py
+++ b/src/urllib3/util/_async/traffic_police.py
@@ -1087,6 +1087,7 @@ class AsyncTrafficPolice(typing.Generic[T]):
         not_idle_only: bool = False,
     ) -> typing.AsyncGenerator[T, None]:
         clean_exit = True
+        conn_or_pool: T | None = None
         try:
             if traffic_indicator:
                 if isinstance(traffic_indicator, type):
@@ -1140,7 +1141,13 @@ class AsyncTrafficPolice(typing.Generic[T]):
         finally:
             # do not release back to the pool a broken connection
             # we need kill_cursor() to take over soon.
-            if clean_exit and self.release():
+            # clean_exit=False not necessarily mean conn broken.
+            # see https://github.com/jawah/urllib3.future/issues/366
+            withhold_conn: bool = not clean_exit and getattr(
+                conn_or_pool, "is_closed", False
+            )
+
+            if not withhold_conn and self.release():
                 await asyncio.sleep(0)
 
     def release(self) -> bool:

--- a/src/urllib3/util/_async/traffic_police.py
+++ b/src/urllib3/util/_async/traffic_police.py
@@ -600,6 +600,12 @@ class AsyncTrafficPolice(typing.Generic[T]):
             del self._registry[eligible_obj_id]
             del self._container[eligible_obj_id]
 
+            await self.put(
+                ItemPlaceholder(),  # type: ignore[arg-type]
+                immediately_unavailable=True,
+                block=block,
+            )
+
             try:
                 await eligible_conn_or_pool.close()
             except Exception:
@@ -696,6 +702,15 @@ class AsyncTrafficPolice(typing.Generic[T]):
             and id(conn_or_pool) not in self._registry
         ):
             await self._sacrifice_first_idle(block=block)
+
+            # we need this because we await conn close
+            # in sacrifice idle, and asyncio scheduler
+            # yield control to another task.
+            # so we placed a placeholder to avoid
+            # another task taking the spot.
+            if self._cursor is not None:
+                del self._registry[self._cursor.obj_id]
+                self._unset_cursor()
 
         should_schedule_another_task: bool = False
         current_task = _current_task_or_die()

--- a/src/urllib3/util/traffic_police.py
+++ b/src/urllib3/util/traffic_police.py
@@ -881,6 +881,7 @@ class TrafficPolice(typing.Generic[T]):
         not_idle_only: bool = False,
     ) -> typing.Generator[T, None, None]:
         clean_exit = True
+        conn_or_pool: T | None = None
         try:
             cursor_key = get_ident()
 
@@ -942,7 +943,13 @@ class TrafficPolice(typing.Generic[T]):
         finally:
             # do not release back to the pool a broken connection
             # we need kill_cursor() to take over soon.
-            if clean_exit:
+            # clean_exit=False not necessarily mean conn broken.
+            # see https://github.com/jawah/urllib3.future/issues/366
+            withhold_conn: bool = not clean_exit and getattr(
+                conn_or_pool, "is_closed", False
+            )
+
+            if not withhold_conn:
                 self.release()
 
     def release(self) -> None:

--- a/test/test_async_connectionpool.py
+++ b/test/test_async_connectionpool.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from urllib3._async.connectionpool import AsyncHTTPConnectionPool
+
+
+@pytest.mark.asyncio
+async def test_legacy_queue_cls_emits_deprecation_warning() -> None:
+    # Covers _async/connectionpool.py: warns + auto-fallback to AsyncTrafficPolice
+    # when QueueCls is not an AsyncTrafficPolice subclass.
+    import queue
+
+    from urllib3.util._async.traffic_police import AsyncTrafficPolice
+
+    class LegacyQueuePool(AsyncHTTPConnectionPool):
+        QueueCls = queue.LifoQueue  # type: ignore[assignment]
+
+    with pytest.warns(
+        DeprecationWarning, match="QueueCls no longer support typical queue"
+    ):
+        pool = LegacyQueuePool(host="localhost", maxsize=1)
+    try:
+        assert pool.QueueCls is AsyncTrafficPolice  # type: ignore[comparison-overlap]
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_keepalive_idle_window_clamps_to_minimum() -> None:
+    # Covers _async/connectionpool.py keepalive_idle_window clamp to
+    # MINIMAL_KEEPALIVE_IDLE_WINDOW when an absurdly small value is given.
+    from urllib3._constant import MINIMAL_KEEPALIVE_IDLE_WINDOW
+
+    pool = AsyncHTTPConnectionPool(
+        host="localhost",
+        maxsize=1,
+        background_watch_delay=0.1,
+        keepalive_idle_window=0.001,
+    )
+    try:
+        assert pool._keepalive_idle_window is not None
+        assert pool._keepalive_idle_window >= MINIMAL_KEEPALIVE_IDLE_WINDOW
+    finally:
+        await pool.close()

--- a/test/test_async_response.py
+++ b/test/test_async_response.py
@@ -111,6 +111,19 @@ class TestAsyncResponse:
         r = AsyncHTTPResponse(None)  # type: ignore[arg-type]
         assert await r.data is None
 
+    async def test_non_integer_status_falls_back_to_zero(self) -> None:
+        # Covers AsyncHTTPResponse.__init__ ValueError fallback when the
+        # status cannot be cast to int. Historically supported by
+        # http.client's broken httplib. See src/urllib3/_async/response.py.
+        r = AsyncHTTPResponse(status="not-a-number")  # type: ignore[arg-type]
+        assert r.status == 0
+
+    async def test_msg_kwarg_emits_deprecation_warning(self) -> None:
+        # Covers AsyncHTTPResponse.__init__ DeprecationWarning emitted when
+        # the legacy ``msg=`` keyword is supplied.
+        with pytest.warns(DeprecationWarning, match="msg=.* is deprecated"):
+            AsyncHTTPResponse(msg="legacy")  # type: ignore[arg-type]
+
     async def test_preload(self) -> None:
         fp = _make_async_fp(b"foo")
 

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import http.client as httplib
 import ssl
+import threading
 import typing
 from socket import error as SocketError
 from ssl import SSLError as BaseSSLError
@@ -585,3 +586,76 @@ class TestConnectionPool:
                 timeout = Timeout(1, 1, 1)
                 with pytest.raises(ReadTimeoutError):
                     pool._make_request(conn, "", "", timeout=timeout)
+
+    def test_legacy_queue_cls_emits_deprecation_warning(self) -> None:
+        # Covers connectionpool.py: warns + auto-fallback to TrafficPolice when
+        # QueueCls is not a TrafficPolice subclass. We also exercise the
+        # TypeError fallback branch by giving a QueueCls whose constructor
+        # rejects the ``concurrency`` kwarg -- but TrafficPolice supplants it
+        # via the auto-fallback, so the second pool creation succeeds.
+        import queue
+
+        class LegacyQueuePool(HTTPConnectionPool):
+            QueueCls = queue.LifoQueue  # type: ignore[assignment]
+
+        with pytest.warns(
+            DeprecationWarning, match="QueueCls no longer support typical queue"
+        ):
+            pool = LegacyQueuePool(host="localhost", maxsize=1)
+        # Auto-fallback should have restored TrafficPolice on the instance.
+        from urllib3.util.traffic_police import TrafficPolice
+
+        assert pool.QueueCls is TrafficPolice  # type: ignore[comparison-overlap]
+        pool.close()
+
+    def test_keepalive_idle_window_clamps_to_minimum(self) -> None:
+        # Covers connectionpool.py keepalive_idle_window clamp to
+        # MINIMAL_KEEPALIVE_IDLE_WINDOW when an absurdly small value is given.
+        from urllib3._constant import MINIMAL_KEEPALIVE_IDLE_WINDOW
+
+        captured: dict[str, typing.Any] = {}
+
+        real_thread = threading.Thread
+
+        def _capture(*args: typing.Any, **kwargs: typing.Any) -> threading.Thread:
+            captured["args"] = kwargs.get("args", args[1] if len(args) > 1 else ())
+            # Return a daemon thread that never starts the real task.
+            t = real_thread(target=lambda: None)
+            return t
+
+        with patch("urllib3.connectionpool.threading.Thread", side_effect=_capture):
+            pool = HTTPConnectionPool(
+                host="localhost",
+                maxsize=1,
+                background_watch_delay=0.1,
+                keepalive_idle_window=0.001,
+            )
+            try:
+                # args = (proxy(self), background_watch_delay, keepalive_delay, keepalive_idle_window)
+                assert captured["args"][3] >= MINIMAL_KEEPALIVE_IDLE_WINDOW
+            finally:
+                pool.close()
+
+    def test_background_watch_delay_clamped_below_idle_window(self) -> None:
+        # Covers connectionpool.py background_watch_delay > keepalive_idle_window
+        # override branch.
+        captured: dict[str, typing.Any] = {}
+
+        real_thread = threading.Thread
+
+        def _capture(*args: typing.Any, **kwargs: typing.Any) -> threading.Thread:
+            captured["args"] = kwargs.get("args", args[1] if len(args) > 1 else ())
+            return real_thread(target=lambda: None)
+
+        with patch("urllib3.connectionpool.threading.Thread", side_effect=_capture):
+            pool = HTTPConnectionPool(
+                host="localhost",
+                maxsize=1,
+                background_watch_delay=5.0,
+                keepalive_idle_window=1.5,
+            )
+            try:
+                # background_watch_delay should have been reduced to idle window.
+                assert captured["args"][1] <= 1.5
+            finally:
+                pool.close()

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -117,6 +117,12 @@ class TestResponse:
         assert r.data == b"foo"
         assert r._body == b"foo"
 
+    def test_non_integer_status_falls_back_to_zero(self) -> None:
+        # Covers HTTPResponse.__init__ ValueError fallback when the status
+        # cannot be cast to int. See src/urllib3/response.py.
+        r = HTTPResponse(status="not-a-number")  # type: ignore[arg-type]
+        assert r.status == 0
+
     def test_cache_content_preload_false(self) -> None:
         fp = BytesIO(b"foo")
         r = HTTPResponse(fp, preload_content=False)

--- a/test/with_dummyserver/asynchronous/test_connection.py
+++ b/test/with_dummyserver/asynchronous/test_connection.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from dummyserver.testcase import HTTPDummyServerTestCase as server
+from urllib3 import AsyncHTTPConnectionPool
+
+
+@pytest.mark.asyncio
+async def test_is_connected_false_after_keepalive_delay_elapsed() -> None:
+    """Async mirror of the keepalive-delay expiry branch in
+    ``AsyncHTTPConnection.is_connected`` (see
+    ``src/urllib3/_async/connection.py``). Once the configured keepalive
+    window has elapsed the pool must consider the connection stale without
+    consulting the kernel.
+    """
+    server.setup_class()
+    try:
+        async with AsyncHTTPConnectionPool(server.host, server.port) as pool:
+            conn = await pool._get_conn()
+            await conn.connect()
+
+            assert conn.is_connected is True
+
+            conn._keepalive_delay = 0.001
+            conn._connected_at = time.monotonic() - 10.0
+
+            assert conn.is_connected is False
+
+            await conn.close()
+    finally:
+        server.teardown_class()
+
+
+@pytest.mark.asyncio
+async def test_is_connected_false_when_socket_fileno_invalid() -> None:
+    """Async mirror covering ``_async/connection.py:308`` -- the
+    ``sock.fileno() == -1`` early-return False branch.
+    """
+    server.setup_class()
+    try:
+        async with AsyncHTTPConnectionPool(server.host, server.port) as pool:
+            conn = await pool._get_conn()
+            await conn.connect()
+
+            assert conn.is_connected is True
+
+            assert conn.sock is not None
+            conn.sock.close()
+
+            assert conn.is_connected is False
+
+            await conn.close()
+    finally:
+        server.teardown_class()

--- a/test/with_dummyserver/asynchronous/test_socketlevel.py
+++ b/test/with_dummyserver/asynchronous/test_socketlevel.py
@@ -1,5 +1,6 @@
 import pytest
 from urllib3 import AsyncHTTPConnectionPool
+from urllib3.exceptions import IncompleteRead, InvalidHeader, ProtocolError
 
 from dummyserver.testcase import SocketDummyServerTestCase
 from threading import Event
@@ -48,3 +49,74 @@ class TestSocketClosing(SocketDummyServerTestCase):
             response = await pool.request("GET", "/", retries=0)
             assert response.status == 200
             assert (await response.data) == b"Response 1"
+
+
+@pytest.mark.asyncio
+class TestRemoteClosedWithoutResponse(SocketDummyServerTestCase):
+    """Async mirror of the sync test of the same name in
+    ``test/with_dummyserver/test_socketlevel.py``. Exercises the
+    ``"Remote end closed connection without response"`` raise in
+    ``src/urllib3/backend/_async/hface.py`` ``__exchange_until``.
+    """
+
+    async def test_server_closes_socket_before_status_line(self) -> None:
+        def socket_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+            sock.close()
+
+        self._start_server(socket_handler)
+        async with AsyncHTTPConnectionPool(self.host, self.port, retries=False) as pool:
+            with pytest.raises(
+                ProtocolError, match="Remote end closed connection without response"
+            ):
+                await pool.request("GET", "/")
+
+
+@pytest.mark.asyncio
+class TestInvalidHTTPResponse(SocketDummyServerTestCase):
+    """Async mirror covering the malformed-header path."""
+
+    async def test_garbage_header_separator_raises_invalid_header(self) -> None:
+        def socket_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+            sock.sendall(
+                b"HTTP/1.1 200 OK\r\nNoColonHeaderLine\r\nContent-Length: 0\r\n\r\n"
+            )
+            sock.close()
+
+        self._start_server(socket_handler)
+        async with AsyncHTTPConnectionPool(self.host, self.port, retries=False) as pool:
+            with pytest.raises((InvalidHeader, ProtocolError)):
+                await pool.request("GET", "/")
+
+
+@pytest.mark.asyncio
+class TestPartialBodyClose(SocketDummyServerTestCase):
+    """Async mirror covering the partial-body close path."""
+
+    async def test_server_closes_after_partial_body(self) -> None:
+        def socket_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+            sock.sendall(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Length: 50\r\n"
+                b"Content-Type: text/plain\r\n"
+                b"\r\n"
+                b"0123456789"
+            )
+            sock.close()
+
+        self._start_server(socket_handler)
+        async with AsyncHTTPConnectionPool(self.host, self.port, retries=False) as pool:
+            resp = await pool.request("GET", "/", preload_content=False, retries=False)
+            with pytest.raises((IncompleteRead, ProtocolError)):
+                await resp.read()

--- a/test/with_dummyserver/test_connection.py
+++ b/test/with_dummyserver/test_connection.py
@@ -150,3 +150,87 @@ def test_invalid_tunnel_scheme(pool: HTTPConnectionPool) -> None:
         str(e.value)
         == "Invalid proxy scheme for tunneling: 'socks', must be either 'http' or 'https'"
     )
+
+
+def test_is_connected_false_after_keepalive_delay_elapsed(
+    pool: HTTPConnectionPool,
+) -> None:
+    """Covers ``HTTPConnection.is_connected`` early-return branch when the
+    connection has outlived its configured ``keepalive_delay`` window.
+    """
+    import time
+
+    conn = pool._get_conn()
+    conn.connect()
+
+    assert conn.is_connected is True
+
+    # Force the connection to look as if it was established a long time ago
+    # and configure a vanishingly small keepalive delay. The next is_connected
+    # probe should reject it without performing the os-level liveness check.
+    conn._keepalive_delay = 0.001
+    conn._connected_at = time.monotonic() - 10.0
+
+    assert conn.is_connected is False
+
+    conn.close()
+
+
+def test_is_connected_false_when_socket_fileno_invalid(
+    pool: HTTPConnectionPool,
+) -> None:
+    """Covers ``HTTPConnection.is_connected`` early-return at
+    ``src/urllib3/connection.py:310`` when the underlying socket has been
+    closed at the file-descriptor level (``fileno() == -1``).
+    """
+    conn = pool._get_conn()
+    conn.connect()
+
+    assert conn.is_connected is True
+
+    # Forcefully close the socket without going through conn.close() so that
+    # _protocol is preserved and only the fileno()==-1 branch fires.
+    assert conn.sock is not None
+    conn.sock.close()
+
+    assert conn.is_connected is False
+
+    conn.close()
+
+
+def test_aws_style_send_override_typeerror_fallback() -> None:
+    """Covers ``src/urllib3/connection.py:548-554`` -- when a subclass
+    overrides ``send()`` with a signature that rejects ``eot`` (as the
+    historic ``botocore.awsrequest.AWSConnection`` did), the request path
+    must fall back to ``super().send(b"", eot=True)`` so that uploads still
+    terminate cleanly.
+    """
+    from urllib3.connection import HTTPConnection
+
+    captured: dict[str, int] = {"calls": 0, "fallbacks": 0}
+
+    class AWSStyleHTTPConnection(HTTPConnection):
+        def send(
+            self,
+            data: typing.Any,
+            *,
+            eot: bool = False,
+        ) -> typing.Any:
+            captured["calls"] += 1
+            if data == b"" and eot:
+                captured["fallbacks"] += 1
+                raise TypeError("send() got an unexpected keyword argument 'eot'")
+            return super().send(data, eot=eot)
+
+    class AWSStylePool(HTTPConnectionPool):
+        ConnectionCls = AWSStyleHTTPConnection
+
+    server.setup_class()
+    try:
+        with AWSStylePool(server.host, server.port) as pool:
+            resp = pool.request("POST", "/echo", body=b"hello-aws-style")
+            assert resp.status == 200
+            assert b"hello-aws-style" in resp.data
+            assert captured["fallbacks"] == 1
+    finally:
+        server.teardown_class()

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -2912,3 +2912,135 @@ class TestContentFraming(SocketDummyServerTestCase):
 
             sent_bytes = bytes(buffer)
             assert sent_bytes.endswith(expected)
+
+
+class TestRemoteClosedWithoutResponse(SocketDummyServerTestCase):
+    """Covers the ``ConnectionTerminated`` event branch in ``__exchange_until``
+    where the server closes the connection after the request was sent but
+    before any HTTP/1.1 response headers are emitted. See ``"Remote end closed connection without response"``
+    raise (and async mirror).
+    """
+
+    def test_server_closes_socket_before_status_line(self) -> None:
+        def socket_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+            # Drain the request, then close immediately without sending anything.
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+            sock.close()
+
+        self._start_server(socket_handler)
+        with HTTPConnectionPool(
+            self.host, self.port, timeout=LONG_TIMEOUT, retries=False
+        ) as pool:
+            with pytest.raises(
+                ProtocolError, match="Remote end closed connection without response"
+            ):
+                pool.request("GET", "/")
+
+
+class TestInvalidHTTPResponse(SocketDummyServerTestCase):
+    """Covers the h11 ``RemoteProtocolError`` -> ``InvalidHeader`` translation
+    in ``__exchange_until`` (lines ~1150-1155 sync, async mirror). h11 raises
+    400 with a message containing ``header`` when it sees a malformed response
+    header on the wire.
+    """
+
+    def test_garbage_header_separator_raises_invalid_header(self) -> None:
+        def socket_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+            # Status line is OK; the header line is malformed (no colon).
+            sock.sendall(
+                b"HTTP/1.1 200 OK\r\nNoColonHeaderLine\r\nContent-Length: 0\r\n\r\n"
+            )
+            sock.close()
+
+        self._start_server(socket_handler)
+        with HTTPConnectionPool(
+            self.host, self.port, timeout=LONG_TIMEOUT, retries=False
+        ) as pool:
+            with pytest.raises((InvalidHeader, ProtocolError)):
+                pool.request("GET", "/")
+
+
+class TestPartialBodyClose(SocketDummyServerTestCase):
+    """Covers the alternative ``IncompleteRead`` message-string parsing path
+    when h11 surfaces a ``RemoteProtocolError`` with
+    ``peer closed connection without sending complete message body``. This is
+    distinct from ``InvalidBodyLengthError`` which already has structured
+    attributes and is covered by ``TestBadContentLength``.
+    """
+
+    def test_server_closes_after_partial_body(self) -> None:
+        def socket_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+            # Announce 50 bytes, send 10, then drop the connection.
+            sock.sendall(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Length: 50\r\n"
+                b"Content-Type: text/plain\r\n"
+                b"\r\n"
+                b"0123456789"
+            )
+            sock.close()
+
+        self._start_server(socket_handler)
+        with HTTPConnectionPool(
+            self.host, self.port, timeout=LONG_TIMEOUT, retries=False
+        ) as pool:
+            resp = pool.request("GET", "/", preload_content=False, retries=False)
+            with pytest.raises((IncompleteRead, ProtocolError)):
+                resp.read()
+
+
+class TestSyncRejectsAsyncIterableBody(SocketDummyServerTestCase):
+    """Covers the ``hasattr(chunks, "__aiter__")`` rejection branch in
+    ``src/urllib3/connection.py`` request body sending path. A synchronous
+    connection cannot drive an ``async`` iterator, so the library raises
+    ``RuntimeError`` rather than silently mis-sending the body.
+    """
+
+    def test_async_iter_body_raises_runtime_error(self) -> None:
+        def socket_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+            # Drain whatever headers arrive, then echo back a minimal 200 so
+            # the request lifecycle can complete cleanly if it ever gets that
+            # far (it should not -- RuntimeError fires before any body byte).
+            buf = b""
+            try:
+                while b"\r\n\r\n" not in buf:
+                    chunk = sock.recv(65536)
+                    if not chunk:
+                        break
+                    buf += chunk
+                sock.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+            except OSError:
+                pass
+            finally:
+                sock.close()
+
+        async def _async_body() -> typing.AsyncIterator[bytes]:
+            yield b"hello"
+            yield b"world"
+
+        self._start_server(socket_handler)
+        with HTTPConnectionPool(
+            self.host, self.port, timeout=LONG_TIMEOUT, retries=False
+        ) as pool:
+            with pytest.raises(
+                RuntimeError,
+                match="Unable to send an async iterable through a synchronous connection",
+            ):
+                pool.urlopen(  # type: ignore[call-overload]
+                    "POST",
+                    "/",
+                    body=_async_body(),
+                    chunked=True,
+                )

--- a/test/with_traefik/asynchronous/test_poolmanager_multiplexed.py
+++ b/test/with_traefik/asynchronous/test_poolmanager_multiplexed.py
@@ -261,3 +261,50 @@ class TestPoolManagerMultiplexed(TraefikTestCase):
             Retry.increment = bck_method  # type: ignore[method-assign]
 
             assert incr > 0
+
+    async def test_multiplexed_retry_exhausted_returns_response_when_not_raising(
+        self,
+    ) -> None:
+        """Async mirror covering ``src/urllib3/_async/poolmanager.py`` retry-
+        from-promise branch in ``AsyncPoolManager.get_response``.
+        """
+        async with AsyncPoolManager(
+            ca_certs=self.ca_authority,
+            resolver=self.test_resolver_raw,
+        ) as pool:
+            retry = Retry(
+                1, status_forcelist=[503], backoff_factor=0.0, raise_on_status=False
+            )
+            promise = await pool.urlopen(
+                "GET",
+                f"{self.https_url}/status/503",
+                retries=retry,
+                multiplexed=True,
+            )
+            assert isinstance(promise, ResponsePromise)
+
+            response = await pool.get_response(promise=promise)
+            assert response is not None
+            assert response.status == 503
+
+    async def test_multiplexed_retry_exhausted_raises_when_configured(
+        self,
+    ) -> None:
+        """Async companion -- exhaustion + raise_on_status=True path."""
+        async with AsyncPoolManager(
+            ca_certs=self.ca_authority,
+            resolver=self.test_resolver_raw,
+        ) as pool:
+            retry = Retry(
+                1, status_forcelist=[503], backoff_factor=0.0, raise_on_status=True
+            )
+            promise = await pool.urlopen(
+                "GET",
+                f"{self.https_url}/status/503",
+                retries=retry,
+                multiplexed=True,
+            )
+            assert isinstance(promise, ResponsePromise)
+
+            with pytest.raises(MaxRetryError):
+                await pool.get_response(promise=promise)

--- a/test/with_traefik/test_poolmanager_multiplexed.py
+++ b/test/with_traefik/test_poolmanager_multiplexed.py
@@ -259,3 +259,51 @@ class TestPoolManagerMultiplexed(TraefikTestCase):
             Retry.increment = bck_method  # type: ignore[method-assign]
 
             assert incr > 0
+
+    def test_multiplexed_retry_exhausted_returns_response_when_not_raising(
+        self,
+    ) -> None:
+        """Covers the retry-from-promise branch in ``PoolManager.get_response``.
+        Forces a deterministic 503 via ``/status/503`` so the retry path is taken on every attempt;
+        """
+        with PoolManager(
+            ca_certs=self.ca_authority,
+            resolver=self.test_resolver,
+        ) as pool:
+            retry = Retry(
+                1, status_forcelist=[503], backoff_factor=0.0, raise_on_status=False
+            )
+            promise = pool.urlopen(
+                "GET",
+                f"{self.https_url}/status/503",
+                retries=retry,
+                multiplexed=True,
+            )
+            assert isinstance(promise, ResponsePromise)
+
+            response = pool.get_response(promise=promise)
+            assert response is not None
+            # Retries exhausted but raise_on_status=False -> final 503 returned.
+            assert response.status == 503
+
+    def test_multiplexed_retry_exhausted_raises_when_configured(self) -> None:
+        """Companion to the previous test -- with ``raise_on_status=True`` the
+        exhaustion path drains the response and re-raises ``MaxRetryError``.
+        """
+        with PoolManager(
+            ca_certs=self.ca_authority,
+            resolver=self.test_resolver,
+        ) as pool:
+            retry = Retry(
+                1, status_forcelist=[503], backoff_factor=0.0, raise_on_status=True
+            )
+            promise = pool.urlopen(
+                "GET",
+                f"{self.https_url}/status/503",
+                retries=retry,
+                multiplexed=True,
+            )
+            assert isinstance(promise, ResponsePromise)
+
+            with pytest.raises(MaxRetryError):
+                pool.get_response(promise=promise)


### PR DESCRIPTION
2.20.904 (2026-05-13)
=====================

- Fixed ``PoolManager.get_response`` (and ``AsyncPoolManager.get_response``) crashing with ``AssertionError`` when a
  (manual) multiplexed request reached the retry-on-status branch (e.g. ``Retry(status_forcelist=[503])``). The branch
  erroneously looked up a redirect ``Location`` header and ``assert isinstance(redirect_location, str)`` failed.
- Fixed withholding of non broken connection in read phase after one non fatal exception. (#366)
