### PR TITLE
fix: reset stale _svn and sock in HfaceBackend.close()

### DIFF
--- a/changelog/377.bugfix.rst
+++ b/changelog/377.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``HfaceBackend.close()`` to reset the stale HTTP/3 version flag and socket reference, preventing crashes when pooled connections were reused after closing.

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -2054,3 +2054,5 @@ class HfaceBackend(BaseBackend):
         self._dgram_gro_enabled = False
         self._dgram_gso_enabled = False
         self._ech_config = None
+        self._svn = None
+        self.sock = None


### PR DESCRIPTION
Fixes #377 