### PR TITLE
Release 2.20.907

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.20.907 (2026-05-22)
+=====================
+
+- Fixed certs retrieval when using HTTPS proxy (Python 3.10+) in a synchronous context. (#375)
+
 2.20.906 (2026-05-21)
 =====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.20.906"
+__version__ = "2.20.907"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -557,23 +557,30 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                 ):
                     chain = self.sock.sslobj._sslobj.get_verified_chain()
 
-                    # When cert_reqs=0 CPython returns an empty dict for the peer cert.
-                    if not self.conn_info.certificate_dict and chain:
-                        self.conn_info.certificate_dict = chain[0].get_info()
+                    cert_in_chain_count: int = len(chain)
+                    parsed_certs: bool = (
+                        all(isinstance(crt, Certificate) for crt in chain)
+                        if Certificate is not None
+                        else False
+                    )
 
-                    if (
-                        len(chain) > 1
-                        and Certificate is not None
-                        and isinstance(chain[1], Certificate)
-                    ):
-                        issuer_public_bytes = chain[1].public_bytes()
-                        if isinstance(issuer_public_bytes, bytes):
-                            self.conn_info.issuer_certificate_der = issuer_public_bytes
-                        elif hasattr(ssl, "PEM_cert_to_DER_cert"):
-                            self.conn_info.issuer_certificate_der = (
-                                ssl.PEM_cert_to_DER_cert(issuer_public_bytes)
-                            )
-                        self.conn_info.issuer_certificate_dict = chain[1].get_info()  # type: ignore[assignment]
+                    if parsed_certs:
+                        if not self.conn_info.certificate_dict and cert_in_chain_count:
+                            self.conn_info.certificate_dict = chain[0].get_info()
+
+                        if cert_in_chain_count > 1:
+                            issuer_public_bytes = chain[1].public_bytes()
+                            if isinstance(issuer_public_bytes, bytes):
+                                self.conn_info.issuer_certificate_der = (
+                                    issuer_public_bytes
+                                )
+                            elif hasattr(ssl, "PEM_cert_to_DER_cert"):
+                                self.conn_info.issuer_certificate_der = (
+                                    ssl.PEM_cert_to_DER_cert(issuer_public_bytes)
+                                )
+                            self.conn_info.issuer_certificate_dict = chain[1].get_info()
+                    elif cert_in_chain_count > 1:
+                        self.conn_info.issuer_certificate_der = chain[1]
 
             if cipher_tuple:
                 self.conn_info.cipher = cipher_tuple[0]

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -598,23 +598,33 @@ class HfaceBackend(BaseBackend):
                 if hasattr(self.sock.sslobj, "get_verified_chain"):
                     chain = self.sock.sslobj.get_verified_chain()
 
-                    # When cert_reqs=0 CPython returns an empty dict for the peer cert.
-                    if not self.conn_info.certificate_dict and chain:
-                        self.conn_info.certificate_dict = chain[0].get_info()
+                    cert_in_chain_count: int = len(chain)
+                    parsed_certs: bool = (
+                        all(isinstance(crt, Certificate) for crt in chain)
+                        if Certificate is not None
+                        else False
+                    )
 
-                    if (
-                        len(chain) > 1
-                        and Certificate is not None
-                        and isinstance(chain[1], Certificate)
+                    if parsed_certs:
+                        if not self.conn_info.certificate_dict and cert_in_chain_count:
+                            self.conn_info.certificate_dict = chain[0].get_info()
+
+                        if cert_in_chain_count > 1:
+                            issuer_public_bytes = chain[1].public_bytes()
+                            if isinstance(issuer_public_bytes, bytes):
+                                self.conn_info.issuer_certificate_der = (
+                                    issuer_public_bytes
+                                )
+                            elif hasattr(ssl, "PEM_cert_to_DER_cert"):
+                                self.conn_info.issuer_certificate_der = (
+                                    ssl.PEM_cert_to_DER_cert(issuer_public_bytes)
+                                )
+                            self.conn_info.issuer_certificate_dict = chain[1].get_info()
+                    elif (
+                        cert_in_chain_count > 1
+                        and not self.conn_info.issuer_certificate_der
                     ):
-                        issuer_public_bytes = chain[1].public_bytes()
-                        if isinstance(issuer_public_bytes, bytes):
-                            self.conn_info.issuer_certificate_der = issuer_public_bytes
-                        elif hasattr(ssl, "PEM_cert_to_DER_cert"):
-                            self.conn_info.issuer_certificate_der = (
-                                ssl.PEM_cert_to_DER_cert(issuer_public_bytes)
-                            )
-                        self.conn_info.issuer_certificate_dict = chain[1].get_info()  # type: ignore[assignment]
+                        self.conn_info.issuer_certificate_der = chain[1]
 
             elif hasattr(self.sock, "getpeercert"):
                 self.conn_info.certificate_der = self.sock.getpeercert(binary_form=True)

--- a/test/with_traefik/asynchronous/test_proxy.py
+++ b/test/with_traefik/asynchronous/test_proxy.py
@@ -113,6 +113,12 @@ class TestProxyToTraefik(TraefikWithProxyTestCase):
 
                 assert resp.status == 200
                 assert conn_info is not None
+
+                if conn_info.tls_version is not None:
+                    # they all should be there (when cert_reqs != 0)
+                    assert conn_info.certificate_der is not None
+                    assert conn_info.certificate_dict is not None
+
                 svn_history.append(resp.version)
 
             assert svn_history[-1] == int(

--- a/test/with_traefik/asynchronous/test_proxy.py
+++ b/test/with_traefik/asynchronous/test_proxy.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import warnings
+
 import pytest
 
 from dummyserver.server import DEFAULT_CA
 from urllib3 import ConnectionInfo, HttpVersion, async_proxy_from_url
+from urllib3.exceptions import InsecureRequestWarning
 from urllib3.util._async.ssl_ import _SSLContextCache
 
 from .. import TraefikWithProxyTestCase
@@ -115,3 +118,31 @@ class TestProxyToTraefik(TraefikWithProxyTestCase):
             assert svn_history[-1] == int(
                 expected_max_svn.value.split("/")[-1].replace(".", "")
             )
+
+    async def test_unverified_proxy_getinfo(self) -> None:
+        async with async_proxy_from_url(
+            self.https_proxy_url,
+            cert_reqs=0,
+            resolver=self.test_async_resolver,
+        ) as http:
+            conn_info: ConnectionInfo | None = None
+
+            async def on_post_connection(o: ConnectionInfo) -> None:
+                nonlocal conn_info
+                conn_info = o
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", InsecureRequestWarning)
+                resp = await http.urlopen(
+                    "GET",
+                    f"{self.https_url}/get",
+                    retries=False,
+                    on_post_connection=on_post_connection,
+                )
+
+            assert resp.status == 200
+            assert conn_info is not None
+
+            # der leaf cert should be there
+            # no guarantees about dict parsed ones!
+            assert conn_info.certificate_der is not None

--- a/test/with_traefik/test_proxy.py
+++ b/test/with_traefik/test_proxy.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import warnings
+
 import pytest
 
 from dummyserver.server import DEFAULT_CA
 from urllib3 import ConnectionInfo, HttpVersion, proxy_from_url
+from urllib3.exceptions import InsecureRequestWarning
 from urllib3.util.ssl_ import _SSLContextCache
 
 from . import TraefikWithProxyTestCase
@@ -109,8 +112,40 @@ class TestProxyToTraefik(TraefikWithProxyTestCase):
 
                 assert resp.status == 200
                 assert conn_info is not None
+                # they all should be there (when cert_reqs != 0)
+                assert conn_info.certificate_der is not None
+                assert conn_info.certificate_dict is not None
+
                 svn_history.append(resp.version)
 
             assert svn_history[-1] == int(
                 expected_max_svn.value.split("/")[-1].replace(".", "")
             )
+
+    def test_unverified_proxy_getinfo(self) -> None:
+        with proxy_from_url(
+            self.https_proxy_url,
+            cert_reqs=0,
+            resolver=self.test_resolver,
+        ) as http:
+            conn_info: ConnectionInfo | None = None
+
+            def on_post_connection(o: ConnectionInfo) -> None:
+                nonlocal conn_info
+                conn_info = o
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", InsecureRequestWarning)
+                resp = http.urlopen(
+                    "GET",
+                    f"{self.https_url}/get",
+                    retries=False,
+                    on_post_connection=on_post_connection,
+                )
+
+            assert resp.status == 200
+            assert conn_info is not None
+
+            # der leaf cert should be there
+            # no guarantees about dict parsed ones!
+            assert conn_info.certificate_der is not None

--- a/test/with_traefik/test_proxy.py
+++ b/test/with_traefik/test_proxy.py
@@ -112,9 +112,11 @@ class TestProxyToTraefik(TraefikWithProxyTestCase):
 
                 assert resp.status == 200
                 assert conn_info is not None
-                # they all should be there (when cert_reqs != 0)
-                assert conn_info.certificate_der is not None
-                assert conn_info.certificate_dict is not None
+
+                if conn_info.tls_version is not None:
+                    # they all should be there (when cert_reqs != 0)
+                    assert conn_info.certificate_der is not None
+                    assert conn_info.certificate_dict is not None
 
                 svn_history.append(resp.version)
 


### PR DESCRIPTION
2.20.907 (2026-05-22)
=====================

- Fixed certs retrieval when using HTTPS proxy (Python 3.10+) in a synchronous context. (#375)

