### PR TITLE
Restore format_header_param compatibility

### DIFF
--- a/changelog/401.bugfix.rst
+++ b/changelog/401.bugfix.rst
@@ -1,0 +1,1 @@
+Restored the deprecated ``urllib3.fields.format_header_param`` public API for compatibility with downstream packages.

--- a/src/urllib3/fields.py
+++ b/src/urllib3/fields.py
@@ -100,6 +100,19 @@ def format_multipart_header_param(name: str, value: _TYPE_FIELD_VALUE) -> str:
     return f'{name}="{value}"'
 
 
+def format_header_param(name: str, value: _TYPE_FIELD_VALUE) -> str:
+    """Deprecated alias for :func:`format_multipart_header_param`."""
+    import warnings
+
+    warnings.warn(
+        "'format_header_param' has been renamed to "
+        "'format_multipart_header_param' and will be removed in urllib3 v3.0.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return format_multipart_header_param(name, value)
+
+
 class RequestField:
     """
     A data container for request body parameters.

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -4,6 +4,7 @@ import pytest
 
 from urllib3.fields import (
     RequestField,
+    format_header_param,
     format_header_param_rfc2231,
     format_multipart_header_param,
     guess_content_type,
@@ -73,6 +74,12 @@ class TestRequestField:
         param = format_header_param_rfc2231("filename", value)
 
         assert param == expect
+
+    def test_format_header_param_deprecated(self) -> None:
+        with pytest.deprecated_call(match=r"removed in urllib3 v3\.0\.0"):
+            param = format_header_param("filename", "na\nme")
+
+        assert param == 'filename="na%0Ame"'
 
     @pytest.mark.parametrize(
         ("value", "expect"),


### PR DESCRIPTION
Fixes #401

Restores the deprecated `urllib3.fields.format_header_param` API as a compatibility wrapper around `format_multipart_header_param`.

Tested with: `PYTHONPATH=src python -m pytest test/test_fields.py -q`