### PR TITLE
Release 2.24.902

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,17 @@
+2.24.902 (2026-08-19)
+=====================
+
+- Fixed HTTP/2 uploads stalling when a remote peer advertises a maximum frame size larger than its
+  initial stream or connection flow-control window. Bytes-like bodies and sync/async iterable bodies
+  are now consistently split according to the effective HTTP/2 maximum data chunk size.
+- Fixed Linux UDP GSO fallback when a kernel or NIC driver rejects segmentation with ``EINVAL``.
+- Improved throughput for fixed amount response reads in both sync and async.
+- Fixed ECH configuration propagation from custom resolvers without relying on arbitrary attributes
+  being writable on socket objects.
+- Restored the deprecated ``format_header_param`` and ``format_header_param_html5`` compatibility
+  functions. They remain aliases of ``format_multipart_header_param`` until next major.
+- Removed the warning emitted by the no-op ``urllib3.http2.inject_into_urllib3`` compatibility shim.
+
 2.24.901 (2026-08-15)
 =====================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
   initial stream or connection flow-control window. Bytes-like bodies and sync/async iterable bodies
   are now consistently split according to the effective HTTP/2 maximum data chunk size.
 - Fixed Linux UDP GSO fallback when a kernel or NIC driver rejects segmentation with ``EINVAL``.
+- Fixed ``ZstdDecoder.flush()`` raising ``AttributeError`` with Python 3.14's stdlib
+  ``compression.zstd`` implementation. Incomplete Zstandard data is still rejected. (#404)
 - Improved throughput for fixed amount response reads in both sync and async.
 - Fixed ECH configuration propagation from custom resolvers without relying on arbitrary attributes
   being writable on socket objects.

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -228,6 +228,7 @@ class AsyncHTTPConnection(AsyncHfaceBackend):
                 and HttpVersion.h3 not in self._disabled_svn
                 and self.socket_kind != socket.SOCK_DGRAM,
                 timing_hook=lambda _: setattr(self, "_connect_timings", _),
+                ech_config_hook=lambda _: setattr(self, "_ech_config", _),
                 default_socket_family=self._socket_family,
             )
         except socket.gaierror as e:
@@ -250,9 +251,6 @@ class AsyncHTTPConnection(AsyncHfaceBackend):
         if sock.type == socket.SOCK_DGRAM and self.socket_kind == socket.SOCK_STREAM:
             self.socket_kind = socket.SOCK_DGRAM
             self._svn = HttpVersion.h3
-
-        if hasattr(sock, "_ech_config"):
-            self._ech_config = sock._ech_config
 
         return sock
 

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -1378,9 +1378,9 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
         # utls -- BoringSSL have predefined headers
         # that we automatically insert.
         if conn_info is not None and conn_info.tls_version is not None:
-            ssl_ctx: ssl.SSLContext | None = getattr(conn, "_custom_tls_context", None) or getattr(
-                conn.sock, "context", None
-            )
+            ssl_ctx: ssl.SSLContext | None = getattr(
+                conn, "_custom_tls_context", None
+            ) or getattr(conn.sock, "context", None)
 
             if ssl_ctx is not None and hasattr(ssl_ctx, "http_header_for_fingerprint"):
                 try:

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -1378,7 +1378,9 @@ class AsyncHTTPConnectionPool(AsyncConnectionPool, AsyncRequestMethods):
         # utls -- BoringSSL have predefined headers
         # that we automatically insert.
         if conn_info is not None and conn_info.tls_version is not None:
-            ssl_ctx: ssl.SSLContext | None = getattr(conn.sock, "context", None)
+            ssl_ctx: ssl.SSLContext | None = getattr(conn, "_custom_tls_context", None) or getattr(
+                conn.sock, "context", None
+            )
 
             if ssl_ctx is not None and hasattr(ssl_ctx, "http_header_for_fingerprint"):
                 try:

--- a/src/urllib3/_async/response.py
+++ b/src/urllib3/_async/response.py
@@ -280,7 +280,9 @@ class AsyncHTTPResponse(HTTPResponse):
 
         return None  # type: ignore[return-value]
 
-    async def _fp_read(self, amt: int | None = None) -> bytes:  # type: ignore[override]
+    async def _fp_read(  # type: ignore[override]
+        self, amt: int | None = None, *, read1: bool = False
+    ) -> bytes:
         """
         Read a response with the thought that reading the number of bytes
         larger than can fit in a 32-bit int at a time via SSL in some
@@ -295,10 +297,17 @@ class AsyncHTTPResponse(HTTPResponse):
           * CPython < 3.10 only when `amt` does not fit 32-bit int.
         """
         assert self._fp
-        if (
+        requires_safe_read = (
             (amt and amt > C_INT_MAX)
             or (self.length_remaining and self.length_remaining > C_INT_MAX)
-        ) and sys.version_info < (3, 10):
+        ) and sys.version_info < (3, 10)
+        if read1 and isinstance(self._fp, AsyncLowLevelResponse):
+            if requires_safe_read:
+                amt = (
+                    CHUNK_AMT_MAX if amt is None or amt < 0 else min(amt, CHUNK_AMT_MAX)
+                )
+            return await self._fp.read1(amt)
+        if requires_safe_read:
             buffer = io.BytesIO()
             # Besides `max_chunk_amt` being a maximum chunk size, it
             # affects memory overhead of reading a response by this
@@ -317,7 +326,7 @@ class AsyncHTTPResponse(HTTPResponse):
                     if is_async_ll:
                         data = await self._fp.read(chunk_amt)
                     else:
-                        data = self._fp.read(chunk_amt)  # type: ignore[attr-defined]
+                        data = self._fp.read(chunk_amt)
                 except ValueError:  # Defensive: overly protective
                     break  # Defensive: can also be an indicator that read ended, should not happen.
                 if not data:
@@ -334,6 +343,8 @@ class AsyncHTTPResponse(HTTPResponse):
     async def _raw_read(  # type: ignore[override]
         self,
         amt: int | None = None,
+        *,
+        read1: bool = False,
     ) -> bytes:
         """
         Reads `amt` of bytes from the socket.
@@ -344,7 +355,7 @@ class AsyncHTTPResponse(HTTPResponse):
         fp_closed = getattr(self._fp, "closed", False)
 
         async with self._error_catcher():
-            data = (await self._fp_read(amt)) if not fp_closed else b""
+            data = (await self._fp_read(amt, read1=read1)) if not fp_closed else b""
 
             # Mocking library often use io.BytesIO
             # which does not auto-close when reading data
@@ -411,13 +422,14 @@ class AsyncHTTPResponse(HTTPResponse):
             'content-encoding' header.
         """
 
-        data = await self.read(
+        data = await self._read(
             amt=amt or -1,
             decode_content=decode_content,
+            read1=True,
         )
         self._uncached_read_occurred = True
 
-        if amt is not None and len(data) > amt:
+        if amt is not None and amt >= 0 and len(data) > amt:
             self._decoded_buffer.put(data)
             return self._decoded_buffer.get(amt)
 
@@ -441,9 +453,8 @@ class AsyncHTTPResponse(HTTPResponse):
         decode_content: bool | None = None,
         cache_content: bool = False,
         *,
-        partial: bool = False,
+        read1: bool = False,
     ) -> bytes:
-        # See ``HTTPResponse._read`` for the meaning of ``partial`` (issue #379).
         try:
             self._init_decoder()
             if decode_content is None:
@@ -508,9 +519,9 @@ class AsyncHTTPResponse(HTTPResponse):
 
             if self._police_officer is not None:
                 async with self._police_officer.borrow(self):
-                    data = await self._raw_read(amt)
+                    data = await self._raw_read(amt, read1=read1)
             else:
-                data = await self._raw_read(amt)
+                data = await self._raw_read(amt, read1=read1)
 
             if not cache_content:
                 self._uncached_read_occurred = True
@@ -553,10 +564,8 @@ class AsyncHTTPResponse(HTTPResponse):
                 )
                 self._decoded_buffer.put(decoded_data)
 
-                surface_per_frame = partial and hasattr(self._fp, "_eot")
-                while (
-                    len(self._decoded_buffer) < amt and data and not surface_per_frame
-                ):
+                single_exchange = read1 and hasattr(self._fp, "_eot")
+                while len(self._decoded_buffer) < amt and data and not single_exchange:
                     # TODO make sure to initially read enough data to get past the headers
                     # For example, the GZ file header takes 10 bytes, we don't want to read
                     # it one byte at a time
@@ -603,9 +612,7 @@ class AsyncHTTPResponse(HTTPResponse):
             or self._decoded_buffer
             or (self._decoder and self._decoder.has_unconsumed_tail)
         ):
-            data = await self._read(
-                amt=amt, decode_content=decode_content, partial=True
-            )
+            data = await self.read1(amt=amt, decode_content=decode_content)
 
             if data:
                 yield data
@@ -614,10 +621,9 @@ class AsyncHTTPResponse(HTTPResponse):
         self, amt: int | None, decode_content: bool | None = None
     ) -> bytes:
         """Read one transfer-decoded body segment from the protocol backend."""
-        return await self._read(
+        return await self.read1(
             amt=-1 if amt is None else amt,
             decode_content=decode_content,
-            partial=True,
         )
 
     async def read_chunked(  # type: ignore[override]

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.24.901"
+__version__ = "2.24.902"

--- a/src/urllib3/backend/_async/_base.py
+++ b/src/urllib3/backend/_async/_base.py
@@ -233,6 +233,12 @@ class AsyncLowLevelResponse:
         return self.closed
 
     async def read(self, __size: int | None = None) -> bytes:
+        return await self._read(__size, read1=False)
+
+    async def read1(self, __size: int | None = None) -> bytes:
+        return await self._read(__size, read1=True)
+
+    async def _read(self, __size: int | None, *, read1: bool) -> bytes:
         if self.closed is True or self.__internal_read_st is None:
             # overly protective, just in case.
             raise ValueError(
@@ -256,6 +262,16 @@ class AsyncLowLevelResponse:
 
             self.__buffer_excess.put_many(chunks)
             buf_capacity = len(self.__buffer_excess)
+
+        if not read1 and __size is not None and __size > 0:
+            while self._eot is False and buf_capacity < __size:
+                chunks, self._eot, self.trailers = await self.__internal_read_st(
+                    __size - buf_capacity, self._stream_id
+                )
+                self.__buffer_excess.put_many(chunks)
+                buf_capacity = len(self.__buffer_excess)
+                if not chunks:
+                    break
 
         data = (
             self.__buffer_excess.get(

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -1549,7 +1549,10 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                 HeadersReceived,
             ),
             maximal_data_in_read=__amt,
-            data_in_len_from=lambda x: len(x.data),  # type: ignore[attr-defined]
+            # Unbounded reads have no byte target to track.
+            data_in_len_from=(
+                (lambda x: len(x.data)) if __amt is not None else None  # type: ignore[attr-defined]
+            ),
             stream_id=__stream_id,
             respect_end_stream_signal=__respect_end_signal,
         )

--- a/src/urllib3/backend/_async/hface.py
+++ b/src/urllib3/backend/_async/hface.py
@@ -360,6 +360,8 @@ class AsyncHfaceBackend(AsyncBaseBackend):
             else:
                 ssl_context = None
 
+        self._custom_tls_context = ssl_context
+
         if ssl_context:
             cert_use_common_name = (
                 getattr(ssl_context, "hostname_checks_common_name", False) or False
@@ -397,10 +399,6 @@ class AsyncHfaceBackend(AsyncBaseBackend):
                     ssl_context.set_fingerprint("chrome:stable")
                 except AttributeError:  # Defensive: should be unreachable
                     pass
-
-            # so that http headers would be made available
-            # via connectionpool "BoringSSL have predefined headers"
-            setattr(self.sock, "context", ssl_context)
 
         self.__custom_tls_settings = QuicTLSConfig(
             insecure=allow_insecure,
@@ -1946,3 +1944,4 @@ class AsyncHfaceBackend(AsyncBaseBackend):
         self._last_used_at = time.monotonic()
         self._recv_size_ema = 0.0
         self._ech_config = None
+        self._custom_tls_context = None

--- a/src/urllib3/backend/_base.py
+++ b/src/urllib3/backend/_base.py
@@ -569,6 +569,7 @@ class BaseBackend:
 
         self._recv_size_ema: float = 0.0
         self._ech_config: bytes | None = None
+        self._custom_tls_context: SSLContext | None = None
 
     def __contains__(self, item: ResponsePromise) -> bool:
         return item.uid in self._promises

--- a/src/urllib3/backend/_base.py
+++ b/src/urllib3/backend/_base.py
@@ -341,6 +341,12 @@ class LowLevelResponse:
         return self.closed
 
     def read(self, __size: int | None = None) -> bytes:
+        return self._read(__size, read1=False)
+
+    def read1(self, __size: int | None = None) -> bytes:
+        return self._read(__size, read1=True)
+
+    def _read(self, __size: int | None, *, read1: bool) -> bytes:
         if self.closed is True or self.__internal_read_st is None:
             # overly protective, just in case.
             raise ValueError(
@@ -364,6 +370,16 @@ class LowLevelResponse:
 
             self.__buffer_excess.put_many(chunks)
             buf_capacity = len(self.__buffer_excess)
+
+        if not read1 and __size is not None and __size > 0:
+            while self._eot is False and buf_capacity < __size:
+                chunks, self._eot, self.trailers = self.__internal_read_st(
+                    __size - buf_capacity, self._stream_id
+                )
+                self.__buffer_excess.put_many(chunks)
+                buf_capacity = len(self.__buffer_excess)
+                if not chunks:
+                    break
 
         data = (
             self.__buffer_excess.get(

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -1672,7 +1672,10 @@ class HfaceBackend(BaseBackend):
             receive_first=True,
             event_type_collectable=(DataReceived, HeadersReceived),
             maximal_data_in_read=__amt,
-            data_in_len_from=lambda x: len(x.data),  # type: ignore[attr-defined]
+            # Unbounded reads have no byte target to track.
+            data_in_len_from=(
+                (lambda x: len(x.data)) if __amt is not None else None  # type: ignore[attr-defined]
+            ),
             stream_id=__stream_id,
             respect_end_stream_signal=__respect_end_signal,
         )

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -387,6 +387,8 @@ class HfaceBackend(BaseBackend):
             else:
                 ssl_context = None
 
+        self._custom_tls_context = ssl_context
+
         if ssl_context:
             cert_use_common_name = (
                 getattr(ssl_context, "hostname_checks_common_name", False) or False
@@ -424,10 +426,6 @@ class HfaceBackend(BaseBackend):
                     ssl_context.set_fingerprint("chrome:stable")
                 except AttributeError:  # Defensive: should be unreachable
                     pass
-
-            # so that http headers would be made available
-            # via connectionpool "BoringSSL have predefined headers"
-            setattr(self.sock, "context", ssl_context)
 
         self.__custom_tls_settings = QuicTLSConfig(
             insecure=allow_insecure,
@@ -2102,3 +2100,4 @@ class HfaceBackend(BaseBackend):
         self._dgram_gro_enabled = False
         self._dgram_gso_enabled = False
         self._ech_config = None
+        self._custom_tls_context = None

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -232,6 +232,7 @@ class HTTPConnection(HfaceBackend):
                 and HttpVersion.h3 not in self._disabled_svn
                 and self.socket_kind != socket.SOCK_DGRAM,
                 timing_hook=lambda _: setattr(self, "_connect_timings", _),
+                ech_config_hook=lambda _: setattr(self, "_ech_config", _),
                 default_socket_family=self._socket_family,
             )
         except socket.gaierror as e:
@@ -253,9 +254,6 @@ class HTTPConnection(HfaceBackend):
         if sock.type == socket.SOCK_DGRAM and self.socket_kind == socket.SOCK_STREAM:
             self.socket_kind = socket.SOCK_DGRAM
             self._svn = HttpVersion.h3
-
-        if hasattr(sock, "_ech_config"):
-            self._ech_config = sock._ech_config
 
         return sock
 

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1387,9 +1387,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # utls -- BoringSSL have predefined headers
         # that we automatically insert.
         if conn_info is not None and conn_info.tls_version is not None:
-            ssl_ctx: ssl.SSLContext | None = getattr(conn, "_custom_tls_context", None) or getattr(
-                conn.sock, "context", None
-            )
+            ssl_ctx: ssl.SSLContext | None = getattr(
+                conn, "_custom_tls_context", None
+            ) or getattr(conn.sock, "context", None)
 
             if ssl_ctx is not None and hasattr(ssl_ctx, "http_header_for_fingerprint"):
                 try:

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1387,7 +1387,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # utls -- BoringSSL have predefined headers
         # that we automatically insert.
         if conn_info is not None and conn_info.tls_version is not None:
-            ssl_ctx: ssl.SSLContext | None = getattr(conn.sock, "context", None)
+            ssl_ctx: ssl.SSLContext | None = getattr(conn, "_custom_tls_context", None) or getattr(
+                conn.sock, "context", None
+            )
 
             if ssl_ctx is not None and hasattr(ssl_ctx, "http_header_for_fingerprint"):
                 try:

--- a/src/urllib3/contrib/emscripten/__init__.py
+++ b/src/urllib3/contrib/emscripten/__init__.py
@@ -13,13 +13,13 @@ import warnings
 def inject_into_urllib3() -> None:
     warnings.warn(
         (
-            "urllib3-future does not support WASM / Emscripten platform. "
-            "Please reinstall legacy urllib3 in the meantime. "
-            "Run `pip uninstall -y urllib3 urllib3-future` then "
-            "`pip install urllib3-future`, finally `pip install urllib3`. "
-            "Sorry for the inconvenience."
+            "urllib3-future does not currently support Emscripten Pyodide. "
+            "Use upstream urllib3 on these platforms. See the cohabitation "
+            "instructions at "
+            "https://niquests.readthedocs.io/en/latest/community/faq.html#cohabitation"
         ),
-        DeprecationWarning,
+        FutureWarning,
+        stacklevel=2,
     )
 
 

--- a/src/urllib3/contrib/hface/protocols/http2/_h2.py
+++ b/src/urllib3/contrib/hface/protocols/http2/_h2.py
@@ -51,6 +51,7 @@ from .._protocols import HTTP2Protocol
 JH2_NOT_RFC_COMPLIANT_SETTINGS: bool = tuple(
     int(p) for p in jh2_version.split(".", maxsplit=3)[:3]
 ) <= (5, 0, 11)
+HTTP2_INITIAL_CONNECTION_WINDOW_SIZE = 2**16 - 1
 
 
 class _PatchedH2Connection(jh2.connection.H2Connection):  # type: ignore[misc]
@@ -177,7 +178,17 @@ class HTTP2ProtocolHyperImpl(HTTP2Protocol):
         self._pending_ping_ack: deque[bytes] = deque()
 
     def max_frame_size(self) -> int:
-        return self._max_frame_size
+        initial_window_size: int = self._connection.remote_settings.initial_window_size
+        if initial_window_size == 0:
+            # body_to_chunks() requires a positive block size. Flow control
+            # still prevents this byte from being sent before WINDOW_UPDATE.
+            return 1
+
+        return min(
+            self._max_frame_size,
+            initial_window_size,
+            HTTP2_INITIAL_CONNECTION_WINDOW_SIZE,
+        )
 
     @staticmethod
     def exceptions() -> tuple[type[BaseException], ...]:

--- a/src/urllib3/contrib/resolver/_async/protocols.py
+++ b/src/urllib3/contrib/resolver/_async/protocols.py
@@ -76,6 +76,7 @@ class AsyncBaseResolver(BaseResolver, metaclass=ABCMeta):
         quic_upgrade_via_dns_rr: bool = False,
         timing_hook: typing.Callable[[tuple[timedelta, timedelta, datetime]], None]
         | None = None,
+        ech_config_hook: typing.Callable[[bytes], None] | None = None,
         default_socket_family: socket.AddressFamily = socket.AF_UNSPEC,
     ) -> AsyncSocket:
         """Connect to *address* and return the socket object.
@@ -226,7 +227,8 @@ class AsyncBaseResolver(BaseResolver, metaclass=ABCMeta):
                     )
 
                 if isinstance(canonname, bytes) and canonname:
-                    sock._ech_config = canonname
+                    if ech_config_hook is not None:
+                        ech_config_hook(canonname)
 
                 return sock
             except (OSError, OverflowError) as _:

--- a/src/urllib3/contrib/resolver/protocols.py
+++ b/src/urllib3/contrib/resolver/protocols.py
@@ -12,10 +12,17 @@ from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 
+if sys.platform == "wasi":
+    try:
+        from ..wasi import socket
+    except ImportError:
+        pass
+
 from ..._constant import UDP_LINUX_GRO, UDP_LINUX_SEGMENT
 from ..._typing import _TYPE_SOCKET_OPTIONS, _TYPE_TIMEOUT_INTERNAL
 from ...exceptions import LocationParseError
 from ...util.connection import (
+    _ORIGINAL_SOCKET,
     _set_socket_options,
     _with_attr_sock,
     allowed_gai_family,
@@ -181,6 +188,7 @@ class BaseResolver(metaclass=ABCMeta):
         timing_hook: (
             typing.Callable[[tuple[timedelta, timedelta, datetime]], None] | None
         ) = None,
+        ech_config_hook: typing.Callable[[bytes], None] | None = None,
         default_socket_family: socket.AddressFamily = socket.AF_UNSPEC,
     ) -> socket.socket:
         """Connect to *address* and return the socket object.
@@ -236,7 +244,12 @@ class BaseResolver(metaclass=ABCMeta):
             af, socktype, proto, canonname, sa = res
             sock = None
             try:
-                sock = _with_attr_sock(af, socktype, proto)
+                socket_cls = (
+                    socket.socket
+                    if _with_attr_sock is _ORIGINAL_SOCKET
+                    else _with_attr_sock
+                )
+                sock = socket_cls(af, socktype, proto)
 
                 # we need to add this or reusing the same origin port will likely fail within
                 # short period of time. kernel put port on wait shut.
@@ -306,7 +319,8 @@ class BaseResolver(metaclass=ABCMeta):
                     )
 
                 if isinstance(canonname, bytes) and canonname:
-                    setattr(sock, "_ech_config", canonname)
+                    if ech_config_hook is not None:
+                        ech_config_hook(canonname)
 
                 return sock
             except (OSError, OverflowError) as _:

--- a/src/urllib3/contrib/ssa/__init__.py
+++ b/src/urllib3/contrib/ssa/__init__.py
@@ -92,8 +92,6 @@ class AsyncSocket:
         self._external_timeout: float | int | None = None
         self._tls_in_tls = False
 
-        self._ech_config: bytes | None = None
-
     def fileno(self) -> int:
         return self._fileno if self._fileno is not None else self._sock.fileno()
 

--- a/src/urllib3/contrib/ssa/_gro.py
+++ b/src/urllib3/contrib/ssa/_gro.py
@@ -244,6 +244,7 @@ _GSO_UNSUPPORTED_ERRNOS: typing.Final = frozenset(
     e
     for e in (
         getattr(errno, "EIO", None),
+        getattr(errno, "EINVAL", None),
         getattr(errno, "ENOTSUP", None),
         getattr(errno, "EOPNOTSUPP", None),
         getattr(errno, "ENOPROTOOPT", None),

--- a/src/urllib3/fields.py
+++ b/src/urllib3/fields.py
@@ -90,7 +90,7 @@ def format_multipart_header_param(name: str, value: _TYPE_FIELD_VALUE) -> str:
     .. versionchanged:: 2.0.0
         Renamed from ``format_header_param_html5`` and
         ``format_header_param``. The old names will be removed in
-        urllib3 v2.1.0.
+        urllib3 v3.0.
     """
     if isinstance(value, bytes):
         value = value.decode("utf-8")
@@ -98,6 +98,42 @@ def format_multipart_header_param(name: str, value: _TYPE_FIELD_VALUE) -> str:
     # percent encode \n \r "
     value = value.translate({10: "%0A", 13: "%0D", 34: "%22"})
     return f'{name}="{value}"'
+
+
+def format_header_param_html5(name: str, value: _TYPE_FIELD_VALUE) -> str:
+    """
+    .. deprecated:: 2.0.0
+        Renamed to :func:`format_multipart_header_param`. Will be
+        removed in urllib3 v3.0.
+    """
+    import warnings
+
+    warnings.warn(
+        "'format_header_param_html5' has been renamed to "
+        "'format_multipart_header_param'. The old name will be "
+        "removed in urllib3 v3.0.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    return format_multipart_header_param(name, value)
+
+
+def format_header_param(name: str, value: _TYPE_FIELD_VALUE) -> str:
+    """
+    .. deprecated:: 2.0.0
+        Renamed to :func:`format_multipart_header_param`. Will be
+        removed in urllib3 v3.0.
+    """
+    import warnings
+
+    warnings.warn(
+        "'format_header_param' has been renamed to "
+        "'format_multipart_header_param'. The old name will be "
+        "removed in urllib3 v3.0.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    return format_multipart_header_param(name, value)
 
 
 class RequestField:

--- a/src/urllib3/http2/__init__.py
+++ b/src/urllib3/http2/__init__.py
@@ -7,16 +7,9 @@
 
 from __future__ import annotations
 
-import warnings
-
 
 def inject_into_urllib3() -> None:
-    warnings.warn(
-        "urllib3-future do not propose the http2 module as it is useless to us. "
-        "enjoy HTTP/1.1, HTTP/2, and HTTP/3 without hacks. urllib3-future just works out "
-        "of the box with all protocols. No hassles.",
-        UserWarning,
-    )
+    pass
 
 
 def extract_from_urllib3() -> None:

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -348,6 +348,11 @@ if zstd is not None:
             ) or bool(self._obj.unused_data)
 
         def flush(self) -> bytes:
+            if _zstd_native:
+                if not self._obj.eof:
+                    raise DecodeError("Zstandard data is incomplete")
+                return b""
+
             ret = self._obj.flush()
             if not self._obj.eof:
                 raise DecodeError("Zstandard data is incomplete")

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -908,7 +908,7 @@ class HTTPResponse(io.IOBase):
             if self._original_response and self._original_response.isclosed():
                 self.release_conn()
 
-    def _fp_read(self, amt: int | None = None) -> bytes:
+    def _fp_read(self, amt: int | None = None, *, read1: bool = False) -> bytes:
         """
         Read a response with the thought that reading the number of bytes
         larger than can fit in a 32-bit int at a time via SSL in some
@@ -923,10 +923,17 @@ class HTTPResponse(io.IOBase):
           * CPython < 3.10 only when `amt` does not fit 32-bit int.
         """
         assert self._fp
-        if (
+        requires_safe_read = (
             (amt and amt > C_INT_MAX)
             or (self.length_remaining and self.length_remaining > C_INT_MAX)
-        ) and sys.version_info < (3, 10):
+        ) and sys.version_info < (3, 10)
+        if read1 and isinstance(self._fp, LowLevelResponse):
+            if requires_safe_read:
+                amt = (
+                    CHUNK_AMT_MAX if amt is None or amt < 0 else min(amt, CHUNK_AMT_MAX)
+                )
+            return self._fp.read1(amt)
+        if requires_safe_read:
             buffer = io.BytesIO()
             # Besides `max_chunk_amt` being a maximum chunk size, it
             # affects memory overhead of reading a response by this
@@ -956,6 +963,8 @@ class HTTPResponse(io.IOBase):
     def _raw_read(
         self,
         amt: int | None = None,
+        *,
+        read1: bool = False,
     ) -> bytes:
         """
         Reads `amt` of bytes from the socket.
@@ -967,7 +976,11 @@ class HTTPResponse(io.IOBase):
         fp_upgraded = getattr(self._fp, "_dsa", None) is not None
 
         with self._error_catcher():
-            data = self._fp_read(amt) if not fp_closed and not fp_upgraded else b""
+            data = (
+                self._fp_read(amt, read1=read1)
+                if not fp_closed and not fp_upgraded
+                else b""
+            )
 
             # Mocking library often use io.BytesIO
             # which does not auto-close when reading data
@@ -1035,13 +1048,14 @@ class HTTPResponse(io.IOBase):
             'content-encoding' header.
         """
 
-        data = self.read(
+        data = self._read(
             amt=amt or -1,
             decode_content=decode_content,
+            read1=True,
         )
         self._uncached_read_occurred = True
 
-        if amt is not None and len(data) > amt:
+        if amt is not None and amt >= 0 and len(data) > amt:
             self._decoded_buffer.put(data)
             return self._decoded_buffer.get(amt)
 
@@ -1085,7 +1099,7 @@ class HTTPResponse(io.IOBase):
         decode_content: bool | None = None,
         cache_content: bool = False,
         *,
-        partial: bool = False,
+        read1: bool = False,
     ) -> bytes:
         """We need this private method to restore BC with urllib3 fast-path for streaming/chunks.
         see https://github.com/jawah/urllib3.future/issues/379"""
@@ -1153,9 +1167,9 @@ class HTTPResponse(io.IOBase):
 
             if self._police_officer is not None:
                 with self._police_officer.borrow(self):
-                    data = self._raw_read(amt)
+                    data = self._raw_read(amt, read1=read1)
             else:
-                data = self._raw_read(amt)
+                data = self._raw_read(amt, read1=read1)
 
             if not cache_content:
                 self._uncached_read_occurred = True
@@ -1198,10 +1212,8 @@ class HTTPResponse(io.IOBase):
                 )
                 self._decoded_buffer.put(decoded_data)
 
-                surface_per_frame = partial and hasattr(self._fp, "_eot")
-                while (
-                    len(self._decoded_buffer) < amt and data and not surface_per_frame
-                ):
+                single_exchange = read1 and hasattr(self._fp, "_eot")
+                while len(self._decoded_buffer) < amt and data and not single_exchange:
                     # TODO make sure to initially read enough data to get past the headers
                     # For example, the GZ file header takes 10 bytes, we don't want to read
                     # it one byte at a time
@@ -1264,7 +1276,7 @@ class HTTPResponse(io.IOBase):
             or len(self._decoded_buffer) > 0
             or (self._decoder and self._decoder.has_unconsumed_tail)
         ):
-            data = self._read(amt=amt, decode_content=decode_content, partial=True)
+            data = self.read1(amt=amt, decode_content=decode_content)
 
             if data:
                 yield data
@@ -1273,10 +1285,9 @@ class HTTPResponse(io.IOBase):
         self, amt: int | None, decode_content: bool | None = None
     ) -> bytes:
         """Read one transfer-decoded body segment from the protocol backend."""
-        return self._read(
+        return self.read1(
             amt=-1 if amt is None else amt,
             decode_content=decode_content,
-            partial=True,
         )
 
     def read_chunked(

--- a/src/urllib3/util/connection.py
+++ b/src/urllib3/util/connection.py
@@ -91,12 +91,8 @@ def allowed_gai_family() -> socket.AddressFamily:
     return family
 
 
-class _with_attr_sock(socket.socket):
-    """socket.socket subclass that carries extra protocol metadata."""
-
-    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
-        self._ech_config: bytes | None = None
-        super().__init__(*args, **kwargs)
+_ORIGINAL_SOCKET = socket.socket
+_with_attr_sock = socket.socket
 
 
 def _has_ipv6() -> bool:
@@ -111,7 +107,12 @@ def _has_ipv6() -> bool:
         # https://github.com/urllib3/urllib3/pull/611
         # https://bugs.python.org/issue658327
         try:
-            sock = _with_attr_sock(socket.AF_INET6)
+            socket_cls = (
+                socket.socket
+                if _with_attr_sock is _ORIGINAL_SOCKET
+                else _with_attr_sock
+            )
+            sock = socket_cls(socket.AF_INET6)
             sock.bind(("::1", 0))
             has_ipv6 = True
         except Exception:

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -327,11 +327,38 @@ def body_to_chunks(
             async for block in body:
                 if encode is None:
                     encode = isinstance(block, str)
-                queue.put(block.encode("utf-8") if encode else block)
-                yield queue.get(blocksize)
+                if block:
+                    queue.put(block.encode("utf-8") if encode else block)
+                    yield queue.get(blocksize)
 
             while queue:
                 yield queue.get(blocksize)
+
+    def chunk_iterable(
+        iterable: typing.Iterable[bytes | bytearray | str | memoryview],
+    ) -> typing.Iterable[bytes]:
+        queue = BytesQueueBuffer()
+
+        for block in iterable:
+            if isinstance(block, str):
+                block = block.encode("utf-8")
+            elif isinstance(block, bytearray):
+                block = memoryview(block)
+            if block:
+                queue.put(block)
+                yield queue.get(blocksize)
+
+        while queue:
+            yield queue.get(blocksize)
+
+    def chunk_buffer(view: memoryview) -> typing.Iterable[bytes]:
+        try:
+            byte_view = view.cast("B")
+        except TypeError:
+            byte_view = memoryview(view.tobytes())
+
+        for offset in range(0, byte_view.nbytes, blocksize):
+            yield bytes(byte_view[offset : offset + blocksize])
 
     # Bytes or strings become bytes
     if isinstance(body, (str, bytes)):
@@ -359,7 +386,8 @@ def body_to_chunks(
         except TypeError:
             try:
                 # Check if the body is an iterable
-                chunks = iter(body)
+                iterable = iter(body)
+                chunks = chunk_iterable(iterable) if force else iterable
                 content_length = None
             except TypeError:
                 raise TypeError(
@@ -368,7 +396,7 @@ def body_to_chunks(
                 ) from None
         else:
             # Since it implements the buffer API can be passed directly to socket.sendall()
-            chunks = (body,)
+            chunks = chunk_buffer(mv) if force and mv.nbytes > blocksize else (body,)
             content_length = mv.nbytes
 
     return ChunksAndContentLength(

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -72,7 +72,7 @@ class BytesQueueBuffer:
     def __len__(self) -> int:
         return self._size
 
-    def put(self, data: bytes) -> None:
+    def put(self, data: bytes | memoryview[bytes]) -> None:
         self.buffer.append(data)
         self._size += len(data)
 

--- a/test/contrib/asynchronous/test_resolver.py
+++ b/test/contrib/asynchronous/test_resolver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import socket
 from test import requires_network
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -28,6 +29,55 @@ from urllib3.contrib.resolver._async.in_memory import InMemoryResolver  # noqa: 
 from urllib3.contrib.resolver._async.null import NullResolver  # noqa: E402
 from urllib3.contrib.resolver._async.system import SystemResolver  # noqa: E402
 from urllib3.exceptions import InsecureRequestWarning  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_create_connection_reports_ech_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from urllib3.contrib.resolver._async import protocols
+
+    ech_config = b"ech-config"
+    resolver = SystemResolver()
+
+    async def getaddrinfo(
+        *args: object, **kwargs: object
+    ) -> list[
+        tuple[
+            socket.AddressFamily,
+            socket.SocketKind,
+            int,
+            bytes,
+            tuple[str, int],
+        ]
+    ]:
+        return [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                ech_config,
+                ("127.0.0.1", 443),
+            )
+        ]
+
+    async def connect(address: tuple[str, int]) -> None:
+        pass
+
+    sock = MagicMock()
+    sock.connect = connect
+    monkeypatch.setattr(resolver, "getaddrinfo", getaddrinfo)
+    monkeypatch.setattr(protocols, "AsyncSocket", Mock(return_value=sock))
+    ech_config_hook = Mock()
+
+    assert (
+        await resolver.create_connection(
+            ("example.com", 443), ech_config_hook=ech_config_hook
+        )
+        is sock
+    )
+    ech_config_hook.assert_called_once_with(ech_config)
+
 
 _DOQ_PARAM = pytest.param(
     "doq://dns.adguard-dns.com/?timeout=5&cert_reqs=0",

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -14,6 +14,7 @@ from urllib3.connection import (  # type: ignore[attr-defined]
     _url_from_connection,
     _wrap_proxy_error,
 )
+from urllib3._async.connection import AsyncHTTPConnection
 from urllib3.exceptions import HTTPError, ProxyError, ResponseNotReady, SSLError
 from urllib3.util import ssl_
 from urllib3.util.ssl_match_hostname import (
@@ -29,6 +30,37 @@ class TestConnection:
     """
     Tests in this suite should not make any network requests or connections.
     """
+
+    def test_new_conn_receives_ech_config(self) -> None:
+        ech_config = b"ech-config"
+        sock = mock.MagicMock(type=socket.SOCK_STREAM)
+        resolver = mock.MagicMock()
+
+        def create_connection(*args: typing.Any, **kwargs: typing.Any) -> object:
+            kwargs["ech_config_hook"](ech_config)
+            return sock
+
+        resolver.create_connection.side_effect = create_connection
+        conn = HTTPConnection("example.com", resolver=resolver)
+
+        assert conn._new_conn() is sock
+        assert conn._ech_config == ech_config
+
+    @pytest.mark.asyncio
+    async def test_async_new_conn_receives_ech_config(self) -> None:
+        ech_config = b"ech-config"
+        sock = mock.MagicMock(type=socket.SOCK_STREAM)
+        resolver = mock.MagicMock()
+
+        async def create_connection(*args: typing.Any, **kwargs: typing.Any) -> object:
+            kwargs["ech_config_hook"](ech_config)
+            return sock
+
+        resolver.create_connection.side_effect = create_connection
+        conn = AsyncHTTPConnection("example.com", resolver=resolver)
+
+        assert await conn._new_conn() is sock
+        assert conn._ech_config == ech_config
 
     def test_match_hostname_no_cert(self) -> None:
         cert = None

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import typing
+
 import pytest
 
 from urllib3.fields import (
     RequestField,
+    format_header_param,
+    format_header_param_html5,
     format_header_param_rfc2231,
     format_multipart_header_param,
     guess_content_type,
@@ -92,6 +96,17 @@ class TestRequestField:
     ) -> None:
         param = format_multipart_header_param("filename", value)
         assert param == f'filename="{expect}"'
+
+    @pytest.mark.parametrize(
+        "formatter",
+        [format_header_param, format_header_param_html5],
+    )
+    def test_deprecated_header_param_aliases(
+        self,
+        formatter: typing.Callable[[str, str], str],
+    ) -> None:
+        with pytest.warns(FutureWarning, match="format_multipart_header_param"):
+            assert formatter("filename", "näme") == 'filename="näme"'
 
     def test_from_tuples(self) -> None:
         field = RequestField.from_tuples("file", ("スキー旅行.txt", "data"))

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -366,6 +366,27 @@ class TestResponse:
         r = HTTPResponse(fp, headers={"content-encoding": "zstd"})
         assert r.data == b"foo"
 
+    def test_decode_zstd_with_stdlib_decompressor(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stdlib_zstd = pytest.importorskip("compression.zstd")
+        from urllib3 import response
+
+        monkeypatch.setattr(response, "_zstd_native", True)
+
+        decoder = response.ZstdDecoder()
+        decoder._obj = stdlib_zstd.ZstdDecompressor()
+
+        assert decoder.decompress(stdlib_zstd.compress(b"foo")) == b"foo"
+        assert decoder.flush() == b""
+
+        decoder = response.ZstdDecoder()
+        decoder._obj = stdlib_zstd.ZstdDecompressor()
+        decoder.decompress(stdlib_zstd.compress(b"foo")[:-1])
+
+        with pytest.raises(DecodeError, match="Zstandard data is incomplete"):
+            decoder.flush()
+
     @onlyZstd()
     def test_decode_multiframe_zstd(self) -> None:
         data = (

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -782,14 +782,14 @@ class TestUtil:
 
     def test_has_ipv6_enabled_but_fails(self) -> None:
         with patch("socket.has_ipv6", True):
-            with patch("urllib3.util.connection._with_attr_sock") as mock:
+            with patch("socket.socket") as mock:
                 instance = mock.return_value
                 instance.bind = Mock(side_effect=Exception("No IPv6 here!"))
                 assert not _has_ipv6()
 
     def test_has_ipv6_enabled_and_working(self) -> None:
         with patch("socket.has_ipv6", True):
-            with patch("urllib3.util.connection._with_attr_sock") as mock:
+            with patch("socket.socket") as mock:
                 instance = mock.return_value
                 instance.bind.return_value = True
                 assert _has_ipv6()
@@ -857,12 +857,12 @@ class TestUtil:
         ],
     )
     @patch("socket.getaddrinfo")
-    @patch("urllib3.contrib.resolver.protocols._with_attr_sock")
+    @patch("socket.socket")
     def test_create_connection_with_valid_idna_labels(
-        self, with_attr_sock: MagicMock, getaddrinfo: MagicMock, host: str
+        self, socket_cls: MagicMock, getaddrinfo: MagicMock, host: str
     ) -> None:
         getaddrinfo.return_value = [(None, None, None, None, None)]
-        with_attr_sock.return_value = Mock()
+        socket_cls.return_value = Mock()
         ResolverDescription.from_url("system://").new().create_connection((host, 80))
 
     @patch("socket.getaddrinfo")
@@ -892,9 +892,9 @@ class TestUtil:
             )
 
     @patch("socket.getaddrinfo")
-    @patch("urllib3.contrib.resolver.protocols._with_attr_sock")
+    @patch("socket.socket")
     def test_create_connection_with_scoped_ipv6(
-        self, with_attr_sock: MagicMock, getaddrinfo: MagicMock
+        self, socket_cls: MagicMock, getaddrinfo: MagicMock
     ) -> None:
         # Check that providing create_connection with a scoped IPv6 address
         # properly propagates the scope to getaddrinfo, and that the returned
@@ -910,10 +910,57 @@ class TestUtil:
                 fake_scoped_sa6,
             )
         ]
-        with_attr_sock.return_value = fake_sock = MagicMock()
+        socket_cls.return_value = fake_sock = MagicMock()
         resolver.create_connection(("a::b%iface", 80))
         assert getaddrinfo.call_args[0][0] == "a::b%iface"
         fake_sock.connect.assert_called_once_with(fake_scoped_sa6)
+
+    @patch("socket.getaddrinfo")
+    @patch("socket.socket")
+    def test_create_connection_reports_ech_config(
+        self, socket_cls: MagicMock, getaddrinfo: MagicMock
+    ) -> None:
+        ech_config = b"ech-config"
+        getaddrinfo.return_value = [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                ech_config,
+                ("127.0.0.1", 443),
+            )
+        ]
+        socket_cls.return_value = MagicMock()
+        ech_config_hook = Mock()
+
+        ResolverDescription.from_url("system://").new().create_connection(
+            ("example.com", 443), ech_config_hook=ech_config_hook
+        )
+
+        ech_config_hook.assert_called_once_with(ech_config)
+
+    @patch("socket.getaddrinfo")
+    @patch("urllib3.contrib.resolver.protocols._with_attr_sock")
+    def test_create_connection_legacy_socket_patch(
+        self, socket_cls: MagicMock, getaddrinfo: MagicMock
+    ) -> None:
+        getaddrinfo.return_value = [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("127.0.0.1", 80),
+            )
+        ]
+
+        ResolverDescription.from_url("system://").new().create_connection(
+            ("example.com", 80)
+        )
+
+        socket_cls.assert_called_once_with(
+            socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP
+        )
 
     @pytest.mark.parametrize(
         "input,params,expected",


### PR DESCRIPTION
2.24.902 (2026-08-19)
=====================

- Fixed HTTP/2 uploads stalling when a remote peer advertises a maximum frame size larger than its
  initial stream or connection flow-control window. Bytes-like bodies and sync/async iterable bodies
  are now consistently split according to the effective HTTP/2 maximum data chunk size.
- Fixed Linux UDP GSO fallback when a kernel or NIC driver rejects segmentation with ``EINVAL``.
- Fixed ``ZstdDecoder.flush()`` raising ``AttributeError`` with Python 3.14's stdlib
  ``compression.zstd`` implementation. Incomplete Zstandard data is still rejected. (#404)
- Improved throughput for fixed amount response reads in both sync and async.
- Fixed ECH configuration propagation from custom resolvers without relying on arbitrary attributes
  being writable on socket objects.
- Restored the deprecated ``format_header_param`` and ``format_header_param_html5`` compatibility
  functions. They remain aliases of ``format_multipart_header_param`` until next major.
- Removed the warning emitted by the no-op ``urllib3.http2.inject_into_urllib3`` compatibility shim.
