### PR TITLE
Release 2.22.901

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@
   real connections; this applies to all protocols (HTTP/1.1, HTTP/2 and HTTP/3). (#379)
 - Fixed ``AsyncHTTPConnectionPool.get_response`` and ``AsyncPoolManager.get_response`` return ``None``
   (no promise left to resolve) without ever yielding control to the event loop. (#384)
+- Fixed abrupt exception when ``ctypes`` isn't available in interpreter (imcc).
 
 2.22.900 (2026-06-26)
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,15 @@
+2.22.901 (2026-07-09)
+=====================
+
+- Fixed ``HTTPResponse.stream(amt)`` and ``HTTPResponse.read(amt)`` (and the async equivalents) blocking on
+  the socket until ``amt`` bytes accumulated instead of serving data as it arrived. On live streams that send
+  a burst of data then go idle (e.g. Server-Sent Events), the initial payload was withheld indefinitely when
+  smaller than ``amt``, and an in-process buffered remainder smaller than ``amt`` triggered a blocking socket
+  read instead of being served. The previous fix for (#379) only exercised a mocked backend and did not cover
+  real connections; this applies to all protocols (HTTP/1.1, HTTP/2 and HTTP/3). (#379)
+- Fixed ``AsyncHTTPConnectionPool.get_response`` and ``AsyncPoolManager.get_response`` return ``None``
+  (no promise left to resolve) without ever yielding control to the event loop. (#384)
+
 2.22.900 (2026-06-26)
 =====================
 

--- a/changelog/379.bugfix.rst
+++ b/changelog/379.bugfix.rst
@@ -1,6 +1,0 @@
-Fixed ``HTTPResponse.stream(amt)`` and ``HTTPResponse.read(amt)`` (and the async equivalents) blocking on
-the socket until ``amt`` bytes accumulated instead of serving data as it arrived. On live streams that send
-a burst of data then go idle (e.g. Server-Sent Events), the initial payload was withheld indefinitely when
-smaller than ``amt``, and an in-process buffered remainder smaller than ``amt`` triggered a blocking socket
-read instead of being served. The previous fix for (#379) only exercised a mocked backend and did not cover
-real connections; this applies to all protocols (HTTP/1.1, HTTP/2 and HTTP/3).

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -889,6 +889,9 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
                     self._raise_timeout(err=e, url=url, timeout_value=conn.timeout)
                     raise
         except UnavailableTraffic:
+            # force a cooperative checkpoint to keep the event loop running
+            # see https://github.com/jawah/urllib3.future/issues/384
+            await asyncio.sleep(0)
             return None
         except (
             TimeoutError,

--- a/src/urllib3/_async/poolmanager.py
+++ b/src/urllib3/_async/poolmanager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import typing
 import warnings
@@ -478,6 +479,9 @@ class AsyncPoolManager(AsyncRequestMethods):
             ) as pool:
                 response = await pool.get_response(promise=promise)
         except UnavailableTraffic:
+            # force a cooperative checkpoint to keep the event loop running
+            # see https://github.com/jawah/urllib3.future/issues/384
+            await asyncio.sleep(0)
             return None
 
         if promise is not None and response is None:

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.22.900"
+__version__ = "2.22.901"

--- a/src/urllib3/contrib/imcc/__init__.py
+++ b/src/urllib3/contrib/imcc/__init__.py
@@ -6,7 +6,14 @@ from io import UnsupportedOperation
 if typing.TYPE_CHECKING:
     import ssl
 
-from ._ctypes import load_cert_chain as _ctypes_load_cert_chain
+try:
+    from ._ctypes import load_cert_chain as _ctypes_load_cert_chain
+except ImportError:  # Defensive: Python not built with ctype extension.
+
+    def _ctypes_load_cert_chain(*args, **kwargs):  # type: ignore[no-untyped-def,misc]
+        raise UnsupportedOperation("ctypes not available")
+
+
 from ._shm import load_cert_chain as _shm_load_cert_chain
 from ._fifo import load_cert_chain as _fifo_load_cert_chain
 

--- a/test/test_async_connectionpool.py
+++ b/test/test_async_connectionpool.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from urllib3._async.connectionpool import AsyncHTTPConnectionPool
@@ -41,5 +43,53 @@ async def test_keepalive_idle_window_clamps_to_minimum() -> None:
     try:
         assert pool._keepalive_idle_window is not None
         assert pool._keepalive_idle_window >= MINIMAL_KEEPALIVE_IDLE_WINDOW
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_get_response_none_path_yields_control() -> None:
+    """Regression test for https://github.com/jawah/urllib3.future/issues/384"""
+
+    class FakeSaturatedConn:
+        is_idle = False  # a pending, not fully consumed, response
+        is_saturated = True  # no more concurrent stream can be opened
+
+        async def close(self) -> None:
+            return None
+
+    pool = AsyncHTTPConnectionPool(host="localhost", maxsize=1)
+
+    try:
+        assert pool.pool is not None
+        await pool.pool.put(FakeSaturatedConn())  # type: ignore[arg-type]
+
+        assert pool.is_saturated is True
+        assert pool.is_idle is False
+
+        # the semantic contract is unchanged: nothing reapable -> None
+        assert await pool.get_response() is None
+
+        beats = 0
+
+        async def heartbeat() -> None:
+            nonlocal beats
+            while True:
+                beats += 1
+                await asyncio.sleep(0)
+
+        unrelated_task = asyncio.get_running_loop().create_task(heartbeat())
+        await asyncio.sleep(0)  # let the heartbeat task start
+
+        # bounded variant of the niquests saturated drain loop shape
+        for _ in range(512):
+            if pool.is_idle:
+                break
+            await pool.get_response()
+
+        unrelated_task.cancel()
+
+        # without the checkpoint the heartbeat task never runs (beats <= 1)
+        assert beats > 1
     finally:
         await pool.close()

--- a/test/test_async_poolmanager.py
+++ b/test/test_async_poolmanager.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from urllib3 import AsyncPoolManager
+
+
+@pytest.mark.asyncio
+async def test_get_response_none_path_yields_control() -> None:
+    """Regression test for https://github.com/jawah/urllib3.future/issues/384"""
+    async with AsyncPoolManager() as pm:
+        # the semantic contract is unchanged: no promise pending -> None
+        assert await pm.get_response() is None
+
+        beats = 0
+
+        async def heartbeat() -> None:
+            nonlocal beats
+            while True:
+                beats += 1
+                await asyncio.sleep(0)
+
+        unrelated_task = asyncio.get_running_loop().create_task(heartbeat())
+        await asyncio.sleep(0)  # let the heartbeat task start
+
+        for _ in range(512):
+            await pm.get_response()
+
+        unrelated_task.cancel()
+
+        # without the checkpoint the heartbeat task never runs (beats <= 1)
+        assert beats > 1


### PR DESCRIPTION
2.22.901 (2026-07-09)
=====================

- Fixed ``HTTPResponse.stream(amt)`` and ``HTTPResponse.read(amt)`` (and the async equivalents) blocking on
  the socket until ``amt`` bytes accumulated instead of serving data as it arrived. On live streams that send
  a burst of data then go idle (e.g. Server-Sent Events), the initial payload was withheld indefinitely when
  smaller than ``amt``, and an in-process buffered remainder smaller than ``amt`` triggered a blocking socket
  read instead of being served. The previous fix for (#379) only exercised a mocked backend and did not cover
  real connections; this applies to all protocols (HTTP/1.1, HTTP/2 and HTTP/3). (#379)
- Fixed ``AsyncHTTPConnectionPool.get_response`` and ``AsyncPoolManager.get_response`` return ``None``
  (no promise left to resolve) without ever yielding control to the event loop. (#384)
- Fixed abrupt exception when ``ctypes`` isn't available in interpreter (imcc).
