### PR TITLE
fix: cap quic pto below total timeout

### DIFF
--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -652,11 +652,18 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         if self._max_tolerable_delay_for_upgrade is not None:
             self.sock.settimeout(self._max_tolerable_delay_for_upgrade)
 
+        handshake_timeout = self.sock.gettimeout()
+        handshake_deadline = (
+            None
+            if handshake_timeout is None
+            else time.monotonic() + handshake_timeout
+        )
         # it may be required to send some initial data, aka. magic header (PRI * HTTP/2..)
         try:
             await self.__exchange_until(
                 HandshakeCompleted,
                 receive_first=False,
+                deadline=handshake_deadline,
             )
         except (
             ProtocolError,
@@ -690,6 +697,8 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                         f"To remediate that issue, either disable {self._svn} or reach out to the server admin."
                     ) from e
             raise
+        finally:
+            self.sock.settimeout(handshake_timeout)
 
         self._connected_at = time.monotonic()
 
@@ -881,6 +890,7 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         maximal_data_in_read: int | None = None,
         data_in_len_from: typing.Callable[[Event], int] | None = None,
         stream_id: int | None = None,
+        deadline: float | None = None,
     ) -> list[Event]:
         """This method simplify socket exchange in/out based on what the protocol state machine orders.
         Can be used for the initial handshake for instance."""
@@ -931,6 +941,12 @@ class AsyncHfaceBackend(AsyncBaseBackend):
             if not protocol.has_pending_event(stream_id=stream_id):
                 if not receive_first:
                     await send_pending()
+
+                if deadline is not None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise SocketTimeout("timed out")
+                    sock.settimeout(remaining)
 
                 next_timer = protocol.next_timer() if _has_next_timer else None  # type: ignore[union-attr]
                 sub = AsyncSubTimeout(sock, next_timer, send_pending)

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -708,10 +708,17 @@ class HfaceBackend(BaseBackend):
         if self._max_tolerable_delay_for_upgrade is not None:
             self.sock.settimeout(self._max_tolerable_delay_for_upgrade)
 
+        handshake_timeout = self.sock.gettimeout()
+        handshake_deadline = (
+            None
+            if handshake_timeout is None
+            else time.monotonic() + handshake_timeout
+        )
         try:
             self.__exchange_until(
                 HandshakeCompleted,
                 receive_first=False,
+                deadline=handshake_deadline,
             )
         except (
             ProtocolError,
@@ -745,6 +752,8 @@ class HfaceBackend(BaseBackend):
                         f"To remediate that issue, either disable {self._svn} or reach out to the server admin."
                     ) from e
             raise
+        finally:
+            self.sock.settimeout(handshake_timeout)
 
         self._connected_at = time.monotonic()
 
@@ -941,6 +950,7 @@ class HfaceBackend(BaseBackend):
         maximal_data_in_read: int | None = None,
         data_in_len_from: typing.Callable[[Event], int] | None = None,
         stream_id: int | None = None,
+        deadline: float | None = None,
     ) -> list[Event]:
         """This method simplify socket exchange in/out based on what the protocol state machine orders.
         Can be used for the initial handshake for instance."""
@@ -1009,6 +1019,12 @@ class HfaceBackend(BaseBackend):
             if not protocol.has_pending_event(stream_id=stream_id):
                 if not receive_first:
                     send_pending()
+
+                if deadline is not None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise SocketTimeout("timed out")
+                    sock.settimeout(remaining)
 
                 next_timer = protocol.next_timer() if _has_next_timer else None  # type: ignore[union-attr]
                 sub = SubTimeout(sock, next_timer, send_pending)

--- a/test/test_hface.py
+++ b/test/test_hface.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import socket
+from types import SimpleNamespace
+
+import pytest
+
+import urllib3.backend._async.hface as async_hface
+import urllib3.backend.hface as hface
+from urllib3.contrib.hface.events import HandshakeCompleted
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self) -> None:
+        self.now += 1.0
+
+
+class _DribbleSocket:
+    def __init__(self, clock: _Clock) -> None:
+        self._clock = clock
+        self._timeout: float | None = None
+        self.timeouts: list[float] = []
+
+    def settimeout(self, timeout: float | None) -> None:
+        self._timeout = timeout
+        if timeout is not None:
+            self.timeouts.append(timeout)
+
+    def gettimeout(self) -> float | None:
+        return self._timeout
+
+    def recv(self, size: int) -> bytes:
+        self._clock.advance()
+        return b"\x00"
+
+    def sendall(self, data: object) -> None:
+        pass
+
+
+class _AsyncDribbleSocket(_DribbleSocket):
+    async def recv(self, size: int) -> bytes:
+        self._clock.advance()
+        return b"\x00"
+
+    async def sendall(self, data: object) -> None:
+        pass
+
+
+class _StalledProtocol:
+    def has_pending_event(self, stream_id: int | None = None) -> bool:
+        return False
+
+    def bytes_to_send(self) -> bytes:
+        return b""
+
+    def next_timer(self) -> None:
+        return None
+
+    def events(self, stream_id: int | None = None) -> tuple[()]:
+        return ()
+
+    def bytes_received(self, data: object) -> None:
+        pass
+
+    def exceptions(self) -> tuple[()]:
+        return ()
+
+
+def test_sync_handshake_deadline_caps_total_not_each_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    monkeypatch.setattr(hface, "time", SimpleNamespace(monotonic=clock))
+
+    backend = hface.HfaceBackend.__new__(hface.HfaceBackend)
+    sock = _DribbleSocket(clock)
+    backend.sock = sock
+    backend._protocol = _StalledProtocol()
+    backend.blocksize = 4096
+    backend._svn = None
+    backend._dgram_gso_enabled = False
+    backend._dgram_gro_enabled = False
+    backend._response = None
+
+    with pytest.raises(socket.timeout):
+        backend._HfaceBackend__exchange_until(  # type: ignore[attr-defined]
+            HandshakeCompleted,
+            deadline=3.0,
+        )
+
+    assert sock.timeouts == [3.0, 2.0, 1.0]
+
+
+@pytest.mark.asyncio
+async def test_async_handshake_deadline_caps_total_not_each_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    monkeypatch.setattr(async_hface, "time", SimpleNamespace(monotonic=clock))
+
+    backend = async_hface.AsyncHfaceBackend.__new__(async_hface.AsyncHfaceBackend)
+    sock = _AsyncDribbleSocket(clock)
+    backend.sock = sock
+    backend._protocol = _StalledProtocol()
+    backend.blocksize = 4096
+    backend._svn = None
+    backend._response = None
+    backend._recv_size_ema = 0.0
+
+    with pytest.raises(socket.timeout):
+        await backend._AsyncHfaceBackend__exchange_until(  # type: ignore[attr-defined]
+            HandshakeCompleted,
+            deadline=3.0,
+        )
+
+    assert sock.timeouts == [3.0, 2.0, 1.0]


### PR DESCRIPTION
https://github.com/jawah/niquests/pull/431

cap sum of sleeps below total timeout instead of capping individual sleep below timeout

<!---
Hello!

If this is your first PR to urllib3.future please review the Contributing Guide:
https://urllib3future.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
