### PR TITLE
Release 2.21.901

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.21.901 (2026-06-01)
+=====================
+
+- Fixed http3 ``assert_hostname`` not forwarded when passing a custom ``SSLContext`` that disable it in async.
+- Fixed edge case failure in http3 upgrade when ``ssl`` is monkeypatched by a 3rd party library.
+- Changed default http3 settings to match decision made for http2 recently.
+
 2.21.900 (2026-05-30)
 =====================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ utls = [
   "utls; platform_python_implementation == 'CPython'",
   # force zstd, and br to be part of utls group
   # we need them as we force "Accept-Encoding: br, zstd, gzip,...)
-  "zstandard>=0.18.0; python_version < '3.14'",
+  "zstandard>=0.18.0; python_version < '3.14' and platform_python_implementation == 'CPython'",
   "brotli>=1.0.9; platform_python_implementation == 'CPython'",
 ]
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.21.900"
+__version__ = "2.21.901"

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -324,12 +324,20 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         if not allow_insecure and resolve_cert_reqs(cert_reqs) == ssl.CERT_NONE:
             allow_insecure = True
 
-        cert_stats = ssl_context.cert_store_stats() if ssl_context is not None else None
-        ssl_ctx_have_certs: bool = (
-            cert_stats is not None
-            and "x509_ca" in cert_stats
-            and cert_stats["x509_ca"] > 0
-        )
+        try:
+            cert_stats = (
+                ssl_context.cert_store_stats() if ssl_context is not None else None
+            )
+            ssl_ctx_have_certs: bool = (
+                cert_stats is not None
+                and "x509_ca" in cert_stats
+                and cert_stats["x509_ca"] > 0
+            )
+        except (
+            AttributeError,
+            NotImplementedError,
+        ):  # Defensive: in case of ssl monkeypatch
+            ssl_ctx_have_certs = False
 
         if (
             not allow_insecure
@@ -354,7 +362,13 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                 allow_insecure = True
 
             if ca_certs is None and ca_cert_dir is None and ca_cert_data is None:
-                ctx_root_certificates: list[bytes] = ssl_context.get_ca_certs(True)
+                try:
+                    ctx_root_certificates: list[bytes] = ssl_context.get_ca_certs(True)
+                except (
+                    AttributeError,
+                    NotImplementedError,
+                ):  # Defensive: in case of ssl monkeypatch
+                    ctx_root_certificates = []
 
                 if ctx_root_certificates:
                     ca_cert_data = "\n".join(

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -382,6 +382,19 @@ class AsyncHfaceBackend(AsyncBaseBackend):
             ):
                 assert_hostname = False
 
+            # BoringSSL case ctx.
+            if hasattr(ssl_context, "set_fingerprint"):
+                try:
+                    ssl_context.http_header_for_fingerprint()  # type: ignore[attr-defined]
+                except ValueError:
+                    ssl_context.set_fingerprint("chrome:stable")
+                except AttributeError:  # Defensive: should be unreachable
+                    pass
+
+            # so that http headers would be made available
+            # via connectionpool "BoringSSL have predefined headers"
+            setattr(self.sock, "context", ssl_context)
+
         self.__custom_tls_settings = QuicTLSConfig(
             insecure=allow_insecure,
             cafile=ca_certs,

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -375,6 +375,13 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                         ssl.DER_cert_to_PEM_cert(cert) for cert in ctx_root_certificates
                     )
 
+            if (
+                assert_hostname is None
+                and hasattr(ssl_context, "check_hostname")
+                and ssl_context.check_hostname is False
+            ):
+                assert_hostname = False
+
         self.__custom_tls_settings = QuicTLSConfig(
             insecure=allow_insecure,
             cafile=ca_certs,

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -355,8 +355,16 @@ class HfaceBackend(BaseBackend):
 
         ssl_ctx_have_certs: bool = False
         if ssl_context is not None:
-            cert_stats = ssl_context.cert_store_stats()
-            ssl_ctx_have_certs = "x509_ca" in cert_stats and cert_stats["x509_ca"] > 0
+            try:
+                cert_stats = ssl_context.cert_store_stats()
+                ssl_ctx_have_certs = (
+                    "x509_ca" in cert_stats and cert_stats["x509_ca"] > 0
+                )
+            except (
+                AttributeError,
+                NotImplementedError,
+            ):  # Defensive: in case of ssl monkeypatch
+                ssl_ctx_have_certs = False
 
         if (
             not allow_insecure
@@ -381,7 +389,13 @@ class HfaceBackend(BaseBackend):
                 allow_insecure = True
 
             if ca_certs is None and ca_cert_dir is None and ca_cert_data is None:
-                ctx_root_certificates: list[bytes] = ssl_context.get_ca_certs(True)
+                try:
+                    ctx_root_certificates: list[bytes] = ssl_context.get_ca_certs(True)
+                except (
+                    AttributeError,
+                    NotImplementedError,
+                ):  # Defensive: in case of ssl monkeypatch
+                    ctx_root_certificates = []
 
                 if ctx_root_certificates:
                     ca_cert_data = "\n".join(

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -409,6 +409,19 @@ class HfaceBackend(BaseBackend):
             ):
                 assert_hostname = False
 
+            # BoringSSL case ctx.
+            if hasattr(ssl_context, "set_fingerprint"):
+                try:
+                    ssl_context.http_header_for_fingerprint()  # type: ignore[attr-defined]
+                except ValueError:
+                    ssl_context.set_fingerprint("chrome:stable")
+                except AttributeError:  # Defensive: should be unreachable
+                    pass
+
+            # so that http headers would be made available
+            # via connectionpool "BoringSSL have predefined headers"
+            setattr(self.sock, "context", ssl_context)
+
         self.__custom_tls_settings = QuicTLSConfig(
             insecure=allow_insecure,
             cafile=ca_certs,

--- a/src/urllib3/contrib/hface/protocols/http3/_qh3.py
+++ b/src/urllib3/contrib/hface/protocols/http3/_qh3.py
@@ -111,8 +111,8 @@ class HTTP3ProtocolAioQuicImpl(HTTP3Protocol):
             secrets_log_file=open(keylogfile_path, "w") if keylogfile_path else None,  # type: ignore[arg-type]
             quic_logger=QuicFileLogger(qlogdir_path) if qlogdir_path else None,
             idle_timeout=tls_config.idle_timeout,
-            max_data=2**24,
-            max_stream_data=2**24,
+            max_data=15728640,
+            max_stream_data=6291456,
         )
 
         # infer support for encrypted hello!


### PR DESCRIPTION
2.21.901 (2026-06-01)
=====================

- Fixed http3 ``assert_hostname`` not forwarded when passing a custom ``SSLContext`` that disable it in async.
- Fixed edge case failure in http3 upgrade when ``ssl`` is monkeypatched by a 3rd party library.
- Changed default http3 settings to match decision made for http2 recently.
