### PR TITLE
Release 2.21.900

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,26 @@ jobs:
             python-version: "3.11"
             os: windows-2025
             experimental: false
+          - traefik-server: true
+            nox-session: test_utls-3.13
+            python-version: "3.13"
+            os: ubuntu-24.04
+            experimental: false
+          - traefik-server: true
+            nox-session: test_utls-3.12
+            python-version: "3.12"
+            os: ubuntu-24.04
+            experimental: false
+          - traefik-server: true
+            nox-session: test_utls-3.11
+            python-version: "3.11"
+            os: ubuntu-24.04
+            experimental: false
+          - traefik-server: true
+            nox-session: test_utls-3.11
+            python-version: "3.11"
+            os: windows-2025
+            experimental: false
           - python-version: "pypy-3.7"
             os: ubuntu-24.04
             experimental: false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@
   streamed responses. (#379)
 - Added support for ``utls`` alternative TLS backend in addition to ``rtls``.
   ``utls`` is based on BoringSSL and have the capability to align with Google Chrome browser capabilities.
+  This new TLS backend is introduced in addition to ``rtls``. urllib3-future tries backend in given order:
+  ``rtls`` -> ``utls`` -> ``ssl``. You may override this by setting ``URLLIB3_FUTURE_SSL_BACKEND`` environment
+  variable. See the documentation to learn more.
+- Fixed handling of unsendable datagram emitted by ``qh3`` MTU discovery probe when the physical NIC can't handle
+  specific >1200 bytes datagrams. (#377)
 
 2.20.907 (2026-05-22)
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@
   variable. See the documentation to learn more.
 - Fixed handling of unsendable datagram emitted by ``qh3`` MTU discovery probe when the physical NIC can't handle
   specific >1200 bytes datagrams. (#377)
+- Fixed support for the ``truststore`` 3rd party library direct alternative to ``wassima``.
 
 2.20.907 (2026-05-22)
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.21.900 (2026-05-29)
+=====================
+
+- Fixed ``HTTPResponse.stream(amt)`` (and the async equivalent) no longer yielding per-frame for
+  streamed responses. (#379)
+- Added support for ``utls`` alternative TLS backend in addition to ``rtls``.
+  ``utls`` is based on BoringSSL and have the capability to align with Google Chrome browser capabilities.
+
 2.20.907 (2026-05-22)
 =====================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 
 - Fixed ``HTTPResponse.stream(amt)`` (and the async equivalent) no longer yielding per-frame for
   streamed responses. (#379)
+- Improved memory usage and throughput when reading response bodies by removing a redundant body
+  concatenation in the stream read path. Received frames are now buffered directly and served with
+  a zero-copy fast path for frame-aligned reads (e.g. per-frame streaming, WebSocket and SSE).
 - Added support for ``utls`` alternative TLS backend in addition to ``rtls``.
   ``utls`` is based on BoringSSL and have the capability to align with Google Chrome browser capabilities.
   This new TLS backend is introduced in addition to ``rtls``. urllib3-future tries backend in given order:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-2.21.900 (2026-05-29)
+2.21.900 (2026-05-30)
 =====================
 
 - Fixed ``HTTPResponse.stream(amt)`` (and the async equivalent) no longer yielding per-frame for
@@ -10,10 +10,13 @@
   ``utls`` is based on BoringSSL and have the capability to align with Google Chrome browser capabilities.
   This new TLS backend is introduced in addition to ``rtls``. urllib3-future tries backend in given order:
   ``rtls`` -> ``utls`` -> ``ssl``. You may override this by setting ``URLLIB3_FUTURE_SSL_BACKEND`` environment
-  variable. See the documentation to learn more.
+  variable. See the documentation to learn more. You can also pass a custom ``SSLContext`` from any
+  of those backends. We can handle multiple TLS backend at the same time within a single ``PoolManager`` instance.
 - Fixed handling of unsendable datagram emitted by ``qh3`` MTU discovery probe when the physical NIC can't handle
   specific >1200 bytes datagrams. (#377)
 - Fixed support for the ``truststore`` 3rd party library direct alternative to ``wassima``.
+  We still recommend ``wassima`` as the "OS truststore" library. It is fixed for strict BC
+  promise we made by being a "urllib3" inplace replacement.
 
 2.20.907 (2026-05-22)
 =====================

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -1659,3 +1659,80 @@ Wonder no more! starting from urllib3-future 2.12.913+ you can have a proper rep
 .. warning:: Both ``PoolManager`` and ``ConnectionPool`` have a ``TrafficPolice`` inside them.
 
 .. danger:: Calling ``repr`` here is highly discouraged at a high frequency. Do it for debug purposes only.
+
+Alternative TLS backends (``anytls``)
+-------------------------------------
+
+urllib3-future can transparently use one of three TLS backends:
+
+* ``rtls`` - Rustls with AWS-LC (`PyPI <https://pypi.org/project/rtls/>`_)
+* ``utls`` - BoringSSL (`PyPI <https://pypi.org/project/utls/>`_)
+* ``ssl``  - the Python standard library (commonly OpenSSL or LibreSSL)
+
+At import time, urllib3-future picks the best available backend, following the
+default priority order:
+
+::
+
+    rtls  ->  utls  ->  ssl
+
+You don't have to do anything to enable this. Just install the optional
+extra you want and urllib3-future will pick it up automatically:
+
+.. code-block:: bash
+
+    # Use Rustls + AWS-LC
+    pip install urllib3-future[rtls]
+
+    # Use BoringSSL
+    pip install urllib3-future[utls]
+
+Forcing a specific backend
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Set the ``URLLIB3_FUTURE_SSL_BACKEND`` environment variable to force a given
+backend. Accepted values (case-insensitive, whitespace trimmed):
+
+============================================  ===============================
+Value                                         Backend
+============================================  ===============================
+``rtls``, ``rustls``, ``aws-lc``, ``awslc``   Rustls + AWS-LC
+``utls``, ``boringssl``                       BoringSSL
+``ssl``, ``stdlib``                           Standard-library ``ssl``
+============================================  ===============================
+
+If the requested backend isn't installed, urllib3-future silently falls
+through the remaining default order. Unknown values emit a warning and use the
+default order.
+
+.. code-block:: bash
+
+    URLLIB3_FUTURE_SSL_BACKEND=ssl python my_script.py
+
+The ``anytls`` module
+~~~~~~~~~~~~~~~~~~~~~
+
+The selection logic lives in :mod:`urllib3.contrib.anytls`. The module is
+public and can be used to inspect the active backend or to perform
+backend-agnostic ``except`` clauses:
+
+.. code-block:: python
+
+    from urllib3.contrib.anytls import (
+        ssl,             # the active backend module
+        stdlib_ssl,      # always the real stdlib ``ssl`` (or None)
+        BACKEND,         # "rtls" | "utls" | "ssl" | "none"
+        HAS_SSL,         # bool - True if any ssl backend is available
+        IS_NONSTDLIB,    # bool - True for rtls or utls
+        Certificate,     # peer certificate class
+    )
+
+    print(f"using {BACKEND} TLS backend ({ssl.OPENSSL_VERSION})")
+
+Cross-backend ``SSLError``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Both ``rtls.SSLError`` and ``utls.SSLError`` subclass ``ssl.SSLError`` from
+the standard library, so ``except ssl.SSLError`` (and
+``urllib3.exceptions.BaseSSLError``) keeps working unchanged regardless of
+which backend is active.

--- a/noxfile.py
+++ b/noxfile.py
@@ -223,15 +223,12 @@ def tests_impl(
         session.run("python", "--version")
         session.run("python", "-c", "import struct; print(struct.calcsize('P') * 8)")
 
-        if "rtls" in extras or "utls" in extras:
-            session.run(
-                "python",
-                "-c",
-                "from urllib3.contrib.anytls import ssl, BACKEND; "
-                "print(BACKEND, ssl.OPENSSL_VERSION)",
-            )
-        else:
-            session.run("python", "-c", "import ssl; print(ssl.OPENSSL_VERSION)")
+        session.run(
+            "python",
+            "-c",
+            "from urllib3.contrib.anytls import ssl, BACKEND; "
+            "print(BACKEND, ssl.OPENSSL_VERSION)",
+        )
 
         # Inspired from https://hynek.me/articles/ditch-codecov-python/
         # We use parallel mode and then combine in a later CI step

--- a/noxfile.py
+++ b/noxfile.py
@@ -223,10 +223,15 @@ def tests_impl(
         session.run("python", "--version")
         session.run("python", "-c", "import struct; print(struct.calcsize('P') * 8)")
 
-        if "rtls" not in extras:
-            session.run("python", "-c", "import ssl; print(ssl.OPENSSL_VERSION)")
+        if "rtls" in extras or "utls" in extras:
+            session.run(
+                "python",
+                "-c",
+                "from urllib3.contrib.anytls import ssl, BACKEND; "
+                "print(BACKEND, ssl.OPENSSL_VERSION)",
+            )
         else:
-            session.run("python", "-c", "import rtls; print(rtls.OPENSSL_VERSION)")
+            session.run("python", "-c", "import ssl; print(ssl.OPENSSL_VERSION)")
 
         # Inspired from https://hynek.me/articles/ditch-codecov-python/
         # We use parallel mode and then combine in a later CI step
@@ -299,6 +304,24 @@ def test(session: nox.Session) -> None:
 )
 def test_rtls(session: nox.Session) -> None:
     tests_impl(session, extras="socks,brotli,zstd,ws,rtls")
+
+
+@nox.session(
+    python=[
+        "3.7",
+        "3.8",
+        "3.9",
+        "3.10",
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.13t",
+        "3.14",
+        "3.14t",
+    ]
+)
+def test_utls(session: nox.Session) -> None:
+    tests_impl(session, extras="socks,brotli,zstd,ws,utls")
 
 
 @nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"])

--- a/noxfile.py
+++ b/noxfile.py
@@ -604,6 +604,9 @@ def downstream_sphinx(session: nox.Session) -> None:
     session.install(".", "--group", "test", silent=False)
     # docutils 0.22 break two unit test of sphinx
     session.install("docutils==0.21")
+    # snowballstemmer failure due to stemWord("international")
+    # change in 3.x (nothing to do with us)
+    session.install("snowballstemmer<3")
 
     session.cd(root)
     session.install(".", silent=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,10 @@ ws = [
   "wsproto>=1.2,<2",
 ]
 rtls = [
-    "rtls; platform_python_implementation == 'CPython'"
+  "rtls; platform_python_implementation == 'CPython'",
+]
+utls = [
+  "utls; platform_python_implementation == 'CPython'",
 ]
 
 [dependency-groups]
@@ -102,7 +105,7 @@ mypy = [
   "qh3==1.8.1",
   "h11==0.14.0; python_version == '3.7'",
   "h11>=0.16.0,<1; python_version >= '3.8'",
-  "jh2==5.0.11",
+  "jh2==5.0.13",
   "wsproto==1.2.0; python_version >= '3.7' and python_version <= '3.9'",
   "wsproto>=1.3.2,<2; python_version >= '3.10'",
   "zstandard==0.21.0; python_version == '3.7'",
@@ -111,6 +114,7 @@ mypy = [
   "types-PySocks==1.7.1.20251001; python_version == '3.9'",
   "types-PySocks>=1.7.1.20260408; python_version >= '3.10'",
   "rtls==2026.4.24",
+  "utls==2026.5.28",
 ]
 dev = [
   {include-group = "common"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ rtls = [
 ]
 utls = [
   "utls; platform_python_implementation == 'CPython'",
+  # force zstd, and br to be part of utls group
+  # we need them as we force "Accept-Encoding: br, zstd, gzip,...)
+  "zstandard>=0.18.0; python_version < '3.14'",
+  "brotli>=1.0.9; platform_python_implementation == 'CPython'",
 ]
 
 [dependency-groups]

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -33,17 +33,7 @@ from .._constant import (
 from ..util.timeout import _DEFAULT_TIMEOUT, Timeout
 from ..util.util import to_str
 
-try:  # Compiled with SSL?
-    if typing.TYPE_CHECKING:
-        import ssl
-    else:
-        try:
-            import rtls as ssl
-        except ImportError:
-            import ssl
-
-except (ImportError, AttributeError):
-    ssl = None  # type: ignore[assignment]
+from ..contrib.anytls import ssl
 
 
 from ..backend import HttpVersion, QuicPreemptiveCacheType, ResponsePromise
@@ -67,7 +57,10 @@ from ..exceptions import (  # noqa: F401
 from ..util import SKIP_HEADER, SKIPPABLE_HEADERS
 from ..util._async.ssl_ import ssl_wrap_socket
 from ..util.request import body_to_chunks
-from ..util.ssl_ import assert_fingerprint as _assert_fingerprint, convert_ssl_ctx_rtls
+from ..util.ssl_ import (
+    assert_fingerprint as _assert_fingerprint,
+    convert_ssl_ctx_nonstdlib,
+)
 from ..util.ssl_ import (
     is_capable_for_quic,
     is_ipaddress,
@@ -762,7 +755,7 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
         ciphers: str | None = None,
     ) -> None:
         if ssl_context is not None:
-            ssl_context = convert_ssl_ctx_rtls(ssl_context)
+            ssl_context = convert_ssl_ctx_nonstdlib(ssl_context)
 
         if not is_capable_for_quic(ssl_context, ssl_maximum_version):
             if disabled_svn is None:

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -1364,6 +1364,20 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
         else:
             extension = None
 
+        # utls -- BoringSSL have predefined headers
+        # that we automatically insert.
+        if conn_info is not None and conn_info.tls_version is not None:
+            ssl_ctx: ssl.SSLContext | None = getattr(conn.sock, "context", None)
+
+            if ssl_ctx is not None and hasattr(ssl_ctx, "http_header_for_fingerprint"):
+                try:
+                    prefixed_headers = ssl_ctx.http_header_for_fingerprint()
+                    prefixed_headers.update(headers)
+
+                    headers = prefixed_headers
+                except ValueError:  # We can forbid it entirely
+                    pass
+
         try:
             rp = await conn.request(
                 method,

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -1375,9 +1375,10 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
                         ssl_ctx.http_header_for_fingerprint()
                     )
 
-                    # user specified headers always win.
-                    for k, v in headers.items():
-                        prefixed_headers[k] = v
+                    if headers is not None:
+                        # user specified headers always win.
+                        for k, v in headers.items():
+                            prefixed_headers[k] = v
 
                     headers = prefixed_headers
                 except ValueError:  # We can forbid it entirely

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -1371,8 +1371,13 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
 
             if ssl_ctx is not None and hasattr(ssl_ctx, "http_header_for_fingerprint"):
                 try:
-                    prefixed_headers = ssl_ctx.http_header_for_fingerprint()
-                    prefixed_headers.update(headers)
+                    prefixed_headers = HTTPHeaderDict(
+                        ssl_ctx.http_header_for_fingerprint()
+                    )
+
+                    # user specified headers always win.
+                    for k, v in headers.items():
+                        prefixed_headers[k] = v
 
                     headers = prefixed_headers
                 except ValueError:  # We can forbid it entirely

--- a/src/urllib3/_async/response.py
+++ b/src/urllib3/_async/response.py
@@ -426,6 +426,21 @@ class AsyncHTTPResponse(HTTPResponse):
         decode_content: bool | None = None,
         cache_content: bool = False,
     ) -> bytes:
+        return await self._read(
+            amt=amt,
+            decode_content=decode_content,
+            cache_content=cache_content,
+        )
+
+    async def _read(  # type: ignore[override]
+        self,
+        amt: int | None = None,
+        decode_content: bool | None = None,
+        cache_content: bool = False,
+        *,
+        partial: bool = False,
+    ) -> bytes:
+        # See ``HTTPResponse._read`` for the meaning of ``partial`` (issue #379).
         try:
             self._init_decoder()
             if decode_content is None:
@@ -535,7 +550,10 @@ class AsyncHTTPResponse(HTTPResponse):
                 )
                 self._decoded_buffer.put(decoded_data)
 
-                while len(self._decoded_buffer) < amt and data:
+                surface_per_frame = partial and hasattr(self._fp, "_eot")
+                while (
+                    len(self._decoded_buffer) < amt and data and not surface_per_frame
+                ):
                     # TODO make sure to initially read enough data to get past the headers
                     # For example, the GZ file header takes 10 bytes, we don't want to read
                     # it one byte at a time
@@ -582,7 +600,9 @@ class AsyncHTTPResponse(HTTPResponse):
             or self._decoded_buffer
             or (self._decoder and self._decoder.has_unconsumed_tail)
         ):
-            data = await self.read(amt=amt, decode_content=decode_content)
+            data = await self._read(
+                amt=amt, decode_content=decode_content, partial=True
+            )
 
             if data:
                 yield data

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.20.907"
+__version__ = "2.21.900"

--- a/src/urllib3/backend/_async/_base.py
+++ b/src/urllib3/backend/_async/_base.py
@@ -14,7 +14,7 @@ class AsyncDirectStreamAccess:
         stream_id: int,
         read: typing.Callable[
             [int | None, int | None, bool, bool],
-            typing.Awaitable[tuple[bytes, bool, HTTPHeaderDict | None]],
+            typing.Awaitable[tuple[list[bytes], bool, HTTPHeaderDict | None]],
         ]
         | None = None,
         write: typing.Callable[[bytes, int, bool], typing.Awaitable[None]]
@@ -23,6 +23,9 @@ class AsyncDirectStreamAccess:
         self._stream_id = stream_id
         self._read = read
         self._write = write
+
+        self._buffer: BytesQueueBuffer = BytesQueueBuffer()
+        self._eot: bool = False
 
     @property
     def closed(self) -> bool:
@@ -65,12 +68,29 @@ class AsyncDirectStreamAccess:
         if self._read is None:
             raise OSError("stream closed error")
 
-        data, eot, trailers = await self._read(
-            __bufsize,
-            self._stream_id,
-            __bufsize is not None,
-            False,
-        )
+        trailers = None
+
+        # Only hit the wire when we have nothing buffered to satisfy the
+        # caller; otherwise serve leftover frames first.
+        if not self._eot and not self._buffer:
+            chunks, self._eot, trailers = await self._read(
+                __bufsize,
+                self._stream_id,
+                __bufsize is not None,
+                False,
+            )
+            self._buffer.put_many(chunks)
+
+        if self._buffer:
+            data = self._buffer.get(
+                __bufsize
+                if __bufsize is not None and __bufsize > 0
+                else len(self._buffer)
+            )
+        else:
+            data = b""
+
+        eot = self._eot and not self._buffer
 
         if eot:
             self._read = None
@@ -115,7 +135,7 @@ class AsyncLowLevelResponse:
     __internal_read_st: (
         typing.Callable[
             [int | None, int | None],
-            typing.Awaitable[tuple[bytes, bool, HTTPHeaderDict | None]],
+            typing.Awaitable[tuple[list[bytes], bool, HTTPHeaderDict | None]],
         ]
         | None
     )
@@ -129,7 +149,7 @@ class AsyncLowLevelResponse:
         headers: HTTPHeaderDict,
         body: typing.Callable[
             [int | None, int | None],
-            typing.Awaitable[tuple[bytes, bool, HTTPHeaderDict | None]],
+            typing.Awaitable[tuple[list[bytes], bool, HTTPHeaderDict | None]],
         ]
         | None,
         *,
@@ -228,15 +248,19 @@ class AsyncLowLevelResponse:
         )
 
         if self._eot is False and not data_ready_to_go:
-            data, self._eot, self.trailers = await self.__internal_read_st(
+            chunks, self._eot, self.trailers = await self.__internal_read_st(
                 __size, self._stream_id
             )
 
-            self.__buffer_excess.put(data)
+            self.__buffer_excess.put_many(chunks)
             buf_capacity = len(self.__buffer_excess)
 
-        data = self.__buffer_excess.get(
-            __size if __size is not None and __size > 0 else buf_capacity
+        data = (
+            self.__buffer_excess.get(
+                __size if __size is not None and __size > 0 else buf_capacity
+            )
+            if buf_capacity
+            else b""
         )
 
         size_in = len(data)

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -730,11 +730,11 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         self._stream_id = self._protocol.get_available_stream_id()
 
         req_context = [
+            (b":method", b"CONNECT"),
             (
                 b":authority",
                 f"{self._tunnel_host}:{self._tunnel_port}".encode("ascii"),
             ),
-            (b":method", b"CONNECT"),
         ]
 
         for header, value in self._tunnel_headers.items():
@@ -1178,11 +1178,6 @@ class AsyncHfaceBackend(AsyncBaseBackend):
 
         self.__headers = [
             (b":method", method.encode("ascii")),
-            (
-                b":scheme",
-                self.scheme.encode("ascii"),
-            ),
-            (b":path", url.encode("ascii")),
         ]
 
         if not skip_host:
@@ -1197,6 +1192,16 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                 ),
             )
             self.__authority_bit_set = True
+
+        self.__headers.extend(
+            [
+                (
+                    b":scheme",
+                    self.scheme.encode("ascii"),
+                ),
+                (b":path", url.encode("ascii")),
+            ]
+        )
 
         if not skip_accept_encoding:
             self.__headers.append(

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -7,28 +7,7 @@ from datetime import datetime, timezone
 from socket import SOCK_DGRAM, SOCK_STREAM
 from socket import timeout as SocketTimeout
 
-try:  # Compiled with SSL?
-    if typing.TYPE_CHECKING:
-        import ssl
-    else:
-        try:
-            import rtls as ssl
-        except ImportError:
-            import ssl
-except (ImportError, AttributeError):
-    ssl = None  # type: ignore[assignment]
-
-
-try:  # We shouldn't do this, it is private. Only for chain extraction check. We should find another way.
-    if typing.TYPE_CHECKING:
-        from _ssl import Certificate
-    else:
-        from rtls import Certificate
-except ImportError:
-    try:
-        from _ssl import Certificate
-    except (ImportError, AttributeError):
-        Certificate = None  # type: ignore[misc,assignment]
+from ...contrib.anytls import ssl, Certificate
 
 from ..._collections import HTTPHeaderDict
 from ..._constant import (

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -1464,8 +1464,14 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         __stream_id: int | None,
         __respect_end_signal: bool = True,
         __dummy_operation: bool = False,
-    ) -> tuple[bytes, bool, HTTPHeaderDict | None]:
-        """Allows us to defer the body loading after constructing the response object."""
+    ) -> tuple[list[bytes], bool, HTTPHeaderDict | None]:
+        """Allows us to defer the body loading after constructing the response object.
+
+        Returns the body as a list of per-frame chunks (not concatenated):
+        the caller feeds them straight into its ``BytesQueueBuffer`` so
+        contiguity is produced lazily and, for frame-aligned reads,
+        zero-copy. Joining here would defeat that buffer.
+        """
 
         # we may want to just remove the response as "pending"
         # e.g. HTTP Extension; making reads on sub protocol close may
@@ -1480,7 +1486,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                 # remote can refuse future inquiries, so no need to go further with this conn.
                 if self._protocol.is_idle() and self._protocol.has_expired():
                     await self.close()
-            return b"", True, None
+            return [], True, None
 
         eot = False
 
@@ -1542,10 +1548,10 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                 events.pop(idx)
 
                 if not events:
-                    return b"", True, trailers
+                    return [], True, trailers
 
         return (
-            b"".join(e.data for e in events) if len(events) > 1 else events[0].data,  # type: ignore[union-attr]
+            [e.data for e in events],  # type: ignore[union-attr]
             eot,
             trailers,
         )

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -509,10 +509,12 @@ class AsyncHfaceBackend(AsyncBaseBackend):
             cipher_tuple: tuple[str, str, int] | None = None
 
             if hasattr(self.sock, "sslobj"):
-                if hasattr(self.sock.sslobj, "ech_status"):
+                if hasattr(self.sock.sslobj, "ech_status"):  # Rustls path
                     self.conn_info.tls_ech_accepted = (
                         self.sock.sslobj.ech_status == "accepted"
                     )
+                elif hasattr(self.sock.sslobj, "ech_accepted"):  # BoringSSL path
+                    self.conn_info.tls_ech_accepted = self.sock.sslobj.ech_accepted()
                 else:
                     self.conn_info.tls_ech_accepted = False
 

--- a/src/urllib3/backend/_base.py
+++ b/src/urllib3/backend/_base.py
@@ -99,7 +99,7 @@ class DirectStreamAccess:
         stream_id: int,
         read: typing.Callable[
             [int | None, int | None, bool, bool],
-            tuple[bytes, bool, HTTPHeaderDict | None],
+            tuple[list[bytes], bool, HTTPHeaderDict | None],
         ]
         | None = None,
         write: typing.Callable[[bytes, int, bool], None] | None = None,
@@ -109,12 +109,18 @@ class DirectStreamAccess:
         if read is not None:
             self._read: (
                 typing.Callable[
-                    [int | None, bool], tuple[bytes, bool, HTTPHeaderDict | None]
+                    [int | None, bool], tuple[list[bytes], bool, HTTPHeaderDict | None]
                 ]
                 | None
             ) = lambda amt, fo: read(amt, self._stream_id, amt is not None, fo)
         else:
             self._read = None
+
+        # Per-frame chunks are buffered here so a frame-aligned ``recv``
+        # returns the protocol's original bytes object zero-copy (instead
+        # of eagerly concatenating every frame on each call).
+        self._buffer: BytesQueueBuffer = BytesQueueBuffer()
+        self._eot: bool = False
 
         if write is not None:
             self._write: typing.Callable[[bytes, bool], None] | None = lambda buf, eot: (
@@ -164,7 +170,27 @@ class DirectStreamAccess:
         if self._read is None:
             raise OSError("stream closed error")
 
-        data, eot, trailers = self._read(__bufsize, False)
+        trailers = None
+
+        # Only hit the wire when we have nothing buffered to satisfy the
+        # caller; otherwise serve leftover frames first.
+        if not self._eot and len(self._buffer) == 0:
+            chunks, self._eot, trailers = self._read(__bufsize, False)
+            self._buffer.put_many(chunks)
+
+        if len(self._buffer):
+            data = self._buffer.get(
+                __bufsize
+                if __bufsize is not None and __bufsize > 0
+                else len(self._buffer)
+            )
+        else:
+            data = b""
+
+        # Only signal end-of-transmission once every buffered frame has
+        # been handed out, otherwise a bounded recv() at eot would make
+        # the caller drop still-buffered bytes.
+        eot = self._eot and len(self._buffer) == 0
 
         if eot:
             self._read = None
@@ -212,7 +238,7 @@ class LowLevelResponse:
         reason: str,
         headers: HTTPHeaderDict,
         body: typing.Callable[
-            [int | None, int | None], tuple[bytes, bool, HTTPHeaderDict | None]
+            [int | None, int | None], tuple[list[bytes], bool, HTTPHeaderDict | None]
         ]
         | None,
         *,
@@ -330,15 +356,19 @@ class LowLevelResponse:
         )
 
         if self._eot is False and not data_ready_to_go:
-            data, self._eot, self.trailers = self.__internal_read_st(
+            chunks, self._eot, self.trailers = self.__internal_read_st(
                 __size, self._stream_id
             )
 
-            self.__buffer_excess.put(data)
+            self.__buffer_excess.put_many(chunks)
             buf_capacity = len(self.__buffer_excess)
 
-        data = self.__buffer_excess.get(
-            __size if __size is not None and __size > 0 else buf_capacity
+        data = (
+            self.__buffer_excess.get(
+                __size if __size is not None and __size > 0 else buf_capacity
+            )
+            if buf_capacity
+            else b""
         )
 
         size_in = len(data)

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -565,9 +565,9 @@ class HfaceBackend(BaseBackend):
                 else:
                     self.conn_info.tls_ech_accepted = False
 
-                self.conn_info.certificate_der = sslobj.getpeercert(binary_form=True)
+                self.conn_info.certificate_der = self.sock.getpeercert(binary_form=True)
                 try:
-                    self.conn_info.certificate_dict = sslobj.getpeercert(
+                    self.conn_info.certificate_dict = self.sock.getpeercert(
                         binary_form=False
                     )
                 except ValueError:

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -1594,8 +1594,14 @@ class HfaceBackend(BaseBackend):
         __stream_id: int | None,
         __respect_end_signal: bool = True,
         __dummy_operation: bool = False,
-    ) -> tuple[bytes, bool, HTTPHeaderDict | None]:
-        """Allows us to defer the body loading after constructing the response object."""
+    ) -> tuple[list[bytes], bool, HTTPHeaderDict | None]:
+        """Allows us to defer the body loading after constructing the response object.
+
+        Returns the body as a list of per-frame chunks (not concatenated):
+        the caller feeds them straight into its ``BytesQueueBuffer`` so
+        contiguity is produced lazily and, for frame-aligned reads,
+        zero-copy. Joining here would defeat that buffer.
+        """
 
         # we may want to just remove the response as "pending"
         # e.g. HTTP Extension; making reads on sub protocol close may
@@ -1610,7 +1616,7 @@ class HfaceBackend(BaseBackend):
                 # remote can refuse future inquiries, so no need to go further with this conn.
                 if self._protocol.is_idle() and self._protocol.has_expired():
                     self.close()
-            return b"", True, None
+            return [], True, None
 
         eot = False
 
@@ -1669,10 +1675,10 @@ class HfaceBackend(BaseBackend):
                 events.pop(idx)
 
                 if not events:
-                    return b"", True, trailers
+                    return [], True, trailers
 
         return (
-            b"".join(e.data for e in events) if len(events) > 1 else events[0].data,  # type: ignore[union-attr]
+            [e.data for e in events],  # type: ignore[union-attr]
             eot,
             trailers,
         )

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -553,19 +553,18 @@ class HfaceBackend(BaseBackend):
         if self._svn is not HttpVersion.h3:
             cipher_tuple: tuple[str, str, int] | None = None
 
-            if hasattr(self.sock, "sslobj"):
-                if hasattr(self.sock.sslobj, "ech_status"):
-                    self.conn_info.tls_ech_accepted = (
-                        self.sock.sslobj.ech_status == "accepted"
-                    )
+            if hasattr(self.sock, "sslobj") or hasattr(self.sock, "_sslobj"):
+                sslobj = getattr(self.sock, "sslobj", getattr(self.sock, "_sslobj"))
+                if hasattr(sslobj, "ech_status"):  # Rustls path
+                    self.conn_info.tls_ech_accepted = sslobj.ech_status == "accepted"
+                elif hasattr(sslobj, "ech_accepted"):  # BoringSSL path
+                    self.conn_info.tls_ech_accepted = sslobj.ech_accepted()
                 else:
                     self.conn_info.tls_ech_accepted = False
 
-                self.conn_info.certificate_der = self.sock.sslobj.getpeercert(
-                    binary_form=True
-                )
+                self.conn_info.certificate_der = sslobj.getpeercert(binary_form=True)
                 try:
-                    self.conn_info.certificate_dict = self.sock.sslobj.getpeercert(
+                    self.conn_info.certificate_dict = sslobj.getpeercert(
                         binary_form=False
                     )
                 except ValueError:
@@ -573,11 +572,11 @@ class HfaceBackend(BaseBackend):
                     self.conn_info.certificate_dict = None
 
                 self.conn_info.destination_address = None
-                cipher_tuple = self.sock.sslobj.cipher()
+                cipher_tuple = sslobj.cipher()
 
                 # Python 3.10+
-                if hasattr(self.sock.sslobj, "get_verified_chain"):
-                    chain = self.sock.sslobj.get_verified_chain()
+                if hasattr(sslobj, "get_verified_chain"):
+                    chain = sslobj.get_verified_chain()
 
                     cert_in_chain_count: int = len(chain)
                     parsed_certs: bool = (

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -814,11 +814,11 @@ class HfaceBackend(BaseBackend):
         self._stream_id = self._protocol.get_available_stream_id()
 
         req_context = [
+            (b":method", b"CONNECT"),
             (
                 b":authority",
                 f"{self._tunnel_host}:{self._tunnel_port}".encode("ascii"),
             ),
-            (b":method", b"CONNECT"),
         ]
 
         for header, value in self._tunnel_headers.items():
@@ -1297,11 +1297,6 @@ class HfaceBackend(BaseBackend):
 
         self.__headers = [
             (b":method", method.encode("ascii")),
-            (
-                b":scheme",
-                self.scheme.encode("ascii"),
-            ),
-            (b":path", url.encode("ascii")),
         ]
 
         if not skip_host:
@@ -1315,6 +1310,16 @@ class HfaceBackend(BaseBackend):
                 ),
             )
             self.__authority_bit_set = True
+
+        self.__headers.extend(
+            [
+                (
+                    b":scheme",
+                    self.scheme.encode("ascii"),
+                ),
+                (b":path", url.encode("ascii")),
+            ]
+        )
 
         if not skip_accept_encoding:
             self.__headers.append(

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -944,6 +944,8 @@ class HfaceBackend(BaseBackend):
         gso_enabled = self._dgram_gso_enabled
         gro_enabled = self._dgram_gro_enabled
         blocksize = self.blocksize
+        is_quic = self._svn is HttpVersion.h3
+
         _has_next_timer = hasattr(protocol, "next_timer")
         _proto_exc = protocol.exceptions()
 
@@ -970,7 +972,10 @@ class HfaceBackend(BaseBackend):
                     data_out = protocol.bytes_to_send()
                     if not data_out:
                         break
-                    sync_send_dgram(sock, data_out)
+                    if is_quic:
+                        sync_send_dgram(sock, data_out)
+                    else:
+                        sock.sendall(data_out)
 
         if maximal_data_in_read is not None:
             if not (maximal_data_in_read >= 0 or maximal_data_in_read == -1):
@@ -1480,11 +1485,15 @@ class HfaceBackend(BaseBackend):
                 elif tbs:
                     sync_send_dgram(self.sock, tbs[0])
             else:
+                is_quic = self._svn is HttpVersion.h3
                 while True:
                     buf = self._protocol.bytes_to_send()
                     if not buf:
                         break
-                    sync_send_dgram(self.sock, buf)
+                    if is_quic:
+                        sync_send_dgram(self.sock, buf)
+                    else:
+                        self.sock.sendall(buf)
         except BrokenPipeError as e:
             rp = ResponsePromise(self, self._stream_id, self.__headers)
             self._promises[rp.uid] = rp
@@ -1939,13 +1948,18 @@ class HfaceBackend(BaseBackend):
                     elif tbs:
                         sync_send_dgram(self.sock, tbs[0])
                 else:
+                    is_quic = self._svn is HttpVersion.h3
+
                     while True:
                         data_out = self._protocol.bytes_to_send()
 
                         if not data_out:
                             break
 
-                        sync_send_dgram(self.sock, data_out)
+                        if is_quic:
+                            sync_send_dgram(self.sock, data_out)
+                        else:
+                            self.sock.sendall(data_out)
             except BrokenPipeError as e:
                 remote_pipe_shutdown = e
 

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -555,7 +555,9 @@ class HfaceBackend(BaseBackend):
             cipher_tuple: tuple[str, str, int] | None = None
 
             if hasattr(self.sock, "sslobj") or hasattr(self.sock, "_sslobj"):
-                sslobj = getattr(self.sock, "sslobj", getattr(self.sock, "_sslobj"))
+                sslobj = getattr(
+                    self.sock, "sslobj", getattr(self.sock, "_sslobj", None)
+                )
                 if hasattr(sslobj, "ech_status"):  # Rustls path
                     self.conn_info.tls_ech_accepted = sslobj.ech_status == "accepted"
                 elif hasattr(sslobj, "ech_accepted"):  # BoringSSL path

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -559,15 +559,15 @@ class HfaceBackend(BaseBackend):
                     self.sock, "sslobj", getattr(self.sock, "_sslobj", None)
                 )
                 if hasattr(sslobj, "ech_status"):  # Rustls path
-                    self.conn_info.tls_ech_accepted = sslobj.ech_status == "accepted"
+                    self.conn_info.tls_ech_accepted = sslobj.ech_status == "accepted"  # type: ignore[union-attr]
                 elif hasattr(sslobj, "ech_accepted"):  # BoringSSL path
-                    self.conn_info.tls_ech_accepted = sslobj.ech_accepted()
+                    self.conn_info.tls_ech_accepted = sslobj.ech_accepted()  # type: ignore[union-attr]
                 else:
                     self.conn_info.tls_ech_accepted = False
 
-                self.conn_info.certificate_der = self.sock.getpeercert(binary_form=True)
+                self.conn_info.certificate_der = self.sock.getpeercert(binary_form=True)  # type: ignore[attr-defined]
                 try:
-                    self.conn_info.certificate_dict = self.sock.getpeercert(
+                    self.conn_info.certificate_dict = self.sock.getpeercert(  # type: ignore[attr-defined]
                         binary_form=False
                     )
                 except ValueError:
@@ -575,11 +575,11 @@ class HfaceBackend(BaseBackend):
                     self.conn_info.certificate_dict = None
 
                 self.conn_info.destination_address = None
-                cipher_tuple = sslobj.cipher()
+                cipher_tuple = sslobj.cipher()  # type: ignore[union-attr]
 
                 # Python 3.10+
                 if hasattr(sslobj, "get_verified_chain"):
-                    chain = sslobj.get_verified_chain()
+                    chain = sslobj.get_verified_chain()  # type: ignore[union-attr]
 
                     cert_in_chain_count: int = len(chain)
                     parsed_certs: bool = (

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -49,6 +49,7 @@ from ..contrib.ssa._gro import (
     _sock_has_gro,
     _sock_has_gso,
     sync_recv_gro,
+    sync_send_dgram,
     sync_sendmsg_gso,
 )
 from ..exceptions import (
@@ -959,15 +960,15 @@ class HfaceBackend(BaseBackend):
                     except GenericSegmentOffloadUnsupported:
                         self._dgram_gso_enabled = gso_enabled = False
                         for dgram in tbs:
-                            sock.sendall(dgram)
+                            sync_send_dgram(sock, dgram)
                 elif tbs:
-                    sock.sendall(tbs[0])
+                    sync_send_dgram(sock, tbs[0])
             else:
                 while True:
                     data_out = protocol.bytes_to_send()
                     if not data_out:
                         break
-                    sock.sendall(data_out)
+                    sync_send_dgram(sock, data_out)
 
         if maximal_data_in_read is not None:
             if not (maximal_data_in_read >= 0 or maximal_data_in_read == -1):
@@ -1473,15 +1474,15 @@ class HfaceBackend(BaseBackend):
                     except GenericSegmentOffloadUnsupported:
                         self._dgram_gso_enabled = False
                         for dgram in tbs:
-                            self.sock.sendall(dgram)
+                            sync_send_dgram(self.sock, dgram)
                 elif tbs:
-                    self.sock.sendall(tbs[0])
+                    sync_send_dgram(self.sock, tbs[0])
             else:
                 while True:
                     buf = self._protocol.bytes_to_send()
                     if not buf:
                         break
-                    self.sock.sendall(buf)
+                    sync_send_dgram(self.sock, buf)
         except BrokenPipeError as e:
             rp = ResponsePromise(self, self._stream_id, self.__headers)
             self._promises[rp.uid] = rp
@@ -1926,9 +1927,9 @@ class HfaceBackend(BaseBackend):
                         except GenericSegmentOffloadUnsupported:
                             self._dgram_gso_enabled = False
                             for dgram in tbs:
-                                self.sock.sendall(dgram)
+                                sync_send_dgram(self.sock, dgram)
                     elif tbs:
-                        self.sock.sendall(tbs[0])
+                        sync_send_dgram(self.sock, tbs[0])
                 else:
                     while True:
                         data_out = self._protocol.bytes_to_send()
@@ -1936,7 +1937,7 @@ class HfaceBackend(BaseBackend):
                         if not data_out:
                             break
 
-                        self.sock.sendall(data_out)
+                        sync_send_dgram(self.sock, data_out)
             except BrokenPipeError as e:
                 remote_pipe_shutdown = e
 

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -9,31 +9,12 @@ from functools import lru_cache
 from socket import SOCK_DGRAM, SOCK_STREAM
 from socket import timeout as SocketTimeout
 
-try:  # Compiled with SSL?
-    if typing.TYPE_CHECKING:
-        import ssl
-    else:
-        try:
-            import rtls as ssl
-        except ImportError:
-            import ssl
+from ..contrib.anytls import ssl, Certificate
 
+if ssl is not None:
     from ..util.ssltransport import SSLTransport
-except (ImportError, AttributeError):
-    ssl = None  # type: ignore[assignment]
+else:
     SSLTransport = None  # type: ignore
-
-
-try:  # We shouldn't do this, it is private. Only for chain extraction check. We should find another way.
-    if typing.TYPE_CHECKING:
-        from _ssl import Certificate
-    else:
-        from rtls import Certificate
-except ImportError:
-    try:
-        from _ssl import Certificate
-    except (ImportError, AttributeError):
-        Certificate = None  # type: ignore[misc,assignment]
 
 from .._collections import HTTPHeaderDict
 from .._constant import (
@@ -661,7 +642,7 @@ class HfaceBackend(BaseBackend):
                             self.conn_info.issuer_certificate_der = (
                                 ssl.PEM_cert_to_DER_cert(issuer_public_bytes)
                             )
-                        self.conn_info.issuer_certificate_dict = chain[1].get_info()  # type: ignore[assignment]
+                        self.conn_info.issuer_certificate_dict = chain[1].get_info()
 
             if cipher_tuple:
                 self.conn_info.cipher = cipher_tuple[0]

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -32,17 +32,7 @@ from .response import HTTPResponse
 from .util.timeout import _DEFAULT_TIMEOUT, Timeout
 from .util.util import to_str
 
-try:  # Compiled with SSL?
-    if typing.TYPE_CHECKING:
-        import ssl
-    else:
-        try:
-            import rtls as ssl
-        except ImportError:
-            import ssl
-
-except (ImportError, AttributeError):
-    ssl = None  # type: ignore[assignment]
+from .contrib.anytls import ssl
 
 from ._version import __version__
 from .backend import HfaceBackend, HttpVersion, QuicPreemptiveCacheType, ResponsePromise
@@ -58,7 +48,10 @@ from .exceptions import (
 )
 from .util import SKIP_HEADER, SKIPPABLE_HEADERS
 from .util.request import body_to_chunks
-from .util.ssl_ import assert_fingerprint as _assert_fingerprint, convert_ssl_ctx_rtls
+from .util.ssl_ import (
+    assert_fingerprint as _assert_fingerprint,
+    convert_ssl_ctx_nonstdlib,
+)
 from .util.ssl_ import (
     is_capable_for_quic,
     is_ipaddress,
@@ -731,7 +724,7 @@ class HTTPSConnection(HTTPConnection):
         ciphers: str | None = None,
     ) -> None:
         if ssl_context is not None:
-            ssl_context = convert_ssl_ctx_rtls(ssl_context)
+            ssl_context = convert_ssl_ctx_nonstdlib(ssl_context)
 
         if not is_capable_for_quic(ssl_context, ssl_maximum_version):
             if disabled_svn is None:

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1370,9 +1370,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                         ssl_ctx.http_header_for_fingerprint()
                     )
 
-                    # user specified headers always win.
-                    for k, v in headers.items():
-                        prefixed_headers[k] = v
+                    if headers is not None:
+                        # user specified headers always win.
+                        for k, v in headers.items():
+                            prefixed_headers[k] = v
 
                     headers = prefixed_headers
                 except ValueError:  # We can forbid it entirely

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1366,9 +1366,14 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
             if ssl_ctx is not None and hasattr(ssl_ctx, "http_header_for_fingerprint"):
                 try:
-                    prefixed_headers = ssl_ctx.http_header_for_fingerprint()
+                    prefixed_headers = HTTPHeaderDict(
+                        ssl_ctx.http_header_for_fingerprint()
+                    )
 
-                    prefixed_headers.update(headers)
+                    # user specified headers always win.
+                    for k, v in headers.items():
+                        prefixed_headers[k] = v
+
                     headers = prefixed_headers
                 except ValueError:  # We can forbid it entirely
                     pass

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1359,6 +1359,20 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         else:
             extension = None
 
+        # utls -- BoringSSL have predefined headers
+        # that we automatically insert.
+        if conn_info is not None and conn_info.tls_version is not None:
+            ssl_ctx: ssl.SSLContext | None = getattr(conn.sock, "context", None)
+
+            if ssl_ctx is not None and hasattr(ssl_ctx, "http_header_for_fingerprint"):
+                try:
+                    prefixed_headers = ssl_ctx.http_header_for_fingerprint()
+
+                    prefixed_headers.update(headers)
+                    headers = prefixed_headers
+                except ValueError:  # We can forbid it entirely
+                    pass
+
         try:
             rp = conn.request(
                 method,

--- a/src/urllib3/contrib/_socks_legacy.py
+++ b/src/urllib3/contrib/_socks_legacy.py
@@ -68,17 +68,6 @@ from ..exceptions import ConnectTimeoutError, NewConnectionError
 from ..poolmanager import PoolManager
 from ..util.url import parse_url
 
-try:
-    if typing.TYPE_CHECKING:
-        import ssl
-    else:
-        try:
-            import rtls as ssl
-        except ImportError:
-            import ssl
-except ImportError:
-    ssl = None  # type: ignore[assignment]
-
 
 class SOCKSConnection(HTTPConnection):
     """

--- a/src/urllib3/contrib/anytls/__init__.py
+++ b/src/urllib3/contrib/anytls/__init__.py
@@ -22,6 +22,7 @@ if typing.TYPE_CHECKING:
     # For static type-checkers, expose the stdlib ``ssl`` module. All three
     # backends share the same surface used by urllib3, so this is safe.
     import ssl
+
     stdlib_ssl = ssl
     Certificate: typing.Any = None
     BACKEND: str = "ssl"

--- a/src/urllib3/contrib/anytls/__init__.py
+++ b/src/urllib3/contrib/anytls/__init__.py
@@ -1,0 +1,43 @@
+"""
+urllib3.contrib.anytls
+======================
+
+Single point of resolution for the active TLS backend.
+
+This module masks the conditional ``import rtls as ssl`` / ``import utls as
+ssl`` / ``import ssl`` dance that would otherwise be duplicated in every
+module that needs TLS. It picks the best available backend at import time
+following the default priority:
+
+    rtls (Rustls + AWS-LC)  ->  utls (BoringSSL)  ->  ssl (stdlib)
+"""
+
+from __future__ import annotations
+
+import typing
+
+from ._backend import _resolve
+
+if typing.TYPE_CHECKING:
+    # For static type-checkers, expose the stdlib ``ssl`` module. All three
+    # backends share the same surface used by urllib3, so this is safe.
+    import ssl
+    stdlib_ssl = ssl
+    Certificate: typing.Any = None
+    BACKEND: str = "ssl"
+    HAS_SSL: bool = True
+    IS_NONSTDLIB: bool = False
+else:
+    ssl, stdlib_ssl, BACKEND, Certificate = _resolve()
+    HAS_SSL = ssl is not None
+    IS_NONSTDLIB = BACKEND in ("rtls", "utls")
+
+
+__all__ = (
+    "ssl",
+    "stdlib_ssl",
+    "BACKEND",
+    "HAS_SSL",
+    "IS_NONSTDLIB",
+    "Certificate",
+)

--- a/src/urllib3/contrib/anytls/_backend.py
+++ b/src/urllib3/contrib/anytls/_backend.py
@@ -1,0 +1,119 @@
+"""Internal resolution helpers for :mod:`urllib3.contrib.anytls`."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import warnings
+from types import ModuleType
+from typing import Tuple
+
+ENV_VAR = "URLLIB3_FUTURE_SSL_BACKEND"
+
+# Default preference order.
+_DEFAULT_ORDER: Tuple[str, ...] = ("rtls", "utls", "ssl")
+
+# Map of accepted env-var tokens (lowercased, stripped) -> canonical backend.
+_TOKEN_MAP = {
+    "rtls": "rtls",
+    "rustls": "rtls",
+    "aws-lc": "rtls",
+    "aws_lc": "rtls",
+    "awslc": "rtls",
+    "utls": "utls",
+    "boringssl": "utls",
+    "boring-ssl": "utls",
+    "boring_ssl": "utls",
+    "ssl": "ssl",
+    "stdlib": "ssl",
+    "stdlib_ssl": "ssl",
+}
+
+# Mapping from canonical backend name -> import path.
+_IMPORT_NAME = {
+    "rtls": "rtls",
+    "utls": "utls",
+    "ssl": "ssl",
+}
+
+
+def _parse_pref(value: str | None) -> list[str]:
+    """Build the ordered list of backends to attempt.
+
+    The user-requested backend (if any) is tried first, then the remaining
+    defaults in the default order, de-duplicated.
+    """
+    order: list[str] = []
+
+    if value:
+        token = value.strip().lower()
+        if token in _TOKEN_MAP:
+            order.append(_TOKEN_MAP[token])
+        elif token:
+            warnings.warn(
+                f"Unknown value {value!r} for environment variable "
+                f"{ENV_VAR}; falling back to default backend resolution "
+                f"order (rtls -> utls -> ssl).",
+                stacklevel=3,
+            )
+
+    for name in _DEFAULT_ORDER:
+        if name not in order:
+            order.append(name)
+
+    return order
+
+
+def _try_import(name: str) -> ModuleType | None:
+    try:
+        return importlib.import_module(_IMPORT_NAME[name])
+    except ImportError:
+        return None
+    except Exception:
+        # Defensive: a broken backend (e.g. missing native lib) must not
+        # crash urllib3 import; treat as unavailable.
+        return None
+
+
+def _load_certificate(backend: str) -> object | None:
+    """Best-effort import of the Certificate type used for peer-cert chain
+    extraction. rtls/utls expose it directly; for stdlib ssl, fall back to the
+    private ``_ssl.Certificate`` (used by ``backend/hface.py``).
+    """
+    if backend in ("rtls", "utls"):
+        try:
+            mod = importlib.import_module(backend)
+            return getattr(mod, "Certificate", None)
+        except ImportError:
+            return None
+    try:
+        _ssl = importlib.import_module("_ssl")
+        return getattr(_ssl, "Certificate", None)
+    except (ImportError, AttributeError):
+        return None
+
+
+def _resolve() -> tuple[ModuleType | None, ModuleType | None, str, object | None]:
+    """Resolve and return (ssl, stdlib_ssl, BACKEND, Certificate)."""
+    try:
+        stdlib_ssl: ModuleType | None = importlib.import_module("ssl")
+    except ImportError:
+        stdlib_ssl = None
+
+    order = _parse_pref(os.environ.get(ENV_VAR))
+
+    chosen_name = "none"
+    chosen_mod: ModuleType | None = None
+
+    for name in order:
+        mod = _try_import(name)
+        if mod is not None:
+            chosen_name = name
+            chosen_mod = mod
+            break
+
+    if chosen_mod is None:
+        return None, stdlib_ssl, "none", None
+
+    certificate = _load_certificate(chosen_name)
+    return chosen_mod, stdlib_ssl, chosen_name, certificate

--- a/src/urllib3/contrib/hface/protocols/http2/_h2.py
+++ b/src/urllib3/contrib/hface/protocols/http2/_h2.py
@@ -27,6 +27,8 @@ import jh2.events  # type: ignore
 import jh2.exceptions  # type: ignore
 import jh2.settings  # type: ignore
 
+from jh2 import __version__ as jh2_version
+
 from ..._stream_matrix import StreamMatrix
 from ..._typing import HeadersType
 from ...events import (
@@ -40,6 +42,15 @@ from ...events import (
     StreamResetReceived,
 )
 from .._protocols import HTTP2Protocol
+
+
+# h2 state machine had a couple of issues
+# we were locked in on some settings and
+# attempting to change them resulted in weird
+# issues. see https://github.com/jawah/h2/releases/tag/v5.0.12
+JH2_NOT_RFC_COMPLIANT_SETTINGS: bool = tuple(
+    int(p) for p in jh2_version.split(".", maxsplit=3)[:3]
+) <= (5, 0, 11)
 
 
 class _PatchedH2Connection(jh2.connection.H2Connection):  # type: ignore[misc]
@@ -56,13 +67,21 @@ class _PatchedH2Connection(jh2.connection.H2Connection):  # type: ignore[misc]
         super().__init__(config=config)
         # by default CONNECT is disabled
         # we need it to support natively WebSocket over HTTP/2 for example.
-        self.local_settings = jh2.settings.Settings(
-            client=True,
-            initial_values={
+        if not JH2_NOT_RFC_COMPLIANT_SETTINGS:
+            initial_settings = {
+                jh2.settings.SettingCodes.HEADER_TABLE_SIZE: 65536,
+                jh2.settings.SettingCodes.ENABLE_PUSH: 0,  # we don't support it anyway for now.
+                jh2.settings.SettingCodes.INITIAL_WINDOW_SIZE: 6291456,
+                jh2.settings.SettingCodes.MAX_HEADER_LIST_SIZE: 262144,
+            }
+        else:
+            initial_settings = {
                 jh2.settings.SettingCodes.MAX_CONCURRENT_STREAMS: 100,
                 jh2.settings.SettingCodes.MAX_HEADER_LIST_SIZE: self.DEFAULT_MAX_HEADER_LIST_SIZE,
-                jh2.settings.SettingCodes.ENABLE_CONNECT_PROTOCOL: 1,
-            },
+            }
+        self.local_settings = jh2.settings.Settings(
+            client=True,
+            initial_values=initial_settings,
         )
         self._observable_impl = observable_impl
 
@@ -143,7 +162,10 @@ class HTTP2ProtocolHyperImpl(HTTP2Protocol):
         )
         self._open_stream_count: int = 0
         self._connection.initiate_connection()
-        self._connection.increment_flow_control_window(2**24)
+        if JH2_NOT_RFC_COMPLIANT_SETTINGS:
+            self._connection.increment_flow_control_window(2**24)
+        else:
+            self._connection.increment_flow_control_window(15663105)
         self._events: StreamMatrix = StreamMatrix()
         self._terminated: bool = False
         self._goaway_to_honor: bool = False
@@ -193,7 +215,6 @@ class HTTP2ProtocolHyperImpl(HTTP2Protocol):
         self, stream_id: int, headers: HeadersType, end_stream: bool = False
     ) -> None:
         self._connection.send_headers(stream_id, headers, end_stream)
-        self._connection.increment_flow_control_window(2**24, stream_id=stream_id)
         self._open_stream_count += 1
 
     def submit_data(

--- a/src/urllib3/contrib/resolver/_async/doq/_qh3.py
+++ b/src/urllib3/contrib/resolver/_async/doq/_qh3.py
@@ -4,13 +4,7 @@ import asyncio
 import socket
 import typing
 
-if typing.TYPE_CHECKING:
-    import ssl
-else:
-    try:
-        import rtls as ssl
-    except ImportError:
-        import ssl
+from ....anytls import ssl
 from collections import deque
 
 from time import time as monotonic

--- a/src/urllib3/contrib/resolver/doq/_qh3.py
+++ b/src/urllib3/contrib/resolver/doq/_qh3.py
@@ -3,13 +3,7 @@ from __future__ import annotations
 import socket
 import typing
 
-if typing.TYPE_CHECKING:
-    import ssl
-else:
-    try:
-        import rtls as ssl
-    except ImportError:
-        import ssl
+from ...anytls import ssl
 from collections import deque
 
 from time import time as monotonic

--- a/src/urllib3/contrib/resolver/doq/_qh3.py
+++ b/src/urllib3/contrib/resolver/doq/_qh3.py
@@ -26,6 +26,7 @@ from ...ssa._gro import (
     _sock_has_gro,
     _sock_has_gso,
     sync_recv_gro,
+    sync_send_dgram,
     sync_sendmsg_gso,
 )
 from ..dou import PlainResolver
@@ -159,10 +160,10 @@ class QUICResolver(PlainResolver):
                         except GenericSegmentOffloadUnsupported:
                             self._dgram_gso_enabled = False
                             for datagram in datagrams:
-                                self._socket.sendall(datagram[0])
+                                sync_send_dgram(self._socket, datagram[0])
                     else:
                         for datagram in datagrams:
-                            self._socket.sendall(datagram[0])
+                            sync_send_dgram(self._socket, datagram[0])
 
                 self._socket.close()
                 self._terminated = True
@@ -287,10 +288,10 @@ class QUICResolver(PlainResolver):
                     except GenericSegmentOffloadUnsupported:
                         self._dgram_gso_enabled = False
                         for dg in datagrams:
-                            self._socket.sendall(dg[0])
+                            sync_send_dgram(self._socket, dg[0])
                 else:
                     for dg in datagrams:
-                        self._socket.sendall(dg[0])
+                        sync_send_dgram(self._socket, dg[0])
 
         responses: list[DomainNameServerReturn] = []
 
@@ -490,10 +491,10 @@ class QUICResolver(PlainResolver):
                     except GenericSegmentOffloadUnsupported:
                         self._dgram_gso_enabled = gso_enabled = False
                         for datagram in datagrams:
-                            sock.sendall(datagram[0])
+                            sync_send_dgram(sock, datagram[0])
                 else:
                     for datagram in datagrams:
-                        sock.sendall(datagram[0])
+                        sync_send_dgram(sock, datagram[0])
 
         while True:
             if receive_first is False:
@@ -510,10 +511,10 @@ class QUICResolver(PlainResolver):
                         except GenericSegmentOffloadUnsupported:
                             self._dgram_gso_enabled = gso_enabled = False
                             for datagram in datagrams:
-                                sock.sendall(datagram[0])
+                                sync_send_dgram(sock, datagram[0])
                     else:
                         for datagram in datagrams:
-                            sock.sendall(datagram[0])
+                            sync_send_dgram(sock, datagram[0])
 
             events = []
 
@@ -558,10 +559,10 @@ class QUICResolver(PlainResolver):
                             except GenericSegmentOffloadUnsupported:
                                 self._dgram_gso_enabled = gso_enabled = False
                                 for datagram in datagrams:
-                                    sock.sendall(datagram[0])
+                                    sync_send_dgram(sock, datagram[0])
                         else:
                             for datagram in datagrams:
-                                sock.sendall(datagram[0])
+                                sync_send_dgram(sock, datagram[0])
 
                 for ev in iter(quic.next_event, None):
                     if isinstance(ev, ConnectionTerminated):

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -106,17 +106,6 @@ if not BYPASS_SOCKS_LEGACY:
     from ..poolmanager import PoolManager
     from ..util.url import parse_url
 
-    try:
-        if typing.TYPE_CHECKING:
-            import ssl
-        else:
-            try:
-                import rtls as ssl
-            except ImportError:
-                import ssl
-    except ImportError:
-        ssl = None  # type: ignore[assignment]
-
     class SOCKSConnection(HTTPConnection):  # type: ignore[no-redef]
         """
         A plain-text HTTP connection that connects via a SOCKS proxy.

--- a/src/urllib3/contrib/ssa/_gro.py
+++ b/src/urllib3/contrib/ssa/_gro.py
@@ -26,6 +26,7 @@ __all__ = (
     "open_dgram_connection",
     "sync_recv_gro",
     "sync_sendmsg_gso",
+    "sync_send_dgram",
     "GenericSegmentOffloadUnsupported",
     "DatagramReader",
     "DatagramWriter",
@@ -251,6 +252,50 @@ _GSO_UNSUPPORTED_ERRNOS: typing.Final = frozenset(
 )
 
 
+# Errnos returned when a datagram is larger than the path/link MTU allows
+# and cannot be fragmented. qh3 performs Datagram Packetization Layer Path
+# MTU Discovery (DPLPMTUD) by emitting PING probe datagrams of increasing
+# size; an oversized probe is expected to bounce with ``EMSGSIZE``.
+_MSG_TOO_BIG_ERRNOS: typing.Final = frozenset(
+    e
+    for e in (
+        getattr(errno, "EMSGSIZE", None),
+        getattr(errno, "WSAEMSGSIZE", None),
+    )
+    if e is not None
+)
+
+# Windows surfaces "message too long" as WSAEMSGSIZE (10040) through the
+# ``winerror`` attribute as well, so account for it explicitly.
+_WSAEMSGSIZE_WINERROR: typing.Final = 10040
+
+
+def _is_msg_too_big(exc: OSError) -> bool:
+    """Return True when *exc* means the datagram exceeded the path MTU."""
+    if exc.errno in _MSG_TOO_BIG_ERRNOS:
+        return True
+    return getattr(exc, "winerror", None) == _WSAEMSGSIZE_WINERROR
+
+
+def sync_send_dgram(sock: socket.socket, data: bytes) -> None:
+    """Send a single datagram, dropping it if it is oversized.
+
+    A datagram the kernel rejects with ``EMSGSIZE`` is silently dropped:
+    it is an over-large qh3 DPLPMTUD probe that is meant to fail, not a
+    fatal connection error (see issue #377). Any other error propagates.
+
+    ``send`` (not ``sendall``) is used deliberately: a UDP datagram is
+    sent atomically, so the stream-oriented retry loop of ``sendall``
+    would be meaningless here (and would re-send a leftover tail as a
+    corrupt second datagram if it ever triggered).
+    """
+    try:
+        sock.send(data)
+    except OSError as exc:
+        if not _is_msg_too_big(exc):
+            raise
+
+
 def sync_sendmsg_gso(sock: socket.socket, datagrams: list[bytes]) -> None:
     """Batch-send datagrams using GSO. Falls back to individual sends.
 
@@ -264,7 +309,12 @@ def sync_sendmsg_gso(sock: socket.socket, datagrams: list[bytes]) -> None:
     """
     for segment_size, group in _group_by_segment_size(datagrams):
         if len(group) == 1:
-            sock.send(group[0])
+            try:
+                sock.send(group[0])
+            except OSError as exc:
+                # Oversized DPLPMTUD probe -- drop it (issue #377).
+                if not _is_msg_too_big(exc):
+                    raise
             continue
         try:
             # Passing the iov as multiple buffers lets the kernel
@@ -277,10 +327,18 @@ def sync_sendmsg_gso(sock: socket.socket, datagrams: list[bytes]) -> None:
         except OSError as exc:
             if exc.errno in _GSO_UNSUPPORTED_ERRNOS:
                 raise GenericSegmentOffloadUnsupported() from exc
-            # Other transient errors (e.g. interface MTU change): fall
-            # back to one-by-one for this batch but keep GSO enabled.
+            # The batch was rejected. This can be a transient error (e.g.
+            # interface MTU change) or an oversized DPLPMTUD probe segment
+            # (EMSGSIZE). Fall back to one-by-one for this batch -- keeping
+            # GSO enabled -- so that only the genuinely oversized datagram
+            # is dropped and any legal (e.g. short trailing) segment in the
+            # same group is still delivered (issue #377).
             for dgram in group:
-                sock.send(dgram)
+                try:
+                    sock.send(dgram)
+                except OSError as inner:
+                    if not _is_msg_too_big(inner):
+                        raise
 
 
 # qh3 ships a Rust-native, quinn-udp backed optimized UDP I/O
@@ -514,10 +572,12 @@ class _NativeOptimizedDatagramTransport(asyncio.DatagramTransport):
             except BlockingIOError:
                 pass
             except OSError as exc:
-                self._protocol.error_received(exc)
+                if not _is_msg_too_big(exc):
+                    self._protocol.error_received(exc)
                 return
         except OSError as exc:
-            self._protocol.error_received(exc)
+            if not _is_msg_too_big(exc):
+                self._protocol.error_received(exc)
             return
 
         # Fell through with EAGAIN -- queue and arm the writer.
@@ -628,10 +688,17 @@ class _NativeOptimizedDatagramTransport(asyncio.DatagramTransport):
                                     self._queue_write(d, addr)
                             return
                         except OSError as inner:
+                            # Oversized DPLPMTUD probe: drop just this
+                            # datagram and keep going (issue #377).
+                            if _is_msg_too_big(inner):
+                                continue
                             self._protocol.error_received(inner)
                             if self._closing or self._closed:
                                 return
                 else:
+                    # Oversized probe -- drop this group (issue #377).
+                    if _is_msg_too_big(exc):
+                        continue
                     self._protocol.error_received(exc)
                     if self._closing or self._closed:
                         return
@@ -679,12 +746,15 @@ class _NativeOptimizedDatagramTransport(asyncio.DatagramTransport):
                 queue.popleft()
                 self._buffer_size -= len(data)
                 self._maybe_resume_protocol()
-                try:
-                    self._protocol.error_received(exc)
-                except (KeyboardInterrupt, SystemExit):
-                    raise
-                except BaseException:  # noqa: BLE001
-                    pass
+                # Oversized DPLPMTUD probe -- drop it without surfacing an
+                # error to the protocol (issue #377).
+                if not _is_msg_too_big(exc):
+                    try:
+                        self._protocol.error_received(exc)
+                    except (KeyboardInterrupt, SystemExit):
+                        raise
+                    except BaseException:  # noqa: BLE001
+                        pass
                 if self._closing or self._closed:
                     break
                 continue

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -16,22 +16,14 @@ if typing.TYPE_CHECKING:
     from .util.retry import Retry
 
 # Base Exceptions
-try:  # Compiled with SSL?
-    if typing.TYPE_CHECKING:
-        import ssl
-    else:
-        try:
-            import rtls as ssl
-        except ImportError:
-            import ssl
+# Use the stdlib ssl.SSLError as base so we catch both stdlib and non-stdlib
+# (rtls/utls) SSL errors. rtls.SSLError / utls.SSLError both subclass the
+# stdlib ssl.SSLError, so isinstance checks work both ways.
+from .contrib.anytls import stdlib_ssl as _stdlib_ssl
 
-    # Use the stdlib ssl.SSLError as base so we catch both stdlib and rtls SSL errors.
-    # rtls.SSLError is a subclass of ssl.SSLError, so isinstance checks work both ways.
-    import ssl as _stdlib_ssl
-
+if _stdlib_ssl is not None:
     BaseSSLError = _stdlib_ssl.SSLError
-except (ImportError, AttributeError):
-    ssl = None  # type: ignore[assignment]
+else:
 
     class BaseSSLError(BaseException):  # type: ignore[no-redef]
         pass

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -1046,6 +1046,22 @@ class HTTPResponse(io.IOBase):
             after having ``.read()`` the file object. (Overridden if ``amt`` is
             set.)
         """
+        return self._read(
+            amt=amt,
+            decode_content=decode_content,
+            cache_content=cache_content,
+        )
+
+    def _read(
+        self,
+        amt: int | None = None,
+        decode_content: bool | None = None,
+        cache_content: bool = False,
+        *,
+        partial: bool = False,
+    ) -> bytes:
+        """We need this private method to restore BC with urllib3 fast-path for streaming/chunks.
+        see https://github.com/jawah/urllib3.future/issues/379"""
         try:
             self._init_decoder()
             if decode_content is None:
@@ -1155,7 +1171,10 @@ class HTTPResponse(io.IOBase):
                 )
                 self._decoded_buffer.put(decoded_data)
 
-                while len(self._decoded_buffer) < amt and data:
+                surface_per_frame = partial and hasattr(self._fp, "_eot")
+                while (
+                    len(self._decoded_buffer) < amt and data and not surface_per_frame
+                ):
                     # TODO make sure to initially read enough data to get past the headers
                     # For example, the GZ file header takes 10 bytes, we don't want to read
                     # it one byte at a time
@@ -1218,7 +1237,7 @@ class HTTPResponse(io.IOBase):
             or len(self._decoded_buffer) > 0
             or (self._decoder and self._decoder.has_unconsumed_tail)
         ):
-            data = self.read(amt=amt, decode_content=decode_content)
+            data = self._read(amt=amt, decode_content=decode_content, partial=True)
 
             if data:
                 yield data

--- a/src/urllib3/util/_async/ssl_.py
+++ b/src/urllib3/util/_async/ssl_.py
@@ -2,20 +2,10 @@ from __future__ import annotations
 
 import io
 import os
-import typing
 import warnings
 from pathlib import Path
 
-if typing.TYPE_CHECKING:
-    import ssl
-else:
-    try:
-        import rtls as ssl
-    except ImportError:
-        try:
-            import ssl
-        except ImportError:
-            ssl = None  # type: ignore[assignment]
+from ...contrib.anytls import ssl, IS_NONSTDLIB
 
 from ...contrib.imcc import load_cert_chain as _ctx_load_cert_chain
 from ...contrib.ssa import AsyncSocket, SSLAsyncSocket
@@ -174,7 +164,7 @@ async def ssl_wrap_socket(
                 else:
                     context.load_cert_chain(certfile, keyfile, key_password)
             elif certdata and keydata:
-                if ssl is not None and "Rustls" in ssl.OPENSSL_VERSION:
+                if IS_NONSTDLIB:
                     context.load_cert_chain(certdata, keydata, key_password)
                 else:
                     try:
@@ -183,7 +173,7 @@ async def ssl_wrap_socket(
                         warnings.warn(
                             "Passing in-memory client/intermediary certificate for mTLS is unsupported on your platform. "
                             f"Reason: {e}. It will be picked out if you upgrade to a QUIC connection or if you install "
-                            "rtls alternative ssl backend.",
+                            "alternative ssl backend (rtls/utls).",
                             UserWarning,
                         )
 

--- a/src/urllib3/util/_async/ssl_.py
+++ b/src/urllib3/util/_async/ssl_.py
@@ -151,10 +151,16 @@ async def ssl_wrap_socket(
                     raise SSLError(e) from e
 
             elif hasattr(context, "load_default_certs"):
-                store_stats = context.cert_store_stats()
-                # try to load OS default certs; works well on Windows.
-                if "x509_ca" not in store_stats or not store_stats["x509_ca"]:
-                    context.load_default_certs()
+                try:
+                    store_stats = context.cert_store_stats()
+                    # try to load OS default certs; works well on Windows.
+                    if "x509_ca" not in store_stats or not store_stats["x509_ca"]:
+                        context.load_default_certs()
+                except (
+                    AttributeError,
+                    NotImplementedError,
+                ):  # Defensive: 3rd party SSLContext implementation (e.g. truststore)
+                    pass
 
             # Attempt to detect if we get the goofy behavior of the
             # keyfile being encrypted and OpenSSL asking for the

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -76,6 +76,13 @@ class BytesQueueBuffer:
         self.buffer.append(data)
         self._size += len(data)
 
+    def put_many(self, chunks: typing.Iterable[bytes | memoryview[bytes]]) -> None:
+        """Append several chunks at once, skipping empty ones."""
+        for data in chunks:
+            if data:
+                self.buffer.append(data)
+                self._size += len(data)
+
     def get(self, n: int) -> bytes:
         if n == 0:
             return b""

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -508,6 +508,18 @@ def create_urllib3_context(
     # PROTOCOL_TLS is deprecated in Python 3.10 so we always use PROTOCOL_TLS_CLIENT
     context = SSLContext(PROTOCOL_TLS_CLIENT)
 
+    # utls (BoringSSL) have a way to propose
+    # autoconfiguration of context based
+    # on latest browser specs observed
+    # over the wire.
+    should_use_browser_autoconfig: bool = (
+        hasattr(context, "set_fingerprint")
+        and ssl_minimum_version is None
+        and ssl_maximum_version is None
+        and ciphers is None
+        and options is None
+        and (ssl_version is None or ssl_version in {PROTOCOL_TLS, PROTOCOL_TLS_CLIENT})
+    )
     default_tlsv1_2: bool = False
 
     if SUPPORT_MIN_MAX_TLS_VERSION:
@@ -555,7 +567,10 @@ def create_urllib3_context(
         # if the server is not rotating its ticketing keys properly.
         options |= OP_NO_TICKET
 
-    context.options |= options
+    if should_use_browser_autoconfig:
+        context.set_fingerprint("chrome:stable")  # type: ignore[attr-defined]
+    else:
+        context.options |= options
 
     # Enable post-handshake authentication for TLS 1.3, see GH #1634. PHA is
     # necessary for conditional client cert authentication with TLS 1.3.
@@ -580,10 +595,11 @@ def create_urllib3_context(
         context.check_hostname = False
         context.verify_mode = cert_reqs  # type: ignore[assignment]
 
-    try:
-        context.hostname_checks_common_name = False
-    except AttributeError:
-        pass
+    if not should_use_browser_autoconfig:
+        try:
+            context.hostname_checks_common_name = False
+        except AttributeError:
+            pass
 
     # Enable logging of TLS session keys via defacto standard environment variable
     # 'SSLKEYLOGFILE', if the feature is available (Python 3.8+). Skip empty values.

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -762,10 +762,17 @@ def ssl_wrap_socket(
                     raise SSLError(e) from e
 
             elif hasattr(context, "load_default_certs"):
-                store_stats = context.cert_store_stats()
-                # try to load OS default certs; works well on Windows.
-                if "x509_ca" not in store_stats or not store_stats["x509_ca"]:
-                    context.load_default_certs()
+                try:
+                    store_stats = context.cert_store_stats()
+
+                    # try to load OS default certs; works well on Windows.
+                    if "x509_ca" not in store_stats or not store_stats["x509_ca"]:
+                        context.load_default_certs()
+                except (
+                    AttributeError,
+                    NotImplementedError,
+                ):  # Defensive: 3rd party like truststore(...)
+                    pass
 
             # Attempt to detect if we get the goofy behavior of the
             # keyfile being encrypted and OpenSSL asking for the

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -20,6 +20,15 @@ from ..contrib.imcc import load_cert_chain as _ctx_load_cert_chain
 from ..exceptions import ProxySchemeUnsupported, SSLError
 from .url import _BRACELESS_IPV6_ADDRZ_RE, _IPV4_RE
 
+from ..contrib.anytls import ssl, IS_NONSTDLIB
+
+if typing.TYPE_CHECKING:
+    from ssl import VerifyMode
+
+    from typing_extensions import Literal
+
+    from .ssltransport import SSLTransport as SSLTransportType
+
 SSLContext = None
 SSLTransport = None
 HAS_NEVER_CHECK_COMMON_NAME = False
@@ -226,24 +235,6 @@ def _is_has_never_check_common_name_reliable(
         is_openssl_issue_14579_fixed
         or _is_bpo_43522_fixed(implementation_name, version_info)
     )
-
-
-if typing.TYPE_CHECKING:
-    import ssl
-
-    from ssl import VerifyMode
-
-    from typing_extensions import Literal
-
-    from .ssltransport import SSLTransport as SSLTransportType
-else:
-    try:
-        import rtls as ssl
-    except ImportError:
-        try:
-            import ssl
-        except ImportError:
-            ssl = None
 
 
 # Mapping from 'ssl.PROTOCOL_TLSX' to 'TLSVersion.X'
@@ -540,7 +531,7 @@ def create_urllib3_context(
             # avoid relying on cpython default cipher list
             # and instead retrieve OpenSSL own default. This should make
             # urllib3.future less flagged by basic firewall anti-bot rules.
-            if "Rustls" not in ssl.OPENSSL_VERSION:
+            if not IS_NONSTDLIB:
                 # the cipher list only contain entries for TLS 1.2
                 # because CPython stdlib enforce TLS 1.3 ciphers automatically
                 # when it's enabled.
@@ -786,7 +777,7 @@ def ssl_wrap_socket(
                 else:
                     context.load_cert_chain(certfile, keyfile, key_password)
             elif certdata and keydata:
-                if "Rustls" in ssl.OPENSSL_VERSION:
+                if IS_NONSTDLIB:
                     context.load_cert_chain(certdata, keydata, key_password)
                 else:
                     try:
@@ -795,7 +786,7 @@ def ssl_wrap_socket(
                         warnings.warn(
                             "Passing in-memory client/intermediary certificate for mTLS is unsupported on your platform. "
                             f"Reason: {e}. It will be picked out if you upgrade to a QUIC connection or if you install "
-                            "rtls alternative ssl backend.",
+                            "alternative ssl backend (rtls/utls).",
                             UserWarning,
                         )
 
@@ -894,12 +885,19 @@ def is_capable_for_quic(
     return not quic_disable
 
 
-def convert_ssl_ctx_rtls(ctx: ssl.SSLContext) -> ssl.SSLContext:
-    """Attempt to convert stdlib SSLContext to rtls SSLContext. Best effort only."""
-    if "Rustls" not in ssl.OPENSSL_VERSION:
+def convert_ssl_ctx_nonstdlib(ctx: ssl.SSLContext) -> ssl.SSLContext:
+    """Attempt to convert stdlib SSLContext to the active non-stdlib backend
+    (rtls or utls) SSLContext. Best effort only.
+
+    If the active backend is the stdlib ssl, the context is returned as-is.
+    If the passed context is already a non-stdlib context (detected via the
+    ``set_ech_configs`` attribute, exposed by both rtls and utls), it is
+    likewise returned as-is.
+    """
+    if not IS_NONSTDLIB:
         return ctx
 
-    if hasattr(ctx, "set_ech_configs"):  # already rtls context, exit early.
+    if hasattr(ctx, "set_ech_configs"):  # already a non-stdlib context, exit early.
         return ctx
 
     import ssl as stdlib_ssl
@@ -918,22 +916,22 @@ def convert_ssl_ctx_rtls(ctx: ssl.SSLContext) -> ssl.SSLContext:
                 stdlib_ssl.DER_cert_to_PEM_cert(cert) for cert in ctx_root_certificates
             )
 
-    rtls_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-    rtls_ctx.verify_mode = ssl.VerifyMode(int(ctx.verify_mode))
+    new_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    new_ctx.verify_mode = ssl.VerifyMode(int(ctx.verify_mode))
 
     if ca_cert_data:
-        rtls_ctx.load_verify_locations(cadata=ca_cert_data)
+        new_ctx.load_verify_locations(cadata=ca_cert_data)
     else:
-        rtls_ctx.load_default_certs()
+        new_ctx.load_default_certs()
 
     opt_match_no_tls: bool = False
 
     try:
         if stdlib_ssl.OP_NO_TLSv1_3 in ctx.options:
-            rtls_ctx.options |= ssl.OP_NO_TLSv1_3
+            new_ctx.options |= ssl.OP_NO_TLSv1_3
             opt_match_no_tls = True
         if stdlib_ssl.OP_NO_TLSv1_2 in ctx.options:
-            rtls_ctx.options |= ssl.OP_NO_TLSv1_2
+            new_ctx.options |= ssl.OP_NO_TLSv1_2
             opt_match_no_tls = True
     except TypeError:
         # TODO: Investigate this weird edge case.
@@ -953,17 +951,21 @@ def convert_ssl_ctx_rtls(ctx: ssl.SSLContext) -> ssl.SSLContext:
         options = ssl.Options(ctx.options)
 
         if ssl.OP_NO_TLSv1_3 in options:
-            rtls_ctx.options |= ssl.OP_NO_TLSv1_3
+            new_ctx.options |= ssl.OP_NO_TLSv1_3
             opt_match_no_tls = True
         if ssl.OP_NO_TLSv1_2 in options:
-            rtls_ctx.options |= ssl.OP_NO_TLSv1_2
+            new_ctx.options |= ssl.OP_NO_TLSv1_2
             opt_match_no_tls = True
 
     if not opt_match_no_tls:
-        rtls_ctx.minimum_version = ssl.TLSVersion(int(ctx.minimum_version))
-        rtls_ctx.maximum_version = ssl.TLSVersion(int(ctx.maximum_version))
+        new_ctx.minimum_version = ssl.TLSVersion(int(ctx.minimum_version))
+        new_ctx.maximum_version = ssl.TLSVersion(int(ctx.maximum_version))
 
     if hasattr(ctx, "check_hostname") and ctx.check_hostname is False:
-        rtls_ctx.check_hostname = False
+        new_ctx.check_hostname = False
 
-    return rtls_ctx
+    return new_ctx
+
+
+# Backwards-compatibility alias (deprecated name).
+convert_ssl_ctx_rtls = convert_ssl_ctx_nonstdlib

--- a/src/urllib3/util/ssltransport.py
+++ b/src/urllib3/util/ssltransport.py
@@ -4,15 +4,10 @@ import socket
 import sys
 import typing
 
-if typing.TYPE_CHECKING:
-    import ssl
-else:
-    try:
-        import rtls as ssl
-    except ImportError:
-        import ssl
-
-import ssl as _stdlib_ssl  # Always import stdlib ssl for exception compatibility
+from ..contrib.anytls import ssl
+from ..contrib.anytls import (
+    stdlib_ssl as _stdlib_ssl,
+)  # Always import stdlib ssl for exception compatibility
 
 from .._constant import DEFAULT_BLOCKSIZE
 from ..exceptions import ProxySchemeUnsupported
@@ -68,10 +63,11 @@ class SSLTransport:
         self.suppress_ragged_eofs = suppress_ragged_eofs
         self.socket = socket
 
-        # Determine the correct MemoryBIO to use.  When rtls is the default
-        # ``ssl`` but the caller passes a stdlib SSLContext (or vice-versa),
-        # wrap_bio() will reject a foreign MemoryBIO with a TypeError.
-        # Try the default ``ssl`` first, then fall back to ``_stdlib_ssl``.
+        # Determine the correct MemoryBIO to use.  When a non-stdlib backend
+        # (rtls/utls) is the default ``ssl`` but the caller passes a stdlib
+        # SSLContext (or vice-versa), wrap_bio() will reject a foreign
+        # MemoryBIO with a TypeError. Try the default ``ssl`` first, then
+        # fall back to ``_stdlib_ssl``.
         _bio_factories: list[type[ssl.MemoryBIO]] = list(
             dict.fromkeys([ssl.MemoryBIO, _stdlib_ssl.MemoryBIO])
         )

--- a/test/test_async_response.py
+++ b/test/test_async_response.py
@@ -49,10 +49,10 @@ def _make_async_fp(
 
     async def _body_reader(
         amt: int | None, _stream_id: int | None
-    ) -> tuple[bytes, bool, HTTPHeaderDict | None]:
+    ) -> tuple[list[bytes], bool, HTTPHeaderDict | None]:
         chunk = buffer.read(amt) if amt else buffer.read()
         eot = len(chunk) == 0 or buffer.tell() >= len(data)
-        return chunk, eot, None
+        return [chunk], eot, None
 
     resp_headers = HTTPHeaderDict(headers or {})
     if chunked:
@@ -1054,8 +1054,8 @@ class TestAsyncResponse:
     async def test_chunked_head_response(self) -> None:
         async def mock_sock(
             amt: int | None, stream_id: int | None
-        ) -> tuple[bytes, bool, HTTPHeaderDict | None]:
-            return b"", True, None
+        ) -> tuple[list[bytes], bool, HTTPHeaderDict | None]:
+            return [], True, None
 
         r = AsyncLowLevelResponse("HEAD", 200, 11, "OK", HTTPHeaderDict(), mock_sock)
         resp = AsyncHTTPResponse(
@@ -1094,7 +1094,7 @@ class TestAsyncResponse:
 
         async def mock_sock(
             amt: int | None, stream_id: int | None
-        ) -> tuple[bytes, bool, HTTPHeaderDict | None]:
+        ) -> tuple[list[bytes], bool, HTTPHeaderDict | None]:
             nonlocal idx
             if idx >= len(chunks):
                 raise AssertionError(
@@ -1103,7 +1103,7 @@ class TestAsyncResponse:
                 )
             d = chunks[idx]
             idx += 1
-            return d, False, None
+            return [d], False, None
 
         r = AsyncLowLevelResponse(
             "GET", 200, http_version, "OK", HTTPHeaderDict(), mock_sock
@@ -1206,13 +1206,13 @@ class TestAsyncResponse:
 
         async def mock_sock(
             amt: int | None, stream_id: int | None
-        ) -> tuple[bytes, bool, HTTPHeaderDict | None]:
+        ) -> tuple[list[bytes], bool, HTTPHeaderDict | None]:
             nonlocal chunks, idx
             if idx >= len(chunks):
-                return b"", True, None
+                return [], True, None
             d = chunks[idx]
             idx += 1
-            return d, False, None
+            return [d], False, None
 
         r = AsyncLowLevelResponse("GET", 200, 11, "OK", HTTPHeaderDict(), mock_sock)
 

--- a/test/test_async_response.py
+++ b/test/test_async_response.py
@@ -611,10 +611,14 @@ class TestAsyncResponse:
         )
         stream = resp.stream(2)
 
-        assert await stream.__anext__() == b"fo"
-        assert await stream.__anext__() == b"o"
-        with pytest.raises(StopAsyncIteration):
-            await stream.__anext__()
+        # ``_make_async_fp`` is a framed backend (``AsyncLowLevelResponse``
+        # exposes ``_eot``), so ``stream()`` surfaces each frame as soon as it
+        # decodes rather than filling ``amt`` (issue #379). The first frame
+        # carries the gzip header + a partial body, decoding to a single byte;
+        # the remainder follows. The joined output is unchanged.
+        chunks = [c async for c in stream]
+        assert chunks == [b"f", b"oo"]
+        assert b"".join(chunks) == b"foo"
 
     async def test_gzipped_streaming_amt_negative_one_does_not_hang(self) -> None:
         # Async mirror of the regression test for issue #364.
@@ -770,10 +774,11 @@ class TestAsyncResponse:
         )
         stream = resp.stream(2)
 
-        assert await stream.__anext__() == b"fo"
-        assert await stream.__anext__() == b"o"
-        with pytest.raises(StopAsyncIteration):
-            await stream.__anext__()
+        # Framed backend: per-frame delivery (issue #379), see
+        # ``test_gzipped_streaming``. Joined output is unchanged.
+        chunks = [c async for c in stream]
+        assert chunks == [b"f", b"oo"]
+        assert b"".join(chunks) == b"foo"
 
     async def test_deflate2_streaming(self) -> None:
         compress = zlib.compressobj(6, zlib.DEFLATED, -zlib.MAX_WBITS)
@@ -788,10 +793,11 @@ class TestAsyncResponse:
         )
         stream = resp.stream(2)
 
-        assert await stream.__anext__() == b"fo"
-        assert await stream.__anext__() == b"o"
-        with pytest.raises(StopAsyncIteration):
-            await stream.__anext__()
+        # Framed backend: per-frame delivery (issue #379), see
+        # ``test_gzipped_streaming``. Joined output is unchanged.
+        chunks = [c async for c in stream]
+        assert chunks == [b"f", b"oo"]
+        assert b"".join(chunks) == b"foo"
 
     async def test_empty_stream(self) -> None:
         fp = _make_async_fp(b"")
@@ -1064,6 +1070,53 @@ class TestAsyncResponse:
         async for _ in resp.stream():
             continue
         resp.release_conn.assert_called_once_with()  # type: ignore[attr-defined]
+
+    @pytest.mark.parametrize(
+        "http_version, headers",
+        [
+            # HTTP/1.1 chunked Transfer-Encoding
+            (11, {"transfer-encoding": "chunked"}),
+            # HTTP/2 framed stream with no declared length (e.g. SSE)
+            (20, {}),
+            # HTTP/3 framed stream with no declared length (e.g. SSE)
+            (30, {}),
+        ],
+    )
+    async def test_stream_yields_per_frame_without_blocking(
+        self, http_version: int, headers: dict[str, str]
+    ) -> None:
+        # Regression test for issue #379 (async): stream(amt) must surface
+        # each frame/chunk as it arrives instead of blocking until ``amt``
+        # decoded bytes accumulate. Not specific to chunked Transfer-Encoding;
+        # HTTP/2 and HTTP/3 deliver framed bodies the same way.
+        chunks = [b"data: hello\n\n"]
+        idx = 0
+
+        async def mock_sock(
+            amt: int | None, stream_id: int | None
+        ) -> tuple[bytes, bool, HTTPHeaderDict | None]:
+            nonlocal idx
+            if idx >= len(chunks):
+                raise AssertionError(
+                    "stream() blocked waiting to fill amt instead of "
+                    "yielding the available frame"
+                )
+            d = chunks[idx]
+            idx += 1
+            return d, False, None
+
+        r = AsyncLowLevelResponse(
+            "GET", 200, http_version, "OK", HTTPHeaderDict(), mock_sock
+        )
+        resp = AsyncHTTPResponse(
+            r,
+            preload_content=False,
+            headers=headers,
+            original_response=r,
+        )
+
+        gen = resp.stream(10000)
+        assert await gen.__anext__() == b"data: hello\n\n"
 
     async def test_get_case_insensitive_headers(self) -> None:
         headers = {"host": "example.com"}

--- a/test/test_ech.py
+++ b/test/test_ech.py
@@ -31,10 +31,10 @@ def test_sync_ech_accepted(happy_eyeballs: bool, http_version: int) -> None:
     if http_version == 30 and not _SYNC_HAS_HTTP3_SUPPORT():
         pytest.skip("Test requires HTTP/3 support")
     if http_version != 30:
-        try:
-            import rtls  # noqa
-        except ImportError:
-            pytest.skip("Test requires rtls for ECH at TCP level")
+        from urllib3.contrib.anytls import IS_NONSTDLIB
+
+        if not IS_NONSTDLIB:
+            pytest.skip("Test requires rtls/utls for ECH at TCP level")
 
     disabled_svn: set[HttpVersion] = set()
 
@@ -88,10 +88,10 @@ async def test_async_ech_accepted(happy_eyeballs: bool, http_version: int) -> No
     if http_version == 30 and not _ASYNC_HAS_HTTP3_SUPPORT():
         pytest.skip("Test requires HTTP/3 support")
     if http_version != 30:
-        try:
-            import rtls  # noqa
-        except ImportError:
-            pytest.skip("Test requires rtls for ECH at TCP level")
+        from urllib3.contrib.anytls import IS_NONSTDLIB
+
+        if not IS_NONSTDLIB:
+            pytest.skip("Test requires rtls/utls for ECH at TCP level")
 
     disabled_svn: set[HttpVersion] = set()
 

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -1160,8 +1160,8 @@ class TestResponse:
     def test_chunked_head_response(self) -> None:
         def mock_sock(
             amt: int | None, stream_id: int | None
-        ) -> tuple[bytes, bool, HTTPHeaderDict | None]:
-            return b"", True, None
+        ) -> tuple[list[bytes], bool, HTTPHeaderDict | None]:
+            return [], True, None
 
         r = LowLevelResponse("HEAD", 200, 11, "OK", HTTPHeaderDict(), mock_sock)
         resp = HTTPResponse(
@@ -1259,13 +1259,13 @@ class TestResponse:
 
         def mock_sock(
             amt: int | None, stream_id: int | None
-        ) -> tuple[bytes, bool, HTTPHeaderDict | None]:
+        ) -> tuple[list[bytes], bool, HTTPHeaderDict | None]:
             nonlocal chunks, idx
             if idx >= len(chunks):
-                return b"", True, None
+                return [], True, None
             d = chunks[idx]
             idx += 1
-            return d, False, None
+            return [d], False, None
 
         r = LowLevelResponse("GET", 200, 11, "OK", HTTPHeaderDict(), mock_sock)
 
@@ -1301,7 +1301,7 @@ class TestResponse:
 
         def mock_sock(
             amt: int | None, stream_id: int | None
-        ) -> tuple[bytes, bool, HTTPHeaderDict | None]:
+        ) -> tuple[list[bytes], bool, HTTPHeaderDict | None]:
             nonlocal idx
             if idx >= len(chunks):
                 # Simulate an idle-but-open connection: a second raw read
@@ -1314,7 +1314,7 @@ class TestResponse:
                 )
             d = chunks[idx]
             idx += 1
-            return d, False, None
+            return [d], False, None
 
         r = LowLevelResponse(
             "GET", 200, http_version, "OK", HTTPHeaderDict(), mock_sock

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -1278,6 +1278,53 @@ class TestResponse:
 
         assert b"foo\nbar" == data
 
+    @pytest.mark.parametrize(
+        "http_version, headers",
+        [
+            # HTTP/1.1 chunked Transfer-Encoding
+            (11, {"transfer-encoding": "chunked"}),
+            # HTTP/2 framed stream with no declared length (e.g. SSE)
+            (20, {}),
+            # HTTP/3 framed stream with no declared length (e.g. SSE)
+            (30, {}),
+        ],
+    )
+    def test_stream_yields_per_frame_without_blocking(
+        self, http_version: int, headers: dict[str, str]
+    ) -> None:
+        # Regression test for issue #379: stream(amt) must surface each
+        # frame/chunk as it arrives instead of blocking until ``amt`` decoded
+        # bytes accumulate. This is not specific to chunked Transfer-Encoding;
+        # HTTP/2 and HTTP/3 deliver framed bodies the same way.
+        chunks = [b"data: hello\n\n"]
+        idx = 0
+
+        def mock_sock(
+            amt: int | None, stream_id: int | None
+        ) -> tuple[bytes, bool, HTTPHeaderDict | None]:
+            nonlocal idx
+            if idx >= len(chunks):
+                # Simulate an idle-but-open connection: a second raw read
+                # would block on the socket here. Raising instead lets us
+                # assert that stream() never attempts it before yielding the
+                # already-available frame.
+                raise AssertionError(
+                    "stream() blocked waiting to fill amt instead of "
+                    "yielding the available frame"
+                )
+            d = chunks[idx]
+            idx += 1
+            return d, False, None
+
+        r = LowLevelResponse(
+            "GET", 200, http_version, "OK", HTTPHeaderDict(), mock_sock
+        )
+
+        resp = HTTPResponse(r, preload_content=False, headers=headers)
+
+        gen = resp.stream(10000)
+        assert next(gen) == b"data: hello\n\n"
+
     def test_non_timeout_ssl_error_on_read(self) -> None:
         mac_error = ssl.SSLError(
             "SSL routines", "ssl3_get_record", "decryption failed or bad record mac"

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -152,7 +152,9 @@ class TestSSL:
         ssl_.create_urllib3_context(caller_id=ssl_._KnownCaller.NIQUESTS)
 
         if support_min_max:
-            if "Rustls" in ssl_.ssl.OPENSSL_VERSION:  # type: ignore[attr-defined]
+            from urllib3.contrib.anytls import IS_NONSTDLIB
+
+            if IS_NONSTDLIB:
                 context.set_ciphers.assert_not_called()
             else:
                 context.set_ciphers.assert_called_once_with(MOZ_INTERMEDIATE_CIPHERS)

--- a/test/with_dummyserver/asynchronous/test_https.py
+++ b/test/with_dummyserver/asynchronous/test_https.py
@@ -384,6 +384,7 @@ class TestAsyncHTTPS(HTTPSDummyServerTestCase):
                 or "certificate verify failed" in str(e.value.reason)
                 or "invalid peer certificate: certificate not valid for name"
                 in str(e.value.reason)
+                or "certificate verification failed" in str(e.value.reason)
             )
 
     @pytest.mark.asyncio
@@ -410,6 +411,8 @@ class TestAsyncHTTPS(HTTPSDummyServerTestCase):
                 or "self signed certificate in certificate chain" in str(e.value.reason)
                 # Rustls specific
                 or "invalid peer certificate:" in str(e.value.reason)
+                # BoringSSL specific
+                or "self-signed certificate" in str(e.value.reason)
             ), f"Expected 'certificate verify failed', instead got: {e.value.reason!r}"
 
     @pytest.mark.asyncio
@@ -453,6 +456,8 @@ class TestAsyncHTTPS(HTTPSDummyServerTestCase):
                 or "invalid certificate chain" in str(e.value.reason)
                 # Rustls specific
                 or "invalid peer certificate:" in str(e.value.reason)
+                # BoringSSL specific
+                or "self-signed certificate" in str(e.value.reason)
             ), (
                 "Expected 'No root certificates specified',  "
                 "'certificate verify failed', or "
@@ -1224,6 +1229,8 @@ eu6FSqdQgPCnXEqULl8FmTxSQeDNtGPPAUO6nIPcj2A781q0tHuu2guQOHXvgR1m
                 or "no appropriate subjectAltName" in str(e.value)
                 or "certificate is not valid for any names (according to its subjectAltName extension"
                 in str(e.value)
+                or "hostname mismatch" in str(e.value)
+                or "certificate verification failed" in str(e.value)
             )
 
     async def test_common_name_without_san_with_different_common_name(
@@ -1244,9 +1251,11 @@ eu6FSqdQgPCnXEqULl8FmTxSQeDNtGPPAUO6nIPcj2A781q0tHuu2guQOHXvgR1m
         ) as https_pool:
             with pytest.raises(MaxRetryError) as e:
                 await https_pool.request("GET", "/")
-            assert "mismatch, certificate is not valid for 'localhost'" in str(
-                e.value
-            ) or "hostname 'localhost' doesn't match 'example.com'" in str(e.value)
+            assert (
+                "mismatch, certificate is not valid for 'localhost'" in str(e.value)
+                or "hostname 'localhost' doesn't match 'example.com'" in str(e.value)
+                or "hostname mismatch" in str(e.value)
+            )
 
     @pytest.mark.parametrize("use_assert_hostname", [True, False])
     async def test_hostname_checks_common_name_respected(

--- a/test/with_dummyserver/asynchronous/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/asynchronous/test_proxy_poolmanager.py
@@ -631,10 +631,9 @@ class TestAsyncHTTPProxyManager(HTTPDummyProxyTestCase):
         if proxy_scheme == "https" and use_forwarding_for_https:
             pytest.skip("Test is expected to fail due to urllib3/urllib3#2577")
 
-        try:
-            import rtls as alt_ssl
-        except ImportError:
-            alt_ssl = None  # type: ignore[assignment]
+        from urllib3.contrib.anytls import ssl as anytls_ssl, IS_NONSTDLIB
+
+        alt_ssl = anytls_ssl if IS_NONSTDLIB else None
 
         proxy_url = self.https_proxy_url if proxy_scheme == "https" else self.proxy_url
         if alt_ssl is None:
@@ -837,6 +836,7 @@ class TestAsyncHTTPSProxyVerification:
                 or "Hostname mismatch" in str(ssl_error)
                 or "invalid peer certificate: certificate not valid for name"
                 in str(ssl_error)
+                or "hostname mismatch" in str(ssl_error)
             )
 
             with pytest.raises(MaxRetryError) as e:
@@ -850,6 +850,7 @@ class TestAsyncHTTPSProxyVerification:
                 or "Hostname mismatch" in str(ssl_error)
                 or "invalid peer certificate: certificate not valid for name"
                 in str(ssl_error)
+                or "hostname mismatch" in str(ssl_error)
             )
 
     async def test_https_proxy_ipv4_san(
@@ -898,6 +899,7 @@ class TestAsyncHTTPSProxyVerification:
                 in str(ssl_error)
                 or "invalid peer certificate: certificate not valid for name"
                 in str(ssl_error)
+                or "hostname mismatch" in str(ssl_error)
             )
 
     async def test_https_proxy_no_san_hostname_checks_common_name(

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -45,7 +45,8 @@ from urllib3.util.ssl_match_hostname import CertificateError
 from urllib3.util.timeout import Timeout
 
 
-from urllib3.util.ssl_ import _SSLContextCache, OPENSSL_VERSION
+from urllib3.util.ssl_ import _SSLContextCache
+from urllib3.contrib.anytls import IS_NONSTDLIB
 from urllib3.contrib.imcc._ctypes import load_cert_chain as _ctypes_load_cert_chain
 from urllib3.contrib.imcc._shm import load_cert_chain as _shm_load_cert_chain
 from urllib3.contrib.imcc._fifo import load_cert_chain as _fifo_load_cert_chain
@@ -263,7 +264,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         strict=False,
     )
     @pytest.mark.skipif(
-        "Rustls" in OPENSSL_VERSION, reason="rtls already have native support for imcc"
+        IS_NONSTDLIB, reason="rtls/utls already have native support for imcc"
     )
     def test_in_memory_client_key_password_ctypes_only(
         self, monkeypatch: pytest.MonkeyPatch
@@ -314,7 +315,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         strict=False,
     )
     @pytest.mark.skipif(
-        "Rustls" in OPENSSL_VERSION, reason="rtls already have native support for imcc"
+        IS_NONSTDLIB, reason="rtls/utls already have native support for imcc"
     )
     def test_in_memory_client_key_password_shm_only(
         self, monkeypatch: pytest.MonkeyPatch
@@ -367,7 +368,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         strict=False,
     )
     @pytest.mark.skipif(
-        "Rustls" in OPENSSL_VERSION, reason="rtls already have native support for imcc"
+        IS_NONSTDLIB, reason="rtls/utls already have native support for imcc"
     )
     def test_in_memory_client_key_password_fifo_only(
         self, monkeypatch: pytest.MonkeyPatch
@@ -526,6 +527,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                 or "certificate verify failed" in str(e.value.reason)
                 or "invalid peer certificate: certificate not valid for name"
                 in str(e.value.reason)
+                or "certificate verification failed" in str(e.value.reason)
             )
 
     def test_verified_with_bad_ca_certs(self) -> None:
@@ -551,6 +553,8 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                 or "self signed certificate in certificate chain" in str(e.value.reason)
                 # Rustls specific
                 or "invalid peer certificate:" in str(e.value.reason)
+                # BoringSSL specific
+                or "self-signed certificate" in str(e.value.reason)
             ), f"Expected 'certificate verify failed', instead got: {e.value.reason!r}"
 
     def test_wrap_socket_failure_resource_leak(self) -> None:
@@ -592,6 +596,8 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                 or "invalid certificate chain" in str(e.value.reason)
                 # Rustls specific
                 or "invalid peer certificate:" in str(e.value.reason)
+                # BoringSSL specific
+                or "self-signed certificate" in str(e.value.reason)
             ), (
                 "Expected 'No root certificates specified',  "
                 "'certificate verify failed', or "
@@ -1204,10 +1210,9 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         reason="Python built against restricted ssl library with one protocol supported",
     )
     def test_default_ssl_context_ssl_min_max_versions(self) -> None:
-        try:
-            import rtls as alt_ssl
-        except ImportError:
-            alt_ssl = None  # type: ignore[assignment]
+        from urllib3.contrib.anytls import ssl as anytls_ssl, IS_NONSTDLIB
+
+        alt_ssl = anytls_ssl if IS_NONSTDLIB else None
 
         ctx = urllib3.util.ssl_.create_urllib3_context()
 
@@ -1218,11 +1223,11 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             ).maximum_version
             assert ctx.maximum_version == expected_maximum_version
         else:
-            assert ctx.minimum_version == alt_ssl.TLSVersion.TLSv1_2  # type: ignore[comparison-overlap]
+            assert ctx.minimum_version == alt_ssl.TLSVersion.TLSv1_2
             expected_maximum_version = alt_ssl.SSLContext(
                 alt_ssl.PROTOCOL_TLS_CLIENT
             ).maximum_version
-            assert ctx.maximum_version == expected_maximum_version  # type: ignore[comparison-overlap]
+            assert ctx.maximum_version == expected_maximum_version
 
     @pytest.mark.skipif(
         urllib3.util.ssl_.SUPPORT_MIN_MAX_TLS_VERSION is False,
@@ -1396,6 +1401,8 @@ eu6FSqdQgPCnXEqULl8FmTxSQeDNtGPPAUO6nIPcj2A781q0tHuu2guQOHXvgR1m
                 or "no appropriate subjectAltName" in str(e.value)
                 or "certificate is not valid for any names (according to its subjectAltName extension"
                 in str(e.value)
+                or "hostname mismatch" in str(e.value)
+                or "certificate verification failed" in str(e.value)
             )
 
     def test_common_name_without_san_with_different_common_name(
@@ -1416,9 +1423,11 @@ eu6FSqdQgPCnXEqULl8FmTxSQeDNtGPPAUO6nIPcj2A781q0tHuu2guQOHXvgR1m
         ) as https_pool:
             with pytest.raises(MaxRetryError) as e:
                 https_pool.request("GET", "/")
-            assert "mismatch, certificate is not valid for 'localhost'" in str(
-                e.value
-            ) or "hostname 'localhost' doesn't match 'example.com'" in str(e.value)
+            assert (
+                "mismatch, certificate is not valid for 'localhost'" in str(e.value)
+                or "hostname 'localhost' doesn't match 'example.com'" in str(e.value)
+                or "hostname mismatch" in str(e.value)
+            )
 
     @pytest.mark.parametrize("use_assert_hostname", [True, False])
     def test_hostname_checks_common_name_respected(

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -202,6 +202,8 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
                 or "self signed certificate in certificate chain" in str(e.value.reason)
                 # Rustls specific
                 or "invalid peer certificate:" in str(e.value.reason)
+                # BoringSSL specific
+                or "self-signed certificate" in str(e.value.reason)
             ), f"Expected 'certificate verify failed', instead got: {e.value.reason!r}"
 
             http = proxy_from_url(
@@ -224,7 +226,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
             with pytest.raises(
                 MaxRetryError,
-                match="doesn't match|IP address mismatch|certificate not valid for name",
+                match=r"doesn't match|IP address mismatch|certificate not valid for name|certificate verification failed",
             ) as e:
                 https_fail_pool.request("GET", "/", retries=0)
             assert isinstance(e.value.reason, SSLError)
@@ -679,10 +681,9 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         if proxy_scheme == "https" and use_forwarding_for_https:
             pytest.skip("Test is expected to fail due to urllib3/urllib3#2577")
 
-        try:
-            import rtls as alt_ssl
-        except ImportError:
-            alt_ssl = None  # type: ignore[assignment]
+        from urllib3.contrib.anytls import ssl as anytls_ssl, IS_NONSTDLIB
+
+        alt_ssl = anytls_ssl if IS_NONSTDLIB else None
 
         proxy_url = self.https_proxy_url if proxy_scheme == "https" else self.proxy_url
         if alt_ssl is None:
@@ -864,6 +865,7 @@ class TestHTTPSProxyVerification:
                 or "Hostname mismatch" in str(ssl_error)
                 or "invalid peer certificate: certificate not valid for name"
                 in str(ssl_error)
+                or "hostname mismatch" in str(ssl_error)
             )
 
             with pytest.raises(MaxRetryError) as e:
@@ -877,6 +879,7 @@ class TestHTTPSProxyVerification:
                 or "Hostname mismatch" in str(ssl_error)
                 or "invalid peer certificate: certificate not valid for name"
                 in str(ssl_error)
+                or "hostname mismatch" in str(ssl_error)
             )
 
     def test_https_proxy_ipv4_san(
@@ -923,6 +926,7 @@ class TestHTTPSProxyVerification:
                 in str(ssl_error)
                 or "invalid peer certificate: certificate not valid for name"
                 in str(ssl_error)
+                or "hostname mismatch" in str(ssl_error)
             )
 
     def test_https_proxy_no_san_hostname_checks_common_name(

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1414,7 +1414,7 @@ class TestSSL(SocketDummyServerTestCase):
         with HTTPSConnectionPool(self.host, self.port, ca_certs=DEFAULT_CA) as pool:
             with pytest.raises(
                 SSLError,
-                match=r"(wrong version number|record overflow|record layer failure|received corrupt message)",
+                match=r"(wrong version number|record overflow|record layer failure|received corrupt message|SSL operation: error)",
             ):
                 pool.request("GET", "/", retries=False)
 
@@ -1611,13 +1611,16 @@ class TestSSL(SocketDummyServerTestCase):
         finally:
             _SSLContextCache.clear()
 
-    def test_ssl_ctx_need_convert_rtls(self, monkeypatch) -> None:  # type: ignore
+    def test_ssl_ctx_need_convert_nonstdlib(self, monkeypatch) -> None:  # type: ignore
         def forbidden(ctx, *a, **kw):  # type: ignore
             raise AssertionError(
                 "load_default_certs must not be called in this test run"
             )
 
-        alt_ssl = pytest.importorskip("rtls")
+        from urllib3.contrib.anytls import ssl as alt_ssl, IS_NONSTDLIB
+
+        if not IS_NONSTDLIB:
+            pytest.skip("Test requires a non-stdlib ssl backend (rtls/utls)")
 
         monkeypatch.setattr(ssl.SSLContext, "load_default_certs", forbidden)
         monkeypatch.setattr(alt_ssl.SSLContext, "load_default_certs", forbidden)
@@ -1673,10 +1676,9 @@ class TestSSL(SocketDummyServerTestCase):
                 "load_default_certs must not be called in this test run"
             )
 
-        try:
-            import rtls as alt_ssl
-        except ImportError:
-            alt_ssl = None  # type: ignore[assignment]
+        from urllib3.contrib.anytls import ssl as anytls_ssl, IS_NONSTDLIB
+
+        alt_ssl = anytls_ssl if IS_NONSTDLIB else None
 
         if alt_ssl is None:
             monkeypatch.setattr(ssl.SSLContext, "load_default_certs", forbidden)
@@ -1729,7 +1731,7 @@ class TestSSL(SocketDummyServerTestCase):
 
             self._start_server(socket_handler)
 
-            with HTTPSConnectionPool(  # type: ignore[arg-type]
+            with HTTPSConnectionPool(
                 self.host, self.port, retries=False, **kwargs
             ) as pool:
                 r = pool.request("GET", "/", timeout=LONG_TIMEOUT)


### PR DESCRIPTION
2.21.900 (2026-05-30)
=====================

- Fixed ``HTTPResponse.stream(amt)`` (and the async equivalent) no longer yielding per-frame for
  streamed responses. (#379)
- Improved memory usage and throughput when reading response bodies by removing a redundant body
  concatenation in the stream read path. Received frames are now buffered directly and served with
  a zero-copy fast path for frame-aligned reads (e.g. per-frame streaming, WebSocket and SSE).
- Added support for ``utls`` alternative TLS backend in addition to ``rtls``.
  ``utls`` is based on BoringSSL and have the capability to align with Google Chrome browser capabilities.
  This new TLS backend is introduced in addition to ``rtls``. urllib3-future tries backend in given order:
  ``rtls`` -> ``utls`` -> ``ssl``. You may override this by setting ``URLLIB3_FUTURE_SSL_BACKEND`` environment
  variable. See the documentation to learn more. You can also pass a custom ``SSLContext`` from any
  of those backends. We can handle multiple TLS backend at the same time within a single ``PoolManager`` instance.
- Fixed handling of unsendable datagram emitted by ``qh3`` MTU discovery probe when the physical NIC can't handle
  specific >1200 bytes datagrams. (#377)
- Fixed support for the ``truststore`` 3rd party library direct alternative to ``wassima``.
  We still recommend ``wassima`` as the "OS truststore" library. It is fixed for strict BC
  promise we made by being a "urllib3" inplace replacement.