### PR TITLE
Release 2.22.900

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.22.900 (2026-06-26)
+=====================
+
+- Added pool level TLS backend selection. You can dynamically use ``rtls`` or ``utls`` or ``ssl`` via programmatic kwargs ``ssl_backend``.
+  E.g. ``PoolManager(ssl_backend="utls")`` to instantiate a PoolManager with BoringSSL backend. Supported values are ``utls``, ``rtls``, ``ssl``
+  or ``None`` (default).
+- Fixed unconsummated tail with the Brotli decoder using amt=-1. (#385)
+
 2.21.902 (2026-06-01)
 =====================
 

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -1709,6 +1709,16 @@ default order.
 
     URLLIB3_FUTURE_SSL_BACKEND=ssl python my_script.py
 
+.. versionadded:: 2.22.900
+
+You can also use the ``ssl_backend`` kwargs into your Pool constructor and specify one of:
+
+- ``rtls``
+- ``utls``
+- ``ssl``
+
+This will overrule any default configuration and force a specific TLS backend.
+
 The ``anytls`` module
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,7 @@ filterwarnings = [
     '''ignore:RecentlyUsedContainer is deprecated and scheduled for removal:DeprecationWarning''',
     '''ignore:The event_loop fixture provided by:DeprecationWarning''',
     '''ignore:A plugin raised an exception during''',
-    '''ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning''',
+    '''ignore:Exception ignored:pytest.PytestUnraisableExceptionWarning''',
     '''ignore:Exception in thread:pytest.PytestUnhandledThreadExceptionWarning''',
     '''ignore:function _SSLProtocolTransport\.__del__:pytest.PytestUnraisableExceptionWarning''',
     '''ignore:function _SelectorTransport\.__del__:pytest.PytestUnraisableExceptionWarning''',

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -711,6 +711,7 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
     ssl_version: int | str | None = None
     ssl_minimum_version: int | None = None
     ssl_maximum_version: int | None = None
+    ssl_backend: Literal["rtls", "utls", "ssl"] | None = None
     assert_fingerprint: str | None = None
     cert_file: str | None = None
     key_file: str | None = None
@@ -747,6 +748,7 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
         ssl_minimum_version: int | None = None,
         ssl_maximum_version: int | None = None,
         ssl_version: int | str | None = None,
+        ssl_backend: Literal["rtls", "utls", "ssl"] | None = None,
         cert_file: str | None = None,
         key_file: str | None = None,
         key_password: str | None = None,
@@ -791,6 +793,7 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
         self.ssl_version = ssl_version
         self.ssl_minimum_version = ssl_minimum_version
         self.ssl_maximum_version = ssl_maximum_version
+        self.ssl_backend = ssl_backend
         self.ca_certs = ca_certs and os.path.expanduser(ca_certs)
         self.ca_cert_dir = ca_cert_dir and os.path.expanduser(ca_cert_dir)
         self.ca_cert_data = ca_cert_data
@@ -872,6 +875,7 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
                 ssl_version=self.ssl_version,
                 ssl_minimum_version=self.ssl_minimum_version,
                 ssl_maximum_version=self.ssl_maximum_version,
+                ssl_backend=self.ssl_backend,
                 ca_certs=self.ca_certs,
                 ca_cert_dir=self.ca_cert_dir,
                 ca_cert_data=self.ca_cert_data,
@@ -944,6 +948,7 @@ class AsyncHTTPSConnection(AsyncHTTPConnection):
             ssl_version=self.ssl_version,
             ssl_minimum_version=self.ssl_minimum_version,
             ssl_maximum_version=self.ssl_maximum_version,
+            ssl_backend=self.ssl_backend,
             ca_certs=self.ca_certs,
             ca_cert_dir=self.ca_cert_dir,
             ca_cert_data=self.ca_cert_data,
@@ -982,6 +987,7 @@ async def _ssl_wrap_socket_and_match_hostname(
     ssl_version: None | str | int,
     ssl_minimum_version: int | None,
     ssl_maximum_version: int | None,
+    ssl_backend: Literal["rtls", "utls", "ssl"] | None = None,
     cert_file: str | None,
     key_file: str | None,
     key_password: str | None,
@@ -1054,6 +1060,7 @@ async def _ssl_wrap_socket_and_match_hostname(
         ssl_version=resolve_ssl_version(ssl_version, mitigate_tls_version=True),
         ssl_minimum_version=ssl_minimum_version,
         ssl_maximum_version=ssl_maximum_version,
+        ssl_backend=ssl_backend,
         check_hostname=check_hostname,
         ech_config_list=ech_config_list,
     )

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -2138,6 +2138,7 @@ class AsyncHTTPSConnectionPool(AsyncHTTPConnectionPool):
         ssl_version: int | str | None = None,
         ssl_minimum_version: ssl.TLSVersion | None = None,
         ssl_maximum_version: ssl.TLSVersion | None = None,
+        ssl_backend: Literal["rtls", "utls", "ssl"] | None = None,
         assert_hostname: str | Literal[False] | None = None,
         assert_fingerprint: str | None = None,
         ca_cert_dir: str | None = None,
@@ -2172,6 +2173,7 @@ class AsyncHTTPSConnectionPool(AsyncHTTPConnectionPool):
         self.ssl_version = ssl_version
         self.ssl_minimum_version = ssl_minimum_version
         self.ssl_maximum_version = ssl_maximum_version
+        self.ssl_backend = ssl_backend
         self.assert_hostname = assert_hostname
         self.assert_fingerprint = assert_fingerprint
         self.ciphers = ciphers
@@ -2390,6 +2392,7 @@ class AsyncHTTPSConnectionPool(AsyncHTTPConnectionPool):
                                 ssl_version=self.ssl_version,
                                 ssl_minimum_version=self.ssl_minimum_version,
                                 ssl_maximum_version=self.ssl_maximum_version,
+                                ssl_backend=self.ssl_backend,
                                 cert_data=self.cert_data,
                                 key_data=self.key_data,
                                 ciphers=self.ciphers,
@@ -2477,6 +2480,7 @@ class AsyncHTTPSConnectionPool(AsyncHTTPConnectionPool):
                     ssl_version=self.ssl_version,
                     ssl_minimum_version=self.ssl_minimum_version,
                     ssl_maximum_version=self.ssl_maximum_version,
+                    ssl_backend=self.ssl_backend,
                     cert_data=self.cert_data,
                     key_data=self.key_data,
                     ciphers=self.ciphers,

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.21.902"
+__version__ = "2.22.900"

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -11,11 +11,6 @@ from socket import timeout as SocketTimeout
 
 from ..contrib.anytls import ssl, Certificate
 
-if ssl is not None:
-    from ..util.ssltransport import SSLTransport
-else:
-    SSLTransport = None  # type: ignore
-
 from .._collections import HTTPHeaderDict
 from .._constant import (
     DEFAULT_BLOCKSIZE,
@@ -490,55 +485,40 @@ class HfaceBackend(BaseBackend):
 
         # first request was not made yet // need to infer what protocol to use.
         if self._svn is None:
-            # if we are on a TLS connection, inspect ALPN.
-            is_tcp_tls_conn = isinstance(self.sock, (ssl.SSLSocket, SSLTransport))
+            # Inspect ALPN when on a TLS connection. SSLSocket (any backend)
+            # and SSLTransport both expose ``selected_alpn_protocol``, so this
+            # structural check stays backend-agnostic (the socket may come from
+            # a forced backend, see ssl_backend=...). We only trust a ``str``
+            # result so unrealistic/mocked sockets fall back gracefully.
+            alpn: str | None = None
+            if hasattr(self.sock, "selected_alpn_protocol"):
+                negotiated = self.sock.selected_alpn_protocol()
+                if isinstance(negotiated, str):
+                    alpn = negotiated
 
-            if is_tcp_tls_conn:
-                alpn: str | None = (
-                    self.sock.selected_alpn_protocol()
-                    if isinstance(self.sock, ssl.SSLSocket)
-                    else self.sock.sslobj.selected_alpn_protocol()  # type: ignore[attr-defined]
+            if alpn == "h2":
+                self._protocol = HTTPProtocolFactory.new(HTTP2Protocol)  # type: ignore[type-abstract]
+                self._svn = HttpVersion.h2
+            elif alpn == "http/1.1":
+                self._protocol = HTTPProtocolFactory.new(HTTP1Protocol)  # type: ignore[type-abstract]
+                self._svn = HttpVersion.h11
+            elif alpn is not None:
+                raise ProtocolError(  # Defensive: ALPN is explicit higher in the stack.
+                    f"Unsupported ALPN '{alpn}' during handshake. Did you try to reach a non-HTTP server ?"
                 )
-
-                if alpn is not None:
-                    if alpn == "h2":
-                        self._protocol = HTTPProtocolFactory.new(HTTP2Protocol)  # type: ignore[type-abstract]
-                        self._svn = HttpVersion.h2
-                    elif alpn == "http/1.1":
-                        self._protocol = HTTPProtocolFactory.new(HTTP1Protocol)  # type: ignore[type-abstract]
-                        self._svn = HttpVersion.h11
-                    else:
-                        raise ProtocolError(  # Defensive: This should be unreachable as ALPN is explicit higher in the stack.
-                            f"Unsupported ALPN '{alpn}' during handshake. Did you try to reach a non-HTTP server ?"
-                        )
-                else:
-                    # no-alpn, let's decide between H2 or H11
-                    # by default, try HTTP/1.1
-                    if HttpVersion.h11 not in self._disabled_svn:
-                        self._protocol = HTTPProtocolFactory.new(HTTP1Protocol)  # type: ignore[type-abstract]
-                        self._svn = HttpVersion.h11
-                    elif HttpVersion.h2 not in self._disabled_svn:
-                        self._protocol = HTTPProtocolFactory.new(HTTP2Protocol)  # type: ignore[type-abstract]
-                        self._svn = HttpVersion.h2
-                    else:
-                        raise RuntimeError(
-                            "No compatible protocol are enabled to emit request. You currently are connected using "
-                            "TCP TLS and must have HTTP/1.1 or/and HTTP/2 enabled to pursue."
-                        )
+            # No ALPN negotiated (plain connection or no agreement): fall back
+            # to a default between HTTP/1.1 and HTTP/2.
+            elif HttpVersion.h11 not in self._disabled_svn:
+                self._protocol = HTTPProtocolFactory.new(HTTP1Protocol)  # type: ignore[type-abstract]
+                self._svn = HttpVersion.h11
+            elif HttpVersion.h2 not in self._disabled_svn:
+                self._protocol = HTTPProtocolFactory.new(HTTP2Protocol)  # type: ignore[type-abstract]
+                self._svn = HttpVersion.h2
             else:
-                # no-TLS, let's decide between H2 or H11
-                # by default, try HTTP/1.1
-                if HttpVersion.h11 not in self._disabled_svn:
-                    self._protocol = HTTPProtocolFactory.new(HTTP1Protocol)  # type: ignore[type-abstract]
-                    self._svn = HttpVersion.h11
-                elif HttpVersion.h2 not in self._disabled_svn:
-                    self._protocol = HTTPProtocolFactory.new(HTTP2Protocol)  # type: ignore[type-abstract]
-                    self._svn = HttpVersion.h2
-                else:
-                    raise RuntimeError(
-                        "No compatible protocol are enabled to emit request. You currently are connected using "
-                        "TCP Unencrypted and must have HTTP/1.1 or/and HTTP/2 enabled to pursue."
-                    )
+                raise RuntimeError(
+                    "No compatible protocol are enabled to emit request. You must "
+                    "have HTTP/1.1 or/and HTTP/2 enabled to pursue."
+                )
         else:  # we or someone manually set the SVN / http version, so load the protocol regardless of what we know.
             if self._svn == HttpVersion.h2:
                 self._protocol = HTTPProtocolFactory.new(HTTP2Protocol)  # type: ignore[type-abstract]

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -680,6 +680,7 @@ class HTTPSConnection(HTTPConnection):
     ssl_version: int | str | None = None
     ssl_minimum_version: int | None = None
     ssl_maximum_version: int | None = None
+    ssl_backend: Literal["rtls", "utls", "ssl"] | None = None
     assert_fingerprint: str | None = None
     cert_file: str | None = None
     key_file: str | None = None
@@ -716,6 +717,7 @@ class HTTPSConnection(HTTPConnection):
         ssl_minimum_version: int | None = None,
         ssl_maximum_version: int | None = None,
         ssl_version: int | str | None = None,
+        ssl_backend: Literal["rtls", "utls", "ssl"] | None = None,
         cert_file: str | None = None,
         key_file: str | None = None,
         key_password: str | None = None,
@@ -760,6 +762,7 @@ class HTTPSConnection(HTTPConnection):
         self.ssl_version = ssl_version
         self.ssl_minimum_version = ssl_minimum_version
         self.ssl_maximum_version = ssl_maximum_version
+        self.ssl_backend = ssl_backend
         self.ca_certs = ca_certs and os.path.expanduser(ca_certs)
         self.ca_cert_dir = ca_cert_dir and os.path.expanduser(ca_cert_dir)
         self.ca_cert_data = ca_cert_data
@@ -841,6 +844,7 @@ class HTTPSConnection(HTTPConnection):
                 ssl_version=self.ssl_version,
                 ssl_minimum_version=self.ssl_minimum_version,
                 ssl_maximum_version=self.ssl_maximum_version,
+                ssl_backend=self.ssl_backend,
                 ca_certs=self.ca_certs,
                 ca_cert_dir=self.ca_cert_dir,
                 ca_cert_data=self.ca_cert_data,
@@ -908,6 +912,7 @@ class HTTPSConnection(HTTPConnection):
             ssl_version=self.ssl_version,
             ssl_minimum_version=self.ssl_minimum_version,
             ssl_maximum_version=self.ssl_maximum_version,
+            ssl_backend=self.ssl_backend,
             ca_certs=self.ca_certs,
             ca_cert_dir=self.ca_cert_dir,
             ca_cert_data=self.ca_cert_data,
@@ -946,6 +951,7 @@ def _ssl_wrap_socket_and_match_hostname(
     ssl_version: None | str | int,
     ssl_minimum_version: int | None,
     ssl_maximum_version: int | None,
+    ssl_backend: Literal["rtls", "utls", "ssl"] | None = None,
     cert_file: str | None,
     key_file: str | None,
     key_password: str | None,
@@ -1019,6 +1025,7 @@ def _ssl_wrap_socket_and_match_hostname(
         ssl_version=resolve_ssl_version(ssl_version, mitigate_tls_version=True),
         ssl_minimum_version=ssl_minimum_version,
         ssl_maximum_version=ssl_maximum_version,
+        ssl_backend=ssl_backend,
         ech_config_list=ech_config_list,
     )
 

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -2114,6 +2114,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         ssl_version: int | str | None = None,
         ssl_minimum_version: ssl.TLSVersion | None = None,
         ssl_maximum_version: ssl.TLSVersion | None = None,
+        ssl_backend: Literal["rtls", "utls", "ssl"] | None = None,
         assert_hostname: str | Literal[False] | None = None,
         assert_fingerprint: str | None = None,
         ca_cert_dir: str | None = None,
@@ -2148,6 +2149,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         self.ssl_version = ssl_version
         self.ssl_minimum_version = ssl_minimum_version
         self.ssl_maximum_version = ssl_maximum_version
+        self.ssl_backend = ssl_backend
         self.ciphers = ciphers
         self.assert_hostname = assert_hostname
         self.assert_fingerprint = assert_fingerprint
@@ -2322,6 +2324,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                                 ssl_version=self.ssl_version,
                                 ssl_minimum_version=self.ssl_minimum_version,
                                 ssl_maximum_version=self.ssl_maximum_version,
+                                ssl_backend=self.ssl_backend,
                                 cert_data=self.cert_data,
                                 key_data=self.key_data,
                                 ciphers=self.ciphers,
@@ -2425,6 +2428,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                     ssl_version=self.ssl_version,
                     ssl_minimum_version=self.ssl_minimum_version,
                     ssl_maximum_version=self.ssl_maximum_version,
+                    ssl_backend=self.ssl_backend,
                     cert_data=self.cert_data,
                     key_data=self.key_data,
                     ciphers=self.ciphers,

--- a/src/urllib3/contrib/anytls/__init__.py
+++ b/src/urllib3/contrib/anytls/__init__.py
@@ -28,10 +28,32 @@ if typing.TYPE_CHECKING:
     BACKEND: str = "ssl"
     HAS_SSL: bool = True
     IS_NONSTDLIB: bool = False
+    # Forced-backend accessors (see ``__getattr__``). All three backends share
+    # the surface used by urllib3, so the stdlib ``ssl`` typing is safe.
+    rtls = ssl
+    utls = ssl
 else:
     ssl, stdlib_ssl, BACKEND, Certificate = _resolve()
     HAS_SSL = ssl is not None
     IS_NONSTDLIB = BACKEND in ("rtls", "utls")
+
+
+def __getattr__(name: str) -> typing.Any:
+    """Lazily expose the individual TLS backends.
+
+    ``rtls`` and ``utls`` resolve to their respective modules (or ``None`` when
+    not installed), regardless of which backend was selected as the default
+    ``ssl``. The stdlib ``ssl`` module is always available as ``stdlib_ssl``.
+    This lets callers force a specific implementation, see
+    :func:`urllib3.util.ssl_.create_urllib3_context` ``ssl_backend``.
+    """
+    if name in ("rtls", "utls"):
+        from ._backend import _try_import
+
+        module = _try_import(name)
+        globals()[name] = module  # cache the result (module or None)
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = (
@@ -41,4 +63,6 @@ __all__ = (
     "HAS_SSL",
     "IS_NONSTDLIB",
     "Certificate",
+    "rtls",
+    "utls",
 )

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -58,6 +58,7 @@ SSL_KEYWORDS = (
     "ssl_version",
     "ssl_minimum_version",
     "ssl_maximum_version",
+    "ssl_backend",
     "ca_cert_dir",
     "ca_cert_data",
     "ssl_context",
@@ -95,6 +96,7 @@ class PoolKey(typing.NamedTuple):
     key_ssl_version: int | str | None
     key_ssl_minimum_version: ssl.TLSVersion | None
     key_ssl_maximum_version: ssl.TLSVersion | None
+    key_ssl_backend: str | None
     key_ca_cert_dir: str | None
     key_ca_cert_data: str | bytes | None
     key_ssl_context: ssl.SSLContext | None

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -225,10 +225,18 @@ if brotli is not None:
         # are for 'brotlipy' and bottom branches for 'Brotli'
         def __init__(self) -> None:
             self._obj = brotli.Decompressor()
+            # brotlicffi honors output_buffer_limit, so can_accept_more_data
+            # is trustworthy. google brotli/brotlipy only expose process(),
+            # ignore the limit and report can_accept_more_data=True while
+            # output is still pending. Track pending output ourselves there
+            # (issue #385).
             if hasattr(self._obj, "decompress"):
                 setattr(self, "_decompress", self._obj.decompress)
+                self._lack_output_buffer_limit = False
             else:
                 setattr(self, "_decompress", self._obj.process)
+                self._lack_output_buffer_limit = True
+            self._pending_output = False
 
         # Requires Brotli >= 1.2.0 for `output_buffer_limit`.
         def _decompress(self, data: bytes, output_buffer_limit: int = -1) -> bytes:
@@ -237,9 +245,11 @@ if brotli is not None:
         def decompress(self, data: bytes, max_length: int = -1) -> bytes:
             try:
                 if max_length > 0:
-                    return self._decompress(data, output_buffer_limit=max_length)
+                    decompressed = self._decompress(
+                        data, output_buffer_limit=max_length
+                    )
                 else:
-                    return self._decompress(data)
+                    decompressed = self._decompress(data)
             except TypeError:
                 # Fallback for Brotli/brotlicffi/brotlipy versions without
                 # the `output_buffer_limit` parameter.
@@ -247,10 +257,15 @@ if brotli is not None:
                     "Brotli >= 1.2.0 is required to prevent decompression bombs.",
                     DependencyWarning,
                 )
-                return self._decompress(data)
+                decompressed = self._decompress(data)
+            # non-empty output means more may remain; drives has_unconsumed_tail.
+            self._pending_output = bool(decompressed)
+            return decompressed
 
         @property
         def has_unconsumed_tail(self) -> bool:
+            if self._lack_output_buffer_limit:
+                return self._pending_output
             try:
                 return not self._obj.can_accept_more_data()
             except AttributeError:

--- a/src/urllib3/util/_async/ssl_.py
+++ b/src/urllib3/util/_async/ssl_.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import io
 import os
+import typing
 import warnings
 from pathlib import Path
+
+if typing.TYPE_CHECKING:
+    from typing_extensions import Literal
 
 from ...contrib.anytls import ssl, IS_NONSTDLIB
 
@@ -59,6 +63,7 @@ async def ssl_wrap_socket(
     ssl_minimum_version: int | None = None,
     ssl_maximum_version: int | None = None,
     ech_config_list: bytes | None = None,
+    ssl_backend: Literal["rtls", "utls", "ssl"] | None = None,
 ) -> SSLAsyncSocket:
     """
     All arguments except for server_hostname, ssl_context, and ca_cert_dir have
@@ -88,6 +93,9 @@ async def ssl_wrap_socket(
         Specify an in-memory client intermediary certificate for mTLS.
     :param keydata:
         Specify an in-memory client intermediary key for mTLS.
+    :param ssl_backend:
+        Force the TLS implementation (``"rtls"``, ``"utls"`` or ``"ssl"``)
+        used to build the context. Ignored when ``ssl_context`` is provided.
     """
     context = ssl_context
 
@@ -110,6 +118,7 @@ async def ssl_wrap_socket(
         ssl_minimum_version,
         ssl_maximum_version,
         check_hostname,
+        ssl_backend,
     ):
         cached_ctx = _SSLContextCache.get() if not cache_disabled else None
 
@@ -122,6 +131,7 @@ async def ssl_wrap_socket(
                     caller_id=_KnownCaller.NIQUESTS,
                     ssl_minimum_version=ssl_minimum_version,
                     ssl_maximum_version=ssl_maximum_version,
+                    ssl_backend=ssl_backend,
                 )
 
             if cert_reqs is not None:

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -446,6 +446,7 @@ def create_urllib3_context(
     ssl_minimum_version: int | None = None,
     ssl_maximum_version: int | None = None,
     caller_id: _KnownCaller | None = None,
+    ssl_backend: Literal["rtls", "utls", "ssl"] | None = None,
 ) -> ssl.SSLContext:
     """Creates and configures an :class:`ssl.SSLContext` instance for use with urllib3.
 
@@ -469,6 +470,12 @@ def create_urllib3_context(
     :param ciphers:
         Which cipher suites to allow the server to select. Defaults to either system configured
         ciphers if OpenSSL 1.1.1+, otherwise uses a secure default set of ciphers.
+    :param ssl_backend:
+        Force the TLS implementation used to build the context, one of
+        ``"rtls"``, ``"utls"`` or ``"ssl"`` (stdlib). Defaults to ``None``,
+        which uses the backend resolved by :mod:`urllib3.contrib.anytls`.
+        Raises :class:`~urllib3.exceptions.SSLError` if the requested backend
+        is not available.
     :returns:
         Constructed SSLContext object with specified options
     :rtype: SSLContext
@@ -476,13 +483,50 @@ def create_urllib3_context(
     if SSLContext is None:
         raise TypeError("Can't create an SSLContext object without an ssl module")
 
+    if ssl_backend is not None:
+        from ..contrib import anytls
+
+        active_ssl = (
+            anytls.stdlib_ssl if ssl_backend == "ssl" else getattr(anytls, ssl_backend)
+        )
+        if active_ssl is None:
+            raise SSLError(
+                f"The requested TLS backend {ssl_backend!r} is not available."
+            )
+        active_is_nonstdlib = ssl_backend in ("rtls", "utls")
+        ssl_context_class = active_ssl.SSLContext
+        protocol_tls = active_ssl.PROTOCOL_TLS
+        protocol_tls_client = active_ssl.PROTOCOL_TLS_CLIENT
+        tls_version = active_ssl.TLSVersion
+        cert_required = active_ssl.CERT_REQUIRED
+        # Option bit flags are library-specific; use the active backend's
+        # values (falling back to the resolved-default constants when absent).
+        op_no_sslv2 = getattr(active_ssl, "OP_NO_SSLv2", OP_NO_SSLv2)
+        op_no_sslv3 = getattr(active_ssl, "OP_NO_SSLv3", OP_NO_SSLv3)
+        op_no_compression = getattr(active_ssl, "OP_NO_COMPRESSION", OP_NO_COMPRESSION)
+        op_no_ticket = getattr(active_ssl, "OP_NO_TICKET", OP_NO_TICKET)
+    else:
+        # Default path: keep using the module-level globals (resolved by
+        # anytls at import time, and patchable in tests).
+        active_ssl = ssl
+        active_is_nonstdlib = IS_NONSTDLIB
+        ssl_context_class = SSLContext
+        protocol_tls = PROTOCOL_TLS
+        protocol_tls_client = PROTOCOL_TLS_CLIENT
+        tls_version = TLSVersion
+        cert_required = CERT_REQUIRED
+        op_no_sslv2 = OP_NO_SSLv2
+        op_no_sslv3 = OP_NO_SSLv3
+        op_no_compression = OP_NO_COMPRESSION
+        op_no_ticket = OP_NO_TICKET
+
     if caller_id is None:
         # a version of Requests attempted the ssl_ctx caching from globals in adapters.py
         # calling this function directly... Requests regretted that change.
         caller_id = _caller_id()
 
     # This means 'ssl_version' was specified as an exact value.
-    if ssl_version not in (None, PROTOCOL_TLS, PROTOCOL_TLS_CLIENT):
+    if ssl_version not in (None, protocol_tls, protocol_tls_client):
         # Disallow setting 'ssl_version' and 'ssl_minimum|maximum_version'
         # to avoid conflicts.
         if ssl_minimum_version is not None or ssl_maximum_version is not None:
@@ -492,21 +536,23 @@ def create_urllib3_context(
             )
 
         else:
-            if hasattr(ssl, "TLSVersion") and isinstance(ssl_version, ssl.TLSVersion):
+            if hasattr(active_ssl, "TLSVersion") and isinstance(
+                ssl_version, tls_version
+            ):
                 ssl_minimum_version = ssl_version
                 ssl_maximum_version = ssl_version
             else:
                 # Use 'ssl_minimum_version' and 'ssl_maximum_version' instead.
                 assert ssl_version is not None  # guarded by `not in (None, ...)`
                 ssl_minimum_version = _SSL_VERSION_TO_TLS_VERSION.get(
-                    ssl_version, TLSVersion.MINIMUM_SUPPORTED
+                    ssl_version, tls_version.MINIMUM_SUPPORTED
                 )
                 ssl_maximum_version = _SSL_VERSION_TO_TLS_VERSION.get(
-                    ssl_version, TLSVersion.MAXIMUM_SUPPORTED
+                    ssl_version, tls_version.MAXIMUM_SUPPORTED
                 )
 
     # PROTOCOL_TLS is deprecated in Python 3.10 so we always use PROTOCOL_TLS_CLIENT
-    context = SSLContext(PROTOCOL_TLS_CLIENT)
+    context: ssl.SSLContext = ssl_context_class(protocol_tls_client)
 
     # utls (BoringSSL) have a way to propose
     # autoconfiguration of context based
@@ -518,7 +564,7 @@ def create_urllib3_context(
         and ssl_maximum_version is None
         and ciphers is None
         and options is None
-        and (ssl_version is None or ssl_version in {PROTOCOL_TLS, PROTOCOL_TLS_CLIENT})
+        and (ssl_version is None or ssl_version in {protocol_tls, protocol_tls_client})
     )
     default_tlsv1_2: bool = False
 
@@ -526,7 +572,7 @@ def create_urllib3_context(
         if ssl_minimum_version is not None:
             context.minimum_version = ssl_minimum_version  # type: ignore[assignment]
         else:  # Python <3.10 defaults to 'MINIMUM_SUPPORTED' so explicitly set TLSv1.2 here
-            context.minimum_version = TLSVersion.TLSv1_2
+            context.minimum_version = tls_version.TLSv1_2
             default_tlsv1_2 = True
 
         if ssl_maximum_version is not None:
@@ -543,29 +589,29 @@ def create_urllib3_context(
             # avoid relying on cpython default cipher list
             # and instead retrieve OpenSSL own default. This should make
             # urllib3.future less flagged by basic firewall anti-bot rules.
-            if not IS_NONSTDLIB:
+            if not active_is_nonstdlib:
                 # the cipher list only contain entries for TLS 1.2
                 # because CPython stdlib enforce TLS 1.3 ciphers automatically
                 # when it's enabled.
                 context.set_ciphers(MOZ_INTERMEDIATE_CIPHERS)
 
     # Setting the default here, as we may have no ssl module on import
-    cert_reqs = ssl.CERT_REQUIRED if cert_reqs is None else cert_reqs
+    cert_reqs = cert_required if cert_reqs is None else cert_reqs
 
     if options is None:
         options = 0
         # SSLv2 is easily broken and is considered harmful and dangerous
-        options |= OP_NO_SSLv2
+        options |= op_no_sslv2
         # SSLv3 has several problems and is now dangerous
-        options |= OP_NO_SSLv3
+        options |= op_no_sslv3
         # Disable compression to prevent CRIME attacks for OpenSSL 1.0+
         # (issue #309)
-        options |= OP_NO_COMPRESSION
+        options |= op_no_compression
         # TLSv1.2 only. Unless set explicitly, do not request tickets.
         # This may save some bandwidth on wire, and although the ticket is encrypted,
         # there is a risk associated with it being on wire,
         # if the server is not rotating its ticketing keys properly.
-        options |= OP_NO_TICKET
+        options |= op_no_ticket
 
     if should_use_browser_autoconfig:
         context.set_fingerprint("chrome:stable")  # type: ignore[attr-defined]
@@ -578,7 +624,7 @@ def create_urllib3_context(
     # versions of Python.  We only enable on Python 3.7.4+ or if certificate
     # verification is enabled to work around Python issue #37428
     # See: https://bugs.python.org/issue37428
-    if (cert_reqs == ssl.CERT_REQUIRED or sys.version_info >= (3, 7, 4)) and getattr(
+    if (cert_reqs == cert_required or sys.version_info >= (3, 7, 4)) and getattr(
         context, "post_handshake_auth", None
     ) is not None:
         context.post_handshake_auth = True
@@ -588,7 +634,7 @@ def create_urllib3_context(
     # check_hostname=True, verify_mode=NONE/OPTIONAL.
     # We always set 'check_hostname=False' for pyOpenSSL so we rely on our own
     # 'ssl.match_hostname()' implementation.
-    if cert_reqs == ssl.CERT_REQUIRED:
+    if cert_reqs == cert_required:
         context.verify_mode = cert_reqs  # type: ignore[assignment]
         context.check_hostname = True
     else:
@@ -637,6 +683,7 @@ def ssl_wrap_socket(
     ssl_minimum_version: int | None = ...,
     ssl_maximum_version: int | None = ...,
     ech_config_list: bytes | None = ...,
+    ssl_backend: Literal["rtls", "utls", "ssl"] | None = ...,
 ) -> ssl.SSLSocket: ...
 
 
@@ -662,6 +709,7 @@ def ssl_wrap_socket(
     ssl_minimum_version: int | None = ...,
     ssl_maximum_version: int | None = ...,
     ech_config_list: bytes | None = ...,
+    ssl_backend: Literal["rtls", "utls", "ssl"] | None = ...,
 ) -> ssl.SSLSocket | SSLTransportType: ...
 
 
@@ -686,6 +734,7 @@ def ssl_wrap_socket(
     ssl_minimum_version: int | None = None,
     ssl_maximum_version: int | None = None,
     ech_config_list: bytes | None = None,
+    ssl_backend: Literal["rtls", "utls", "ssl"] | None = None,
 ) -> ssl.SSLSocket | SSLTransportType:
     """
     All arguments except for server_hostname, ssl_context, and ca_cert_dir have
@@ -715,6 +764,9 @@ def ssl_wrap_socket(
         Specify an in-memory client intermediary certificate for mTLS.
     :param keydata:
         Specify an in-memory client intermediary key for mTLS.
+    :param ssl_backend:
+        Force the TLS implementation (``"rtls"``, ``"utls"`` or ``"ssl"``)
+        used to build the context. Ignored when ``ssl_context`` is provided.
     """
     context = ssl_context
     cache_disabled: bool = context is not None
@@ -736,6 +788,7 @@ def ssl_wrap_socket(
         ssl_minimum_version,
         ssl_maximum_version,
         check_hostname,
+        ssl_backend,
     ):
         cached_ctx = _SSLContextCache.get() if not cache_disabled else None
 
@@ -750,6 +803,7 @@ def ssl_wrap_socket(
                     caller_id=_caller_id(),
                     ssl_minimum_version=ssl_minimum_version,
                     ssl_maximum_version=ssl_maximum_version,
+                    ssl_backend=ssl_backend,
                 )
 
             if cert_reqs is not None:

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -345,16 +345,13 @@ class TestResponse:
         # issue #385: google brotli truncated stream(amt=-1) on large bodies.
         # Payload must exceed the decoder's ~32 KiB internal buffer.
         uncompressed = b"".join(
-            f'{{"id": {i}, "name": "row-{i}-padding"}}\n'.encode()
-            for i in range(50000)
+            f'{{"id": {i}, "name": "row-{i}-padding"}}\n'.encode() for i in range(50000)
         )
         assert len(uncompressed) > 1_000_000
         data = brotli.compress(uncompressed)
 
         fp = BytesIO(data)
-        r = HTTPResponse(
-            fp, headers={"content-encoding": "br"}, preload_content=False
-        )
+        r = HTTPResponse(fp, headers={"content-encoding": "br"}, preload_content=False)
 
         chunks = list(r.stream(amt=-1))
         assert b"".join(chunks) == uncompressed

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -340,6 +340,25 @@ class TestResponse:
         with pytest.raises(DecodeError):
             HTTPResponse(fp, headers={"content-encoding": "br"})
 
+    @onlyBrotli()
+    def test_brotli_stream_amt_negative_one_not_truncated(self) -> None:
+        # issue #385: google brotli truncated stream(amt=-1) on large bodies.
+        # Payload must exceed the decoder's ~32 KiB internal buffer.
+        uncompressed = b"".join(
+            f'{{"id": {i}, "name": "row-{i}-padding"}}\n'.encode()
+            for i in range(50000)
+        )
+        assert len(uncompressed) > 1_000_000
+        data = brotli.compress(uncompressed)
+
+        fp = BytesIO(data)
+        r = HTTPResponse(
+            fp, headers={"content-encoding": "br"}, preload_content=False
+        )
+
+        chunks = list(r.stream(amt=-1))
+        assert b"".join(chunks) == uncompressed
+
     @onlyZstd()
     def test_decode_zstd(self) -> None:
         data = zstd.compress(b"foo")

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -216,3 +216,45 @@ class TestSSL:
             ssl_.assert_fingerprint(
                 cert=None, fingerprint="55:39:BF:70:05:12:43:FA:1F:D1:BF:4E:E8:1B:07:1D"
             )
+
+    def test_create_urllib3_context_force_stdlib_backend(self) -> None:
+        ctx = ssl_.create_urllib3_context(ssl_backend="ssl")
+        # The stdlib backend must always produce a stdlib ``ssl.SSLContext``.
+        assert type(ctx).__module__ == "ssl"
+
+    @pytest.mark.parametrize("backend", ["rtls", "utls"])
+    def test_create_urllib3_context_force_nonstdlib_backend(self, backend: str) -> None:
+        from urllib3.contrib import anytls
+
+        module = getattr(anytls, backend)
+        if module is None:
+            pytest.skip(f"{backend} backend is not installed")
+
+        ctx = ssl_.create_urllib3_context(ssl_backend=backend)  # type: ignore[arg-type]
+        assert type(ctx).__module__.split(".")[0] == backend
+
+    def test_create_urllib3_context_force_unavailable_backend(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from urllib3.contrib import anytls
+
+        monkeypatch.setattr(anytls, "utls", None, raising=False)
+        with pytest.raises(SSLError, match="utls.* is not available"):
+            ssl_.create_urllib3_context(ssl_backend="utls")
+
+    def test_ssl_backend_changes_ssl_context_cache_key(self) -> None:
+        # Forcing different backends must not collide in the SSLContext cache.
+        from urllib3.util.ssl_ import _SSLContextCache
+
+        keys = []
+        for backend in ("ssl", "rtls", "utls", None):
+            args = [None] * 16 + [backend]
+            with _SSLContextCache.lock(*args):
+                keys.append(_SSLContextCache._cursor)
+        assert len(set(keys)) == len(keys)
+
+    def test_anytls_getattr_unknown_attribute(self) -> None:
+        from urllib3.contrib import anytls
+
+        with pytest.raises(AttributeError):
+            anytls.does_not_exist

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1030,6 +1030,7 @@ class TestUtilSSL:
             caller_id=_KnownCaller.OTHER,
             ssl_minimum_version=None,
             ssl_maximum_version=None,
+            ssl_backend=None,
         )
 
     def test_ssl_wrap_socket_loads_verify_locations(self) -> None:


### PR DESCRIPTION
2.22.900 (2026-06-26)
=====================

- Added pool level TLS backend selection. You can dynamically use ``rtls`` or ``utls`` or ``ssl`` via programmatic kwargs ``ssl_backend``.
  E.g. ``PoolManager(ssl_backend="utls")`` to instantiate a PoolManager with BoringSSL backend. Supported values are ``utls``, ``rtls``, ``ssl``
  or ``None`` (default).
- Fixed unconsummated tail with the Brotli decoder using amt=-1. (#385)
