### PR TITLE
fix: stream(amt)/read(amt) blocking until amt bytes accumulate

### DIFF
--- a/changelog/379.bugfix.rst
+++ b/changelog/379.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed ``HTTPResponse.stream(amt)`` and ``HTTPResponse.read(amt)`` (and the async equivalents) blocking on
+the socket until ``amt`` bytes accumulated instead of serving data as it arrived. On live streams that send
+a burst of data then go idle (e.g. Server-Sent Events), the initial payload was withheld indefinitely when
+smaller than ``amt``, and an in-process buffered remainder smaller than ``amt`` triggered a blocking socket
+read instead of being served. The previous fix for (#379) only exercised a mocked backend and did not cover
+real connections; this applies to all protocols (HTTP/1.1, HTTP/2 and HTTP/3).

--- a/src/urllib3/backend/_async/_base.py
+++ b/src/urllib3/backend/_async/_base.py
@@ -243,9 +243,11 @@ class AsyncLowLevelResponse:
             return b""  # Defensive: This is unreachable, this case is already covered higher in the stack.
 
         buf_capacity = len(self.__buffer_excess)
-        data_ready_to_go = (
-            __size is not None and buf_capacity > 0 and buf_capacity >= __size
-        )
+        # any buffered data must be served first, even if smaller than
+        # __size: reaching for the socket while holding deliverable bytes
+        # can block forever on a live stream (e.g. SSE).
+        # see https://github.com/jawah/urllib3.future/issues/379
+        data_ready_to_go = __size is not None and buf_capacity > 0
 
         if self._eot is False and not data_ready_to_go:
             chunks, self._eot, self.trailers = await self.__internal_read_st(

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -1157,6 +1157,18 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                             if reshelve_events:
                                 protocol.reshelve(*reshelve_events)
                             return events
+
+                        # serving a sized body read (maximal_data_in_read is set)
+                        # and some data has been collected already: return it now
+                        # instead of blocking on the socket until the cap is
+                        # reached. A live stream (e.g. SSE) may leave the
+                        # connection idle long after sending a partial payload.
+                        # see https://github.com/jawah/urllib3.future/issues/379
+                        if maximal_data_in_read is not None and data_in_len > 0:
+                            if reshelve_events:
+                                protocol.reshelve(*reshelve_events)
+                            return events
+
                         continue
 
                     if reshelve_events:

--- a/src/urllib3/backend/_base.py
+++ b/src/urllib3/backend/_base.py
@@ -351,9 +351,11 @@ class LowLevelResponse:
             return b""  # Defensive: This is unreachable, this case is already covered higher in the stack.
 
         buf_capacity = len(self.__buffer_excess)
-        data_ready_to_go = (
-            __size is not None and buf_capacity > 0 and buf_capacity >= __size
-        )
+        # any buffered data must be served first, even if smaller than
+        # __size: reaching for the socket while holding deliverable bytes
+        # can block forever on a live stream (e.g. SSE).
+        # see https://github.com/jawah/urllib3.future/issues/379
+        data_ready_to_go = __size is not None and buf_capacity > 0
 
         if self._eot is False and not data_ready_to_go:
             chunks, self._eot, self.trailers = self.__internal_read_st(

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -1254,6 +1254,18 @@ class HfaceBackend(BaseBackend):
                             if reshelve_events:
                                 protocol.reshelve(*reshelve_events)
                             return events
+
+                        # serving a sized body read (maximal_data_in_read is set)
+                        # and some data has been collected already: return it now
+                        # instead of blocking on the socket until the cap is
+                        # reached. A live stream (e.g. SSE) may leave the
+                        # connection idle long after sending a partial payload.
+                        # see https://github.com/jawah/urllib3.future/issues/379
+                        if maximal_data_in_read is not None and data_in_len > 0:
+                            if reshelve_events:
+                                protocol.reshelve(*reshelve_events)
+                            return events
+
                         continue
 
                     if reshelve_events:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -2322,6 +2322,67 @@ class TestStream(SocketDummyServerTestCase):
 
             done_event.set()
 
+    @pytest.mark.parametrize("amt", [4096, 10000])
+    def test_stream_amt_serves_available_data_without_blocking(self, amt: int) -> None:
+        # Regression test for https://github.com/jawah/urllib3.future/issues/379
+        # SSE-like response: the server sends one 5479 bytes burst, then keeps
+        # the connection open (more data may come much later). ``stream(amt)``
+        # must serve available data instead of blocking until ``amt`` bytes
+        # accumulate. Both traps are exercised here:
+        #   amt=10000: burst < amt, the first read used to block on the socket
+        #   amt=4096: the buffered 1383 bytes remainder < amt, serving it used
+        #             to trigger a blocking socket read
+        payload = b"event:put\ndata:" + b"x" * 5462 + b"\n\n"
+        assert len(payload) == 5479
+
+        done_event = Event()
+
+        def socket_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+
+            sock.sendall(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/event-stream\r\n"
+                b"Transfer-Encoding: chunked\r\n"
+                b"\r\n" + (b"%x\r\n" % len(payload)) + payload + b"\r\n"
+            )
+
+            done_event.wait(LONG_TIMEOUT * 10)
+            sock.sendall(b"0\r\n\r\n")
+            sock.close()
+
+        self._start_server(socket_handler)
+
+        with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
+            resp = pool.request(
+                "GET",
+                "/",
+                timeout=util.Timeout(connect=LONG_TIMEOUT, read=2),
+                preload_content=False,
+            )
+
+            stream = resp.stream(amt)
+
+            received = 0
+
+            while received < len(payload):
+                # pre-fix: ReadTimeoutError, the client blocked on the socket
+                # even though data was available (or already buffered).
+                chunk = next(stream)
+                assert 0 < len(chunk) <= amt
+                received += len(chunk)
+
+            assert received == len(payload)
+
+            done_event.set()
+
+            # consume the end of stream cleanly.
+            assert b"".join(stream) == b""
+
     def test_large_compressed_stream(self) -> None:
         done_event = Event()
         expected_total_length = 296085

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -2460,11 +2460,15 @@ class TestBadContentLength(SocketDummyServerTestCase):
                 "GET", url="/", preload_content=False, enforce_content_length=True
             )
             data = get_response.stream(100)
+            # the available 12 bytes are yielded as they arrive; the
+            # content-length violation surfaces when reaching the premature
+            # end of stream.
+            assert next(data) == b"hello, world"
+            done_event.set()
             with pytest.raises(
                 IncompleteRead, match=r"12 bytes read\, 10 more expected"
             ):
                 next(data)
-            done_event.set()
 
     def test_enforce_content_length_no_body(self) -> None:
         done_event = Event()

--- a/test/with_traefik/asynchronous/test_stream.py
+++ b/test/with_traefik/asynchronous/test_stream.py
@@ -6,7 +6,7 @@ from json import JSONDecodeError, loads
 
 import pytest
 
-from urllib3 import AsyncHTTPSConnectionPool
+from urllib3 import AsyncHTTPSConnectionPool, HttpVersion
 from urllib3.backend._async.hface import _HAS_HTTP3_SUPPORT  # type: ignore
 
 from .. import TraefikTestCase
@@ -98,6 +98,52 @@ class TestStreamResponse(TraefikTestCase):
                     f"did not yield decodable JSON: {e}"
                 )
             assert payload.get("gzipped") is True
+
+    @pytest.mark.parametrize("target_http", [11, 20, 30])
+    async def test_sse_stream_amt_yields_per_event(self, target_http: int) -> None:
+        # Async mirror of the regression test for
+        # https://github.com/jawah/urllib3.future/issues/379
+        # ``stream(amt)`` against a live stream (here SSE) must yield data as
+        # it arrives, even when fewer than ``amt`` bytes are available, instead
+        # of blocking until ``amt`` bytes accumulate or the stream ends.
+        if target_http == 30 and _HAS_HTTP3_SUPPORT() is False:
+            pytest.skip("Test requires http3 support")
+
+        disabled_svn = {
+            11: {HttpVersion.h2, HttpVersion.h3},
+            20: {HttpVersion.h11, HttpVersion.h3},
+            30: {HttpVersion.h11, HttpVersion.h2},
+        }[target_http]
+
+        async with AsyncHTTPSConnectionPool(
+            self.host,
+            self.https_port,
+            ca_certs=self.ca_authority,
+            resolver=self.test_async_resolver.new(),
+            disabled_svn=disabled_svn,
+            retries=False,
+        ) as p:
+            resp = await p.request(
+                "GET", "/sse?delay=1s&count=5", preload_content=False
+            )
+
+            assert resp.status == 200
+            assert resp.version == target_http
+
+            chunks = []
+
+            async for chunk in resp.stream(2**16):
+                chunks.append(chunk)
+
+            payload = b"".join(chunks)
+            assert payload.count(b"event:") == 5
+
+            # the whole stream is far smaller than ``amt``: the broken
+            # behavior was a single monolithic yield delivered only once
+            # the server closed the stream. Per-arrival delivery must give
+            # us the first event alone in the first yield.
+            assert chunks[0].count(b"event:") == 1
+            assert len(chunks) >= 5
 
     async def test_read_zero(self) -> None:
         async with AsyncHTTPSConnectionPool(

--- a/test/with_traefik/test_stream.py
+++ b/test/with_traefik/test_stream.py
@@ -6,7 +6,7 @@ from json import JSONDecodeError, loads
 
 import pytest
 
-from urllib3 import HTTPSConnectionPool
+from urllib3 import HTTPSConnectionPool, HttpVersion
 from urllib3.backend.hface import _HAS_HTTP3_SUPPORT
 
 from . import TraefikTestCase
@@ -102,6 +102,46 @@ class TestStreamResponse(TraefikTestCase):
                     f"did not yield decodable JSON: {e}"
                 )
             assert payload.get("gzipped") is True
+
+    @pytest.mark.parametrize("target_http", [11, 20, 30])
+    def test_sse_stream_amt_yields_per_event(self, target_http: int) -> None:
+        # Regression test for https://github.com/jawah/urllib3.future/issues/379
+        # ``stream(amt)`` against a live stream (here SSE) must yield data as
+        # it arrives, even when fewer than ``amt`` bytes are available, instead
+        # of blocking until ``amt`` bytes accumulate or the stream ends.
+        if target_http == 30 and _HAS_HTTP3_SUPPORT() is False:
+            pytest.skip("Test requires http3 support")
+
+        disabled_svn = {
+            11: {HttpVersion.h2, HttpVersion.h3},
+            20: {HttpVersion.h11, HttpVersion.h3},
+            30: {HttpVersion.h11, HttpVersion.h2},
+        }[target_http]
+
+        with HTTPSConnectionPool(
+            self.host,
+            self.https_port,
+            ca_certs=self.ca_authority,
+            resolver=[self.test_resolver_raw],
+            disabled_svn=disabled_svn,
+            retries=False,
+        ) as p:
+            resp = p.request("GET", "/sse?delay=1s&count=5", preload_content=False)
+
+            assert resp.status == 200
+            assert resp.version == target_http
+
+            chunks = list(resp.stream(2**16))
+
+            payload = b"".join(chunks)
+            assert payload.count(b"event:") == 5
+
+            # the whole stream is far smaller than ``amt``: the broken
+            # behavior was a single monolithic yield delivered only once
+            # the server closed the stream. Per-arrival delivery must give
+            # us the first event alone in the first yield.
+            assert chunks[0].count(b"event:") == 1
+            assert len(chunks) >= 5
 
     def test_read_zero(self) -> None:
         with HTTPSConnectionPool(


### PR DESCRIPTION
HTTPResponse.stream(amt) and read(amt) (sync and async) blocked on the socket until amt bytes accumulated or the stream ended, instead of serving data as it arrived. Two compounding defects:

- HfaceBackend.__exchange_until kept looping back to a blocking sock.recv() after collecting DataReceived events whenever data_in_len < maximal_data_in_read and the stream was still open.
- LowLevelResponse.read refused to serve an in-process buffered remainder smaller than the requested size and reached for the wire instead, blocking on an idle connection.

On live streams that burst then idle (e.g. Server-Sent Events, such as LaunchDarkly's SDK stream read via resp.stream(10000)), the initial payload was withheld indefinitely. The prior fix for #379 (2.21.900) only unblocked a mocked backend layer, so real connections kept hanging; this addresses the backend itself, for HTTP/1.1, HTTP/2 and HTTP/3 alike.

Adds a socket-level regression test reproducing the SSE burst-then-idle shape for both traps, and e2e /sse tests (sync + async) over h11, h2 and h3 via the traefik test infrastructure. Adapts test_enforce_content_length_get: available bytes are now yielded as they arrive, the IncompleteRead surfaces on the following iteration.

<!---
Hello!

If this is your first PR to urllib3.future please review the Contributing Guide:
https://urllib3future.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
