### PR TITLE
Fix h2 stream close

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.24.904 (2026-08-24)
+=====================
+
+- Fixed HTTP/2 stream reset procedure raising unattended exception when the remote closed it before you (e.g. SSE extension). (#406)
+- Fixed HTTP/2 connection status when disposing of many SSE extension streams (i.e. could remain marked saturated when the client initiated the SSE close).
+
 2.24.903 (2026-08-23)
 =====================
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.24.903"
+__version__ = "2.24.904"

--- a/src/urllib3/contrib/hface/protocols/http2/_h2.py
+++ b/src/urllib3/contrib/hface/protocols/http2/_h2.py
@@ -234,7 +234,14 @@ class HTTP2ProtocolHyperImpl(HTTP2Protocol):
         self._connection.send_data(stream_id, data, end_stream)
 
     def submit_stream_reset(self, stream_id: int, error_code: int = 0) -> None:
-        self._connection.reset_stream(stream_id, error_code)
+        try:
+            self._connection.reset_stream(stream_id, error_code)
+        except jh2.exceptions.StreamClosedError:
+            # The peer may have closed the stream after the caller decided to
+            # abort it but before the reset reached the HTTP/2 state machine.
+            pass
+        else:
+            self._open_stream_count -= 1
 
     def next_event(self, stream_id: int | None = None) -> Event | None:
         return self._events.popleft(stream_id=stream_id)


### PR DESCRIPTION
2.24.904 (2026-08-24)
=====================

- Fixed HTTP/2 stream reset procedure raising unattended exception when the remote closed it before you (e.g. SSE extension). (#406)
- Fixed HTTP/2 connection status when disposing of many SSE extension streams (i.e. could remain marked saturated when the client initiated the SSE close).
