### PR TITLE
Release 2.20.906

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 - Fixed TLS connection to some server that requires OP_NO_RENEGOTIATION enabled (legacy TLS1.2 server). (https://github.com/jawah/niquests/issues/402)
 - Fixed automatic fallback to single datagram send when GSO is available for UDP I/O but the physical NIC don't support it. (#373)
 - Fixed automatic fallback tls/quic to tls/tcp when the discrete upgrade failed. (#372)
+- Fixed broken connection handling in (contrib) webextension wsproto that lead to hangs. (#371)
 
 2.20.905 (2026-05-17)
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.20.906 (2026-05-21)
+=====================
+
+- Fixed TLS connection to some server that requires OP_NO_RENEGOTIATION enabled (legacy TLS1.2 server). (https://github.com/jawah/niquests/issues/402)
+- Fixed automatic fallback to single datagram send when GSO is available for UDP I/O but the physical NIC don't support it. (#373)
+- Fixed automatic fallback tls/quic to tls/tcp when the discrete upgrade failed. (#372)
+
 2.20.905 (2026-05-17)
 =====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.20.905"
+__version__ = "2.20.906"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -643,10 +643,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
             ConnectionRefusedError,
             ConnectionResetError,
         ) as e:
-            if (
-                isinstance(self._protocol, HTTPOverQUICProtocol)
-                and self.__alt_authority is not None
-            ):
+            if self.__alt_authority is not None:
                 # we want to remove invalid quic cache capability
                 # because the alt-svc was probably bogus...
                 if (

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -64,6 +64,7 @@ from ..contrib.hface.events import (
     StreamResetReceived,
 )
 from ..contrib.ssa._gro import (
+    GenericSegmentOffloadUnsupported,
     _sock_has_gro,
     _sock_has_gso,
     sync_recv_gro,
@@ -954,6 +955,7 @@ class HfaceBackend(BaseBackend):
         _proto_exc = protocol.exceptions()
 
         def send_pending() -> None:
+            nonlocal gso_enabled
             if gso_enabled:
                 tbs: list[bytes] = []
                 while True:
@@ -962,7 +964,12 @@ class HfaceBackend(BaseBackend):
                         break
                     tbs.append(data_out)
                 if len(tbs) > 1:
-                    sync_sendmsg_gso(sock, tbs)
+                    try:
+                        sync_sendmsg_gso(sock, tbs)
+                    except GenericSegmentOffloadUnsupported:
+                        self._dgram_gso_enabled = gso_enabled = False
+                        for dgram in tbs:
+                            sock.sendall(dgram)
                 elif tbs:
                     sock.sendall(tbs[0])
             else:
@@ -1465,7 +1472,12 @@ class HfaceBackend(BaseBackend):
                         break
                     tbs.append(buf)
                 if len(tbs) > 1:
-                    sync_sendmsg_gso(self.sock, tbs)
+                    try:
+                        sync_sendmsg_gso(self.sock, tbs)
+                    except GenericSegmentOffloadUnsupported:
+                        self._dgram_gso_enabled = False
+                        for dgram in tbs:
+                            self.sock.sendall(dgram)
                 elif tbs:
                     self.sock.sendall(tbs[0])
             else:
@@ -1913,7 +1925,12 @@ class HfaceBackend(BaseBackend):
                             break
                         tbs.append(data_out)
                     if len(tbs) > 1:
-                        sync_sendmsg_gso(self.sock, tbs)
+                        try:
+                            sync_sendmsg_gso(self.sock, tbs)
+                        except GenericSegmentOffloadUnsupported:
+                            self._dgram_gso_enabled = False
+                            for dgram in tbs:
+                                self.sock.sendall(dgram)
                     elif tbs:
                         self.sock.sendall(tbs[0])
                 else:

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -1104,7 +1104,6 @@ class HfaceBackend(BaseBackend):
                 stream_related_event: bool = hasattr(event, "stream_id")
 
                 if not stream_related_event and isinstance(event, ConnectionTerminated):
-
                     self._protocol = None
                     self.close()
 

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -1104,6 +1104,10 @@ class HfaceBackend(BaseBackend):
                 stream_related_event: bool = hasattr(event, "stream_id")
 
                 if not stream_related_event and isinstance(event, ConnectionTerminated):
+
+                    self._protocol = None
+                    self.close()
+
                     # A server may end the transmission without error
                     # to mark the end of SSE for example. While it's not ideal
                     # it's not forbidden either.
@@ -1151,8 +1155,6 @@ class HfaceBackend(BaseBackend):
                         )
                         and not any(isinstance(e, HeadersReceived) for e in events)
                     ):
-                        self._protocol = None
-                        self.close()
                         raise ProtocolError(
                             "Remote end closed connection without response"
                         )

--- a/src/urllib3/contrib/resolver/doq/_qh3.py
+++ b/src/urllib3/contrib/resolver/doq/_qh3.py
@@ -27,7 +27,13 @@ from qh3.quic.events import (
 
 from ....util.ssl_ import IS_FIPS, resolve_cert_reqs
 from ....util.sub_timeout import SubTimeout
-from ...ssa._gro import _sock_has_gro, _sock_has_gso, sync_recv_gro, sync_sendmsg_gso
+from ...ssa._gro import (
+    GenericSegmentOffloadUnsupported,
+    _sock_has_gro,
+    _sock_has_gso,
+    sync_recv_gro,
+    sync_sendmsg_gso,
+)
 from ..dou import PlainResolver
 from ..protocols import (
     COMMON_RCODE_LABEL,
@@ -154,7 +160,12 @@ class QUICResolver(PlainResolver):
                         break
 
                     if self._dgram_gso_enabled and len(datagrams) > 1:
-                        sync_sendmsg_gso(self._socket, [d[0] for d in datagrams])
+                        try:
+                            sync_sendmsg_gso(self._socket, [d[0] for d in datagrams])
+                        except GenericSegmentOffloadUnsupported:
+                            self._dgram_gso_enabled = False
+                            for datagram in datagrams:
+                                self._socket.sendall(datagram[0])
                     else:
                         for datagram in datagrams:
                             self._socket.sendall(datagram[0])
@@ -277,7 +288,12 @@ class QUICResolver(PlainResolver):
 
                 datagrams = self._quic.datagrams_to_send(monotonic())
                 if self._dgram_gso_enabled and len(datagrams) > 1:
-                    sync_sendmsg_gso(self._socket, [d[0] for d in datagrams])
+                    try:
+                        sync_sendmsg_gso(self._socket, [d[0] for d in datagrams])
+                    except GenericSegmentOffloadUnsupported:
+                        self._dgram_gso_enabled = False
+                        for dg in datagrams:
+                            self._socket.sendall(dg[0])
                 else:
                     for dg in datagrams:
                         self._socket.sendall(dg[0])
@@ -467,6 +483,7 @@ class QUICResolver(PlainResolver):
         gro_enabled = self._dgram_gro_enabled
 
         def send_pending() -> None:
+            nonlocal gso_enabled
             now = monotonic()
             quic.handle_timer(now)
             while True:
@@ -474,7 +491,12 @@ class QUICResolver(PlainResolver):
                 if not datagrams:
                     break
                 if gso_enabled and len(datagrams) > 1:
-                    sync_sendmsg_gso(sock, [d[0] for d in datagrams])
+                    try:
+                        sync_sendmsg_gso(sock, [d[0] for d in datagrams])
+                    except GenericSegmentOffloadUnsupported:
+                        self._dgram_gso_enabled = gso_enabled = False
+                        for datagram in datagrams:
+                            sock.sendall(datagram[0])
                 else:
                     for datagram in datagrams:
                         sock.sendall(datagram[0])
@@ -489,7 +511,12 @@ class QUICResolver(PlainResolver):
                         break
 
                     if gso_enabled and len(datagrams) > 1:
-                        sync_sendmsg_gso(sock, [d[0] for d in datagrams])
+                        try:
+                            sync_sendmsg_gso(sock, [d[0] for d in datagrams])
+                        except GenericSegmentOffloadUnsupported:
+                            self._dgram_gso_enabled = gso_enabled = False
+                            for datagram in datagrams:
+                                sock.sendall(datagram[0])
                     else:
                         for datagram in datagrams:
                             sock.sendall(datagram[0])
@@ -532,7 +559,12 @@ class QUICResolver(PlainResolver):
                             break
 
                         if gso_enabled and len(datagrams) > 1:
-                            sync_sendmsg_gso(sock, [d[0] for d in datagrams])
+                            try:
+                                sync_sendmsg_gso(sock, [d[0] for d in datagrams])
+                            except GenericSegmentOffloadUnsupported:
+                                self._dgram_gso_enabled = gso_enabled = False
+                                for datagram in datagrams:
+                                    sock.sendall(datagram[0])
                         else:
                             for datagram in datagrams:
                                 sock.sendall(datagram[0])

--- a/src/urllib3/contrib/ssa/_gro.py
+++ b/src/urllib3/contrib/ssa/_gro.py
@@ -11,6 +11,7 @@ All other platforms fall back to the standard asyncio DatagramTransport.
 from __future__ import annotations
 
 import asyncio
+import errno
 import socket
 import struct
 import sys
@@ -25,6 +26,7 @@ __all__ = (
     "open_dgram_connection",
     "sync_recv_gro",
     "sync_sendmsg_gso",
+    "GenericSegmentOffloadUnsupported",
     "DatagramReader",
     "DatagramWriter",
 )
@@ -224,8 +226,42 @@ def sync_recv_gro(
     return _split_gro_buffer(data, segment_size)
 
 
+class GenericSegmentOffloadUnsupported(Exception):
+    """Raised when a UDP GSO send is rejected by the kernel/driver
+    because the NIC does not actually support segmentation offload,
+    even though Kernel support it.
+
+    Callers should disable GSO on the affected socket for the rest of
+    the connection and re-send the failing batch without GSO. This
+    mirrors the fallback strategy used by ``quic-go``.
+    """
+
+
+# Errnos returned by the kernel/driver when a UDP segmentation offload
+# request cannot actually be honored by the NIC or routing path.
+_GSO_UNSUPPORTED_ERRNOS: typing.Final = frozenset(
+    e
+    for e in (
+        getattr(errno, "EIO", None),
+        getattr(errno, "ENOTSUP", None),
+        getattr(errno, "EOPNOTSUPP", None),
+        getattr(errno, "ENOPROTOOPT", None),
+    )
+    if e is not None
+)
+
+
 def sync_sendmsg_gso(sock: socket.socket, datagrams: list[bytes]) -> None:
-    """Batch-send datagrams using GSO. Falls back to individual sends."""
+    """Batch-send datagrams using GSO. Falls back to individual sends.
+
+    Raises :class:`GenericSegmentOffloadUnsupported` if the kernel/driver
+    rejects the GSO send because the underlying NIC does not actually
+    support UDP segmentation offload (e.g. ``EIO`` from ``sendmsg``).
+    The current group is not sent in that case; callers are expected to
+    disable GSO for the connection and re-send the batch without GSO.
+    Duplicate delivery of any earlier group is harmless for QUIC
+    (the receiver de-duplicates by packet number).
+    """
     for segment_size, group in _group_by_segment_size(datagrams):
         if len(group) == 1:
             sock.send(group[0])
@@ -238,9 +274,11 @@ def sync_sendmsg_gso(sock: socket.socket, datagrams: list[bytes]) -> None:
                 group,
                 [(_SOL_UDP, UDP_LINUX_SEGMENT, _UINT16.pack(segment_size))],
             )
-        except OSError:
-            # Fallback to one-by-one if the kernel rejects this batch
-            # (e.g. interface MTU change, unsupported NIC, etc.).
+        except OSError as exc:
+            if exc.errno in _GSO_UNSUPPORTED_ERRNOS:
+                raise GenericSegmentOffloadUnsupported() from exc
+            # Other transient errors (e.g. interface MTU change): fall
+            # back to one-by-one for this batch but keep GSO enabled.
             for dgram in group:
                 sock.send(dgram)
 
@@ -569,6 +607,11 @@ class _NativeOptimizedDatagramTransport(asyncio.DatagramTransport):
                 # GSO send, fall back to per-datagram sends so partial
                 # progress is still possible.
                 if len(group) > 1:
+                    # NIC/driver lies about GSO support: disable it
+                    # permanently for this transport so future batches
+                    # take the plain ``sendto`` path.
+                    if exc.errno in _GSO_UNSUPPORTED_ERRNOS:
+                        self._gso_enabled = False
                     for dgram in group:
                         try:
                             self._raw_send(dgram, addr)

--- a/src/urllib3/contrib/webextensions/_async/ws.py
+++ b/src/urllib3/contrib/webextensions/_async/ws.py
@@ -20,6 +20,7 @@ from wsproto.utilities import ProtocolError as WebSocketProtocolError
 
 from ....backend import HttpVersion
 from ....exceptions import ProtocolError
+from ....util.traffic_police import UnavailableTraffic
 from .protocol import AsyncExtensionFromHTTP
 
 
@@ -110,18 +111,29 @@ class AsyncWebSocketExtensionFromHTTP(AsyncExtensionFromHTTP):
         """End/Notify close for sub protocol."""
         if self._dsa is not None:
             if self._police_officer is not None:
-                async with self._police_officer.borrow(self._response):
-                    if self._remote_shutdown is False:
-                        try:
-                            data_to_send: bytes = self._protocol.send(
-                                CloseConnection(0)
-                            )
-                        except WebSocketProtocolError:
-                            pass
-                        else:
-                            async with self._write_error_catcher():
+                try:
+                    async with self._police_officer.borrow(self._response):
+                        # close() must be tolerant: when the peer has already
+                        # gone (TCP FIN, half-closed stream, or a protocol
+                        # violation that tore down the underlying HTTP state
+                        # machine), every socket-touching call below can fail.
+                        if self._remote_shutdown is False:
+                            try:
+                                data_to_send: bytes = self._protocol.send(
+                                    CloseConnection(0)
+                                )
                                 await self._dsa.sendall(data_to_send)
-                    await self._dsa.close()
+                            except (WebSocketProtocolError, OSError, AssertionError):
+                                pass
+                        try:
+                            await self._dsa.close()
+                        except (OSError, AssertionError):
+                            pass
+                        self._dsa = None
+                except UnavailableTraffic:
+                    # the underlying connection was already destroyed
+                    # (e.g. via kill_cursor() after a protocol violation).
+                    # nothing to send; just clean up local state.
                     self._dsa = None
             else:
                 self._dsa = None
@@ -143,42 +155,10 @@ class AsyncWebSocketExtensionFromHTTP(AsyncExtensionFromHTTP):
         bytes_buf: list[bytes] = []
 
         async with self._police_officer.borrow(self._response):
-            for event in self._protocol.events():
-                if isinstance(event, TextMessage):
-                    if event.message_finished and not text_buf:
-                        return event.data
-                    text_buf.append(event.data)
-                    if event.message_finished:
-                        return "".join(text_buf)
-                elif isinstance(event, BytesMessage):
-                    if event.message_finished and not bytes_buf:
-                        return event.data
-                    bytes_buf.append(event.data)
-                    if event.message_finished:
-                        return b"".join(bytes_buf)
-                elif isinstance(event, CloseConnection):
-                    self._remote_shutdown = True
-                    await self.close()
-                    return None
-                elif isinstance(event, Ping):
-                    try:
-                        data_to_send: bytes = self._protocol.send(event.response())
-                    except WebSocketProtocolError as e:
-                        await self.close()
-                        raise ProtocolError from e
-
-                    async with self._write_error_catcher():
-                        await self._dsa.sendall(data_to_send)
-
-            while True:
-                async with self._read_error_catcher():
-                    data, eot, _ = await self._dsa.recv_extended(None)
-
-                try:
-                    self._protocol.receive_data(data)
-                except WebSocketProtocolError as e:
-                    raise ProtocolError from e
-
+            # wsproto uses bare ``assert`` statements inside ``events()`` and
+            # the per-message-deflate inbound decompression to validate frame
+            # payloads. We treat such failures as a protocol violation.
+            try:
                 for event in self._protocol.events():
                     if isinstance(event, TextMessage):
                         if event.message_finished and not text_buf:
@@ -197,11 +177,59 @@ class AsyncWebSocketExtensionFromHTTP(AsyncExtensionFromHTTP):
                         await self.close()
                         return None
                     elif isinstance(event, Ping):
-                        data_to_send = self._protocol.send(event.response())
+                        try:
+                            data_to_send: bytes = self._protocol.send(event.response())
+                        except WebSocketProtocolError as e:
+                            await self.close()
+                            raise ProtocolError from e
+
                         async with self._write_error_catcher():
                             await self._dsa.sendall(data_to_send)
-                    elif isinstance(event, Pong):
-                        continue
+            except AssertionError as e:
+                await self.close()
+                raise ProtocolError from e
+
+            while True:
+                async with self._read_error_catcher():
+                    data, eot, _ = await self._dsa.recv_extended(None)
+
+                try:
+                    self._protocol.receive_data(data)
+                except WebSocketProtocolError as e:
+                    await self.close()
+                    raise ProtocolError from e
+
+                try:
+                    for event in self._protocol.events():
+                        if isinstance(event, TextMessage):
+                            if event.message_finished and not text_buf:
+                                return event.data
+                            text_buf.append(event.data)
+                            if event.message_finished:
+                                return "".join(text_buf)
+                        elif isinstance(event, BytesMessage):
+                            if event.message_finished and not bytes_buf:
+                                return event.data
+                            bytes_buf.append(event.data)
+                            if event.message_finished:
+                                return b"".join(bytes_buf)
+                        elif isinstance(event, CloseConnection):
+                            self._remote_shutdown = True
+                            await self.close()
+                            return None
+                        elif isinstance(event, Ping):
+                            try:
+                                data_to_send = self._protocol.send(event.response())
+                            except WebSocketProtocolError as e:
+                                await self.close()
+                                raise ProtocolError from e
+                            async with self._write_error_catcher():
+                                await self._dsa.sendall(data_to_send)
+                        elif isinstance(event, Pong):
+                            continue
+                except AssertionError as e:
+                    await self.close()
+                    raise ProtocolError from e
 
     async def send_payload(self, buf: str | bytes) -> None:
         """Dispatch a buffer to remote."""
@@ -209,12 +237,16 @@ class AsyncWebSocketExtensionFromHTTP(AsyncExtensionFromHTTP):
             raise OSError("The HTTP extension is closed or uninitialized")
 
         async with self._police_officer.borrow(self._response):
+            # the per-message-deflate outbound path uses a bare ``assert`` to
+            # protect against compressing a CONTINUATION frame; treat such a
+            # failure as a protocol violation.
             try:
                 if isinstance(buf, str):
                     data_to_send: bytes = self._protocol.send(TextMessage(buf))
                 else:
                     data_to_send = self._protocol.send(BytesMessage(buf))
-            except WebSocketProtocolError as e:
+            except (WebSocketProtocolError, AssertionError) as e:
+                await self.close()
                 raise ProtocolError from e
 
             async with self._write_error_catcher():
@@ -228,6 +260,7 @@ class AsyncWebSocketExtensionFromHTTP(AsyncExtensionFromHTTP):
             try:
                 data_to_send: bytes = self._protocol.send(Ping())
             except WebSocketProtocolError as e:
+                await self.close()
                 raise ProtocolError from e
 
             async with self._write_error_catcher():

--- a/src/urllib3/contrib/webextensions/ws.py
+++ b/src/urllib3/contrib/webextensions/ws.py
@@ -20,6 +20,7 @@ from wsproto.utilities import ProtocolError as WebSocketProtocolError
 
 from ...backend import HttpVersion
 from ...exceptions import ProtocolError
+from ...util.traffic_police import UnavailableTraffic
 from .protocol import ExtensionFromHTTP
 
 
@@ -110,18 +111,29 @@ class WebSocketExtensionFromHTTP(ExtensionFromHTTP):
         """End/Notify close for sub protocol."""
         if self._dsa is not None:
             if self._police_officer is not None:
-                with self._police_officer.borrow(self._response):
-                    if self._remote_shutdown is False:
-                        try:
-                            data_to_send: bytes = self._protocol.send(
-                                CloseConnection(0)
-                            )
-                        except WebSocketProtocolError:
-                            pass
-                        else:
-                            with self._write_error_catcher():
+                try:
+                    with self._police_officer.borrow(self._response):
+                        # close() must be tolerant: when the peer has already
+                        # gone (TCP FIN, half-closed stream, or a protocol
+                        # violation that tore down the underlying HTTP state
+                        # machine), every socket-touching call below can fail.
+                        if self._remote_shutdown is False:
+                            try:
+                                data_to_send: bytes = self._protocol.send(
+                                    CloseConnection(0)
+                                )
                                 self._dsa.sendall(data_to_send)
-                    self._dsa.close()
+                            except (WebSocketProtocolError, OSError, AssertionError):
+                                pass
+                        try:
+                            self._dsa.close()
+                        except (OSError, AssertionError):
+                            pass
+                        self._dsa = None
+                except UnavailableTraffic:
+                    # the underlying connection was already destroyed
+                    # (e.g. via kill_cursor() after a protocol violation).
+                    # nothing to send; just clean up local state.
                     self._dsa = None
             else:
                 self._dsa = None
@@ -144,43 +156,10 @@ class WebSocketExtensionFromHTTP(ExtensionFromHTTP):
 
         with self._police_officer.borrow(self._response):
             # we may have pending event to unpack!
-            for event in self._protocol.events():
-                if isinstance(event, TextMessage):
-                    if event.message_finished and not text_buf:
-                        return event.data
-                    text_buf.append(event.data)
-                    if event.message_finished:
-                        return "".join(text_buf)
-                elif isinstance(event, BytesMessage):
-                    if event.message_finished and not bytes_buf:
-                        return event.data
-                    bytes_buf.append(event.data)
-                    if event.message_finished:
-                        return b"".join(bytes_buf)
-                elif isinstance(event, CloseConnection):
-                    self._remote_shutdown = True
-                    self.close()
-                    return None
-                elif isinstance(event, Ping):
-                    try:
-                        data_to_send: bytes = self._protocol.send(event.response())
-                    except WebSocketProtocolError as e:
-                        self.close()
-                        raise ProtocolError from e
-
-                    with self._write_error_catcher():
-                        self._dsa.sendall(data_to_send)
-
-            while True:
-                with self._read_error_catcher():
-                    data, eot, _ = self._dsa.recv_extended(None)
-
-                try:
-                    self._protocol.receive_data(data)
-                except WebSocketProtocolError as e:
-                    self.close()
-                    raise ProtocolError from e
-
+            # wsproto uses bare ``assert`` statements inside ``events()`` and
+            # the per-message-deflate inbound decompression to validate frame
+            # payloads. We treat such failures as a protocol violation.
+            try:
                 for event in self._protocol.events():
                     if isinstance(event, TextMessage):
                         if event.message_finished and not text_buf:
@@ -200,14 +179,58 @@ class WebSocketExtensionFromHTTP(ExtensionFromHTTP):
                         return None
                     elif isinstance(event, Ping):
                         try:
-                            data_to_send = self._protocol.send(event.response())
+                            data_to_send: bytes = self._protocol.send(event.response())
                         except WebSocketProtocolError as e:
                             self.close()
                             raise ProtocolError from e
+
                         with self._write_error_catcher():
                             self._dsa.sendall(data_to_send)
-                    elif isinstance(event, Pong):
-                        continue
+            except AssertionError as e:
+                self.close()
+                raise ProtocolError from e
+
+            while True:
+                with self._read_error_catcher():
+                    data, eot, _ = self._dsa.recv_extended(None)
+
+                try:
+                    self._protocol.receive_data(data)
+                except WebSocketProtocolError as e:
+                    self.close()
+                    raise ProtocolError from e
+
+                try:
+                    for event in self._protocol.events():
+                        if isinstance(event, TextMessage):
+                            if event.message_finished and not text_buf:
+                                return event.data
+                            text_buf.append(event.data)
+                            if event.message_finished:
+                                return "".join(text_buf)
+                        elif isinstance(event, BytesMessage):
+                            if event.message_finished and not bytes_buf:
+                                return event.data
+                            bytes_buf.append(event.data)
+                            if event.message_finished:
+                                return b"".join(bytes_buf)
+                        elif isinstance(event, CloseConnection):
+                            self._remote_shutdown = True
+                            self.close()
+                            return None
+                        elif isinstance(event, Ping):
+                            try:
+                                data_to_send = self._protocol.send(event.response())
+                            except WebSocketProtocolError as e:
+                                self.close()
+                                raise ProtocolError from e
+                            with self._write_error_catcher():
+                                self._dsa.sendall(data_to_send)
+                        elif isinstance(event, Pong):
+                            continue
+                except AssertionError as e:
+                    self.close()
+                    raise ProtocolError from e
 
     def send_payload(self, buf: str | bytes) -> None:
         """Dispatch a buffer to remote."""
@@ -215,12 +238,15 @@ class WebSocketExtensionFromHTTP(ExtensionFromHTTP):
             raise OSError("The HTTP extension is closed or uninitialized")
 
         with self._police_officer.borrow(self._response):
+            # the per-message-deflate outbound path uses a bare ``assert`` to
+            # protect against compressing a CONTINUATION frame; treat such a
+            # failure as a protocol violation.
             try:
                 if isinstance(buf, str):
                     data_to_send: bytes = self._protocol.send(TextMessage(buf))
                 else:
                     data_to_send = self._protocol.send(BytesMessage(buf))
-            except WebSocketProtocolError as e:
+            except (WebSocketProtocolError, AssertionError) as e:
                 self.close()
                 raise ProtocolError from e
 

--- a/src/urllib3/util/_async/traffic_police.py
+++ b/src/urllib3/util/_async/traffic_police.py
@@ -1142,14 +1142,20 @@ class AsyncTrafficPolice(typing.Generic[T]):
             raise
         finally:
             # do not release back to the pool a broken connection
-            # we need kill_cursor() to take over soon.
+            # we need kill_cursor() to take over.
             # clean_exit=False not necessarily mean conn broken.
             # see https://github.com/jawah/urllib3.future/issues/366
             withhold_conn: bool = not clean_exit and getattr(
                 conn_or_pool, "is_closed", False
             )
 
-            if not withhold_conn and self.release():
+            if withhold_conn:
+                # killing the cursor immediately frees other coroutines waiting
+                # in locate(...) (e.g. WebSocket reconnector calling close())
+                # via UnavailableTraffic instead of letting them hang forever.
+                # see https://github.com/jawah/urllib3.future/issues/371
+                await self.kill_cursor()
+            elif self.release():
                 await asyncio.sleep(0)
 
     def release(self) -> bool:

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -266,7 +266,7 @@ try:  # Do we have ssl at all?
     SSLContext = ssl.SSLContext
     TLSVersion = ssl.TLSVersion
 
-    OP_NO_RENEGOTIATION = getattr(ssl, "OP_NO_RENEGOTIATION", None)
+    OP_NO_RENEGOTIATION = getattr(ssl, "OP_NO_RENEGOTIATION", None)  # noqa:
 
     PROTOCOL_SSLv23 = PROTOCOL_TLS
 
@@ -325,7 +325,7 @@ except ImportError:
     OP_NO_SSLv3 = 0x2000000  # type: ignore[assignment]
     PROTOCOL_SSLv23 = PROTOCOL_TLS = 2  # type: ignore[assignment]
     PROTOCOL_TLS_CLIENT = PROTOCOL_TLS
-    OP_NO_RENEGOTIATION = None
+    OP_NO_RENEGOTIATION = None  # noqa:
     SUPPORT_MIN_MAX_TLS_VERSION = False
     IS_FIPS = False
 
@@ -563,21 +563,6 @@ def create_urllib3_context(
         # there is a risk associated with it being on wire,
         # if the server is not rotating its ticketing keys properly.
         options |= OP_NO_TICKET
-
-        # Only apply if Niquests or direct urllib3-future usage
-        # Don't bother other or Requests.
-        if caller_id is None or caller_id is _KnownCaller.NIQUESTS:
-            # some may want to still enable the renegotiation due to
-            # compatibility issue. we found some old IIS server rejecting HTTP
-            # request (with close conn) when this setting is set...!
-            weak_security_set = ciphers is not None and ciphers.upper().endswith(
-                "@SECLEVEL=0"
-            )
-            # Disable renegotiation as it was proven to be weak and dangerous.
-            if (
-                OP_NO_RENEGOTIATION is not None and weak_security_set is False
-            ):  # Not always available depending on your interpreter.
-                options |= OP_NO_RENEGOTIATION
 
     context.options |= options
 

--- a/src/urllib3/util/traffic_police.py
+++ b/src/urllib3/util/traffic_police.py
@@ -979,14 +979,20 @@ class TrafficPolice(typing.Generic[T]):
             raise
         finally:
             # do not release back to the pool a broken connection
-            # we need kill_cursor() to take over soon.
+            # we need kill_cursor() to take over.
             # clean_exit=False not necessarily mean conn broken.
             # see https://github.com/jawah/urllib3.future/issues/366
             withhold_conn: bool = not clean_exit and getattr(
                 conn_or_pool, "is_closed", False
             )
 
-            if not withhold_conn:
+            if withhold_conn:
+                # killing the cursor immediately frees other threads waiting
+                # in locate(...) (e.g. WebSocket reconnector calling close())
+                # via UnavailableTraffic instead of letting them hang forever.
+                # see https://github.com/jawah/urllib3.future/issues/371
+                self.kill_cursor()
+            else:
                 self.release()
 
     def release(self) -> None:


### PR DESCRIPTION
2.20.906 (2026-05-21)
=====================

- Fixed TLS connection to some server that requires OP_NO_RENEGOTIATION enabled (legacy TLS1.2 server). (https://github.com/jawah/niquests/issues/402)
- Fixed automatic fallback to single datagram send when GSO is available for UDP I/O but the physical NIC don't support it. (#373)
- Fixed automatic fallback tls/quic to tls/tcp when the discrete upgrade failed. (#372)
- Fixed broken connection handling in (contrib) webextension wsproto that lead to hangs. (#371)
