### PR TITLE
Release 2.21.902

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.21.902 (2026-06-01)
+=====================
+
+- Fixed PyPy certificate extraction within exposed ``ConnectionInfo``. Unintentional regression caused by our ``anytls``
+  contrib module.
+
 2.21.901 (2026-06-01)
 =====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.21.901"
+__version__ = "2.21.902"

--- a/src/urllib3/contrib/anytls/_backend.py
+++ b/src/urllib3/contrib/anytls/_backend.py
@@ -86,10 +86,20 @@ def _load_certificate(backend: str) -> object | None:
             return getattr(mod, "Certificate", None)
         except ImportError:
             return None
+    # CPython stdlib
     try:
         _ssl = importlib.import_module("_ssl")
-        return getattr(_ssl, "Certificate", None)
-    except (ImportError, AttributeError):
+        cert = getattr(_ssl, "Certificate", None)
+        if cert is not None:
+            return cert
+    except ImportError:
+        pass
+    # PyPy: same type lives here instead of on _ssl
+    try:
+        from _cffi_ssl._stdssl.certificate import Certificate
+
+        return Certificate
+    except ImportError:
         return None
 
 

--- a/src/urllib3/contrib/anytls/_backend.py
+++ b/src/urllib3/contrib/anytls/_backend.py
@@ -75,7 +75,7 @@ def _try_import(name: str) -> ModuleType | None:
         return None
 
 
-def _load_certificate(backend: str) -> object | None:
+def _load_certificate(backend: str) -> type | None:
     """Best-effort import of the Certificate type used for peer-cert chain
     extraction. rtls/utls expose it directly; for stdlib ssl, fall back to the
     private ``_ssl.Certificate`` (used by ``backend/hface.py``).
@@ -91,14 +91,14 @@ def _load_certificate(backend: str) -> object | None:
         _ssl = importlib.import_module("_ssl")
         cert = getattr(_ssl, "Certificate", None)
         if cert is not None:
-            return cert
+            return cert  # type: ignore[no-any-return]
     except ImportError:
         pass
     # PyPy: same type lives here instead of on _ssl
     try:
-        from _cffi_ssl._stdssl.certificate import Certificate
+        from _cffi_ssl._stdssl.certificate import Certificate  # type: ignore[import-not-found]
 
-        return Certificate
+        return Certificate  # type: ignore[no-any-return]
     except ImportError:
         return None
 


### PR DESCRIPTION
2.21.902 (2026-06-01)
=====================

- Fixed PyPy certificate extraction within exposed ``ConnectionInfo``. Unintentional regression caused by our ``anytls``
  contrib module.
